### PR TITLE
Reduce storage usage

### DIFF
--- a/src/client/java/com/yucareux/tellus/client/screen/EarthCustomizeScreen.java
+++ b/src/client/java/com/yucareux/tellus/client/screen/EarthCustomizeScreen.java
@@ -418,6 +418,7 @@ public class EarthCustomizeScreen extends Screen {
       boolean enableRoads = this.findToggleValue("enable_roads", EarthGeneratorSettings.DEFAULT.enableRoads());
       boolean enableBuildings = this.findToggleValue("enable_buildings", EarthGeneratorSettings.DEFAULT.enableBuildings());
       boolean enableWater = this.findToggleValue("enable_water", EarthGeneratorSettings.DEFAULT.enableWater());
+      boolean enableStorageOptimization = this.findToggleValue("optimize_storage", EarthGeneratorSettings.DEFAULT.optimizeStorage());
       boolean deepDark = this.findToggleValue("deep_dark", EarthGeneratorSettings.DEFAULT.deepDark());
       boolean geodes = this.findToggleValue("geodes", EarthGeneratorSettings.DEFAULT.geodes());
       boolean addStrongholds = this.findToggleValue("add_strongholds", EarthGeneratorSettings.DEFAULT.addStrongholds());
@@ -516,7 +517,8 @@ public class EarthCustomizeScreen extends Screen {
          demSelection,
          enableRoads,
          enableBuildings,
-         enableWater
+         enableWater,
+         enableStorageOptimization
       );
    }
 
@@ -564,6 +566,7 @@ public class EarthCustomizeScreen extends Screen {
       this.setToggleValue("enable_roads", initialSettings.enableRoads());
       this.setToggleValue("enable_buildings", initialSettings.enableBuildings());
       this.setToggleValue("enable_water", initialSettings.enableWater());
+      this.setToggleValue("optimize_storage", initialSettings.optimizeStorage());
       this.setToggleValue("deep_dark", initialSettings.deepDark());
       this.setToggleValue("geodes", initialSettings.geodes());
       this.setToggleValue("add_strongholds", initialSettings.addStrongholds());
@@ -864,6 +867,14 @@ public class EarthCustomizeScreen extends Screen {
                toggle("realtime_time", EarthGeneratorSettings.DEFAULT.realtimeTime()),
                toggle("realtime_weather", EarthGeneratorSettings.DEFAULT.realtimeWeather()),
                toggle("historical_snow", false).forceDisabled(true, historicalSnowReworkTooltip())
+            )
+         )
+      );
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "optimizations",
+            List.of(
+                  toggle("optimize_storage", EarthGeneratorSettings.DEFAULT.optimizeStorage())
             )
          )
       );

--- a/src/main/java/com/yucareux/tellus/mixin/ReduceStorageSizeMixin.java
+++ b/src/main/java/com/yucareux/tellus/mixin/ReduceStorageSizeMixin.java
@@ -59,7 +59,6 @@ public abstract class ReduceStorageSizeMixin {
             }
         }
 
-        // PostProcessing : supprimer les sous-listes vides
         Optional<ListTag> ppOpt = tag.getList("PostProcessing");
         if (ppOpt.isPresent()) {
             ListTag pp = ppOpt.get();

--- a/src/main/java/com/yucareux/tellus/mixin/ReduceStorageSizeMixin.java
+++ b/src/main/java/com/yucareux/tellus/mixin/ReduceStorageSizeMixin.java
@@ -1,0 +1,74 @@
+package com.yucareux.tellus.mixin;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.world.level.chunk.storage.SerializableChunkData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+
+import java.util.Optional;
+
+@Mixin(SerializableChunkData.class)
+public abstract class ReduceStorageSizeMixin {
+
+    @Inject(
+        method = "write",
+        at = @At("RETURN")
+    )
+    private void reduceStorageSize(CallbackInfoReturnable<CompoundTag> cir) {
+        
+        if (!EarthChunkGenerator.optimizeStorage) return;
+
+        CompoundTag tag = cir.getReturnValue();
+        if (tag == null) return;
+
+        Optional<ListTag> sectionsOpt = tag.getList("sections");
+        if (sectionsOpt.isEmpty()) return;
+        ListTag sections = sectionsOpt.get();
+
+        for (int i = 0; i < sections.size(); i++) {
+            Optional<CompoundTag> sectionOpt = sections.getCompound(i);
+            if (sectionOpt.isEmpty()) continue;
+            CompoundTag section = sectionOpt.get();
+
+            Optional<CompoundTag> blockStatesOpt = section.getCompound("block_states");
+            if (blockStatesOpt.isEmpty()) continue;
+
+            Optional<ListTag> paletteOpt = blockStatesOpt.get().getList("palette");
+            if (paletteOpt.isEmpty() || paletteOpt.get().size() != 1) continue;
+
+            section.remove("BlockLight");
+            section.remove("SkyLight");
+            section.remove("biomes");
+        }
+
+        Optional<ListTag> blockTicksOpt = tag.getList("block_ticks");
+        if (blockTicksOpt.isPresent()) {
+            ListTag blockTicks = blockTicksOpt.get();
+            for (int i = blockTicks.size() - 1; i >= 0; i--) {
+                Optional<CompoundTag> tickOpt = blockTicks.getCompound(i);
+                if (tickOpt.isEmpty()) continue;
+                Optional<String> id = tickOpt.get().getString("i");
+                if (id.isPresent() && id.get().endsWith("_leaves")) {
+                    blockTicks.remove(i);
+                }
+            }
+        }
+
+        // PostProcessing : supprimer les sous-listes vides
+        Optional<ListTag> ppOpt = tag.getList("PostProcessing");
+        if (ppOpt.isPresent()) {
+            ListTag pp = ppOpt.get();
+            for (int i = pp.size() - 1; i >= 0; i--) {
+                Optional<ListTag> subList = pp.getList(i);
+                if (subList.isPresent() && subList.get().isEmpty()) {
+                    pp.remove(i);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/yucareux/tellus/worldgen/EarthChunkGenerator.java
+++ b/src/main/java/com/yucareux/tellus/worldgen/EarthChunkGenerator.java
@@ -96,6 +96,7 @@ import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.biome.BiomeGenerationSettings.PlainBuilder;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
@@ -333,6 +334,8 @@ public final class EarthChunkGenerator extends ChunkGenerator {
    private final AtomicLong chunkDetailGenerationSequence = new AtomicLong();
    private final ConcurrentHashMap<Long, Long> terrainGenerationStamps = new ConcurrentHashMap<>();
 
+   public static volatile boolean optimizeStorage = false;
+
    public EarthChunkGenerator(BiomeSource biomeSource, EarthGeneratorSettings settings) {
       super(biomeSource, biome -> generationSettingsForBiome(biome, settings));
       this.settings = settings;
@@ -348,6 +351,8 @@ public final class EarthChunkGenerator extends ChunkGenerator {
       int spawnBlockZ = Mth.floor(EarthProjection.latToBlockZ(settings.spawnLatitude(), settings.worldScale()));
       this.configuredSpawnChunkX = Math.floorDiv(spawnBlockX, 16);
       this.configuredSpawnChunkZ = Math.floorDiv(spawnBlockZ, 16);
+      EarthChunkGenerator.optimizeStorage = settings.optimizeStorage();
+
       if (biomeSource instanceof EarthBiomeSource earthBiomeSource) {
          earthBiomeSource.setFastSpawnMode(true);
       }
@@ -3824,6 +3829,20 @@ public final class EarthChunkGenerator extends ChunkGenerator {
 
                                  ConfiguredFeature<?, ?> feature = features.get(random.nextInt(features.size()));
                                  feature.place(level, this, random, position);
+                                 
+                                 if(EarthChunkGenerator.optimizeStorage) {
+                                    // Force persistent=true on leaves to remove scheduled ticks and reduce storage size
+                                    BlockPos.betweenClosed(
+                                       position.offset(-8, -1, -8),
+                                       position.offset(8, 16, 8)
+                                    ).forEach(bp -> {
+                                       BlockState state = level.getBlockState(bp);
+                                       if (state.is(BlockTags.LEAVES) && state.hasProperty(LeavesBlock.PERSISTENT)) {
+                                          level.setBlock(bp, state.setValue(LeavesBlock.PERSISTENT, true), 20);
+                                       }
+                                    });
+                                 }
+                                 
                               }
                            }
                         }

--- a/src/main/java/com/yucareux/tellus/worldgen/EarthGeneratorSettings.java
+++ b/src/main/java/com/yucareux/tellus/worldgen/EarthGeneratorSettings.java
@@ -66,7 +66,8 @@ public record EarthGeneratorSettings(
    EarthGeneratorSettings.DemSelection demSelection,
    boolean enableRoads,
    boolean enableBuildings,
-   boolean enableWater
+   boolean enableWater,
+   boolean optimizeStorage
 ) {
    public static final double DEFAULT_SPAWN_LATITUDE = 27.9881;
    public static final double DEFAULT_SPAWN_LONGITUDE = 86.925;
@@ -135,6 +136,7 @@ public record EarthGeneratorSettings(
       4,
       EarthGeneratorSettings.DistantHorizonsRenderMode.FAST,
       EarthGeneratorSettings.DemSelection.automaticSelection(),
+      false,
       false,
       false,
       false
@@ -279,6 +281,7 @@ public record EarthGeneratorSettings(
    private static final MapCodec<Boolean> ENABLE_ROADS_CODEC = Codec.BOOL.fieldOf("enable_roads").orElse(DEFAULT.enableRoads());
    private static final MapCodec<Boolean> ENABLE_BUILDINGS_CODEC = Codec.BOOL.fieldOf("enable_buildings").orElse(DEFAULT.enableBuildings());
    private static final MapCodec<Boolean> ENABLE_WATER_CODEC = Codec.BOOL.fieldOf("enable_water").orElse(DEFAULT.enableWater());
+   private static final MapCodec<Boolean> OPTIMIZE_STORAGE_CODEC = Codec.BOOL.fieldOf("optimize_storage").orElse(DEFAULT.optimizeStorage());
    private static final MapCodec<Boolean> VOXY_CHUNK_PREGEN_ENABLED_CODEC = Codec.BOOL
       .fieldOf("voxy_chunk_pregen_enabled")
       .orElse(DEFAULT.voxyChunkPregenEnabled());
@@ -343,6 +346,7 @@ public record EarthGeneratorSettings(
             builder = EarthGeneratorSettings.ENABLE_ROADS_CODEC.encode(input.enableRoads(), ops, builder);
             builder = EarthGeneratorSettings.ENABLE_BUILDINGS_CODEC.encode(input.enableBuildings(), ops, builder);
             builder = EarthGeneratorSettings.ENABLE_WATER_CODEC.encode(input.enableWater(), ops, builder);
+            builder = EarthGeneratorSettings.OPTIMIZE_STORAGE_CODEC.encode(input.optimizeStorage(), ops, builder);
             builder = EarthGeneratorSettings.VOXY_CHUNK_PREGEN_ENABLED_CODEC.encode(input.voxyChunkPregenEnabled(), ops, builder);
             builder = EarthGeneratorSettings.VOXY_CHUNK_PREGEN_MAX_RADIUS_CODEC.encode(input.voxyChunkPregenMaxRadius(), ops, builder);
             builder = EarthGeneratorSettings.VOXY_CHUNK_PREGEN_CHUNKS_PER_TICK_CODEC.encode(input.voxyChunkPregenChunksPerTick(), ops, builder);
@@ -394,6 +398,7 @@ public record EarthGeneratorSettings(
             DataResult<Boolean> enableRoads = EarthGeneratorSettings.ENABLE_ROADS_CODEC.decode(ops, input);
             DataResult<Boolean> enableBuildings = EarthGeneratorSettings.ENABLE_BUILDINGS_CODEC.decode(ops, input);
             DataResult<Boolean> enableWater = EarthGeneratorSettings.ENABLE_WATER_CODEC.decode(ops, input);
+            DataResult<Boolean> optimizeStorage = EarthGeneratorSettings.OPTIMIZE_STORAGE_CODEC.decode(ops, input);
             DataResult<Boolean> voxyChunkPregenEnabled = EarthGeneratorSettings.VOXY_CHUNK_PREGEN_ENABLED_CODEC.decode(ops, input);
             DataResult<Integer> voxyChunkPregenMaxRadius = EarthGeneratorSettings.VOXY_CHUNK_PREGEN_MAX_RADIUS_CODEC.decode(ops, input);
             DataResult<Integer> voxyChunkPregenChunksPerTick = EarthGeneratorSettings.VOXY_CHUNK_PREGEN_CHUNKS_PER_TICK_CODEC.decode(ops, input);
@@ -435,6 +440,7 @@ public record EarthGeneratorSettings(
             settings = settings.apply2(EarthGeneratorSettings::applyEnableRoads, enableRoads);
             settings = settings.apply2(EarthGeneratorSettings::applyEnableBuildings, enableBuildings);
             settings = settings.apply2(EarthGeneratorSettings::applyEnableWater, enableWater);
+            settings = settings.apply2(EarthGeneratorSettings::applyOptimizeStorage, optimizeStorage);
             settings = settings.apply2(EarthGeneratorSettings::applyDeepDark, deepDark);
             settings = settings.apply2(EarthGeneratorSettings::applyGeodes, geodes);
             settings = settings.apply2(EarthGeneratorSettings::withStructureSettings, structures);
@@ -456,6 +462,7 @@ public record EarthGeneratorSettings(
             baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.ENABLE_ROADS_CODEC.keys(ops));
             baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.ENABLE_BUILDINGS_CODEC.keys(ops));
             baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.ENABLE_WATER_CODEC.keys(ops));
+            baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.OPTIMIZE_STORAGE_CODEC.keys(ops));
             baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.VOXY_CHUNK_PREGEN_ENABLED_CODEC.keys(ops));
             baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.VOXY_CHUNK_PREGEN_MAX_RADIUS_CODEC.keys(ops));
             baseKeys = Stream.concat(baseKeys, EarthGeneratorSettings.VOXY_CHUNK_PREGEN_CHUNKS_PER_TICK_CODEC.keys(ops));
@@ -518,7 +525,8 @@ public record EarthGeneratorSettings(
       EarthGeneratorSettings.DemSelection demSelection,
       boolean enableRoads,
       boolean enableBuildings,
-      boolean enableWater
+      boolean enableWater,
+      boolean optimizeStorage
    ) {
       worldScale = clampWorldScale(worldScale);
       voxyChunkPregenMaxRadius = Mth.clamp(voxyChunkPregenMaxRadius, 0, MAX_VOXY_PREGEN_RADIUS);
@@ -577,6 +585,7 @@ public record EarthGeneratorSettings(
       this.enableRoads = enableRoads;
       this.enableBuildings = enableBuildings;
       this.enableWater = enableWater;
+      this.optimizeStorage = optimizeStorage;
    }
 
    public boolean isSeaLevelAutomatic() {
@@ -824,7 +833,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -891,7 +901,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -946,7 +957,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1001,7 +1013,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1056,7 +1069,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1111,7 +1125,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1166,7 +1181,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1221,7 +1237,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          enableRoads,
          this.enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1276,7 +1293,8 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          enableBuildings,
-         this.enableWater
+         this.enableWater,
+         this.optimizeStorage
       );
    }
 
@@ -1331,7 +1349,68 @@ public record EarthGeneratorSettings(
          this.demSelection,
          this.enableRoads,
          this.enableBuildings,
-         enableWater
+         enableWater,
+         this.optimizeStorage
+      );
+   }
+
+   private static EarthGeneratorSettings applyOptimizeStorage(EarthGeneratorSettings settings, Boolean enabled) {
+    return settings.withOptimizeStorage(Objects.requireNonNull(enabled, "optimizeStorage"));
+}
+
+   private EarthGeneratorSettings withOptimizeStorage(boolean optimizeStorage) {
+      return new EarthGeneratorSettings(
+         this.worldScale, 
+         this.terrestrialHeightScale, 
+         this.oceanicHeightScale,
+         this.heightOffset, 
+         this.seaLevel, 
+         this.spawnLatitude, 
+         this.spawnLongitude,
+         this.minAltitude, 
+         this.maxAltitude, 
+         this.riverLakeShorelineBlend,
+         this.oceanShorelineBlend, 
+         this.shorelineBlendCliffLimit, 
+         this.caveGeneration,
+         this.oreDistribution, 
+         this.lavaPools, 
+         this.addStrongholds, 
+         this.addVillages,
+         this.addMineshafts, 
+         this.addOceanMonuments, 
+         this.addWoodlandMansions,
+         this.addDesertTemples, 
+         this.addJungleTemples, 
+         this.addPillagerOutposts,
+         this.addRuinedPortals, 
+         this.addShipwrecks, 
+         this.addOceanRuins,
+         this.addBuriedTreasure, 
+         this.addIgloos, 
+         this.addWitchHuts,
+         this.addAncientCities, 
+         this.addTrialChambers, 
+         this.addTrailRuins,
+         this.deepDark, 
+         this.geodes, 
+         this.distantHorizonsWaterResolver,
+         this.distantHorizonsOsmFeatures, 
+         this.distantHorizonsOsmRoadMaxDetail,
+         this.distantHorizonsOsmBuildingMaxDetail, 
+         this.distantHorizonsOsmNonBlockingFetch,
+         this.realtimeTime, 
+         this.realtimeWeather, 
+         this.historicalSnow,
+         this.voxyChunkPregenEnabled, 
+         this.voxyChunkPregenMaxRadius,
+         this.voxyChunkPregenChunksPerTick, 
+         this.distantHorizonsRenderMode,
+         this.demSelection, 
+         this.enableRoads, 
+         this.enableBuildings, 
+         this.enableWater,
+         optimizeStorage
       );
    }
 
@@ -2128,7 +2207,8 @@ public record EarthGeneratorSettings(
             this.demSelection,
             EarthGeneratorSettings.DEFAULT.enableRoads(),
             EarthGeneratorSettings.DEFAULT.enableBuildings(),
-            EarthGeneratorSettings.DEFAULT.enableWater()
+            EarthGeneratorSettings.DEFAULT.enableWater(),
+            EarthGeneratorSettings.DEFAULT.optimizeStorage()
          );
       }
    }

--- a/src/main/resources/assets/tellus/lang/en_us.json
+++ b/src/main/resources/assets/tellus/lang/en_us.json
@@ -211,5 +211,8 @@
   "property.tellus.enable_water.tooltip": "Use Overture/OSM water when enabled. Leave off to keep ESA water",
   "tellus.openstreetmaps_features.scale_limit_warning": "Roads and buildings are disabled because they are only available when World Scale is 1:15 (15 m/block) or finer.",
   "property.tellus.enable_roads.scale_limit.tooltip": "Disabled because roads are only available when World Scale is 1:15 (15 m/block) or finer.",
-  "property.tellus.enable_buildings.scale_limit.tooltip": "Disabled because buildings are only available when World Scale is 1:15 (15 m/block) or finer."
+  "property.tellus.enable_buildings.scale_limit.tooltip": "Disabled because buildings are only available when World Scale is 1:15 (15 m/block) or finer.",
+  "category.tellus.optimizations.name": "Optimizations",
+  "property.tellus.optimize_storage.name": "Optimize Storage",
+  "property.tellus.optimize_storage.tooltip": "Reduces save file size by up to 60% by removing redundant data from empty chunk sections.\nWarning: This prevents tree leaves from breaking automatically."
 }

--- a/src/main/resources/assets/tellus/lang/es_es.json
+++ b/src/main/resources/assets/tellus/lang/es_es.json
@@ -211,5 +211,8 @@
   "property.tellus.enable_water.tooltip": "Usa agua de Overture/OSM cuando está activado. Déjalo desactivado para mantener el agua ESA",
   "tellus.openstreetmaps_features.scale_limit_warning": "Las carreteras y los edificios están desactivados porque solo están disponibles cuando la escala del mundo es 1:15 (15 m/bloque) o más detallada.",
   "property.tellus.enable_roads.scale_limit.tooltip": "Desactivado porque las carreteras solo están disponibles cuando la escala del mundo es 1:15 (15 m/bloque) o más detallada.",
-  "property.tellus.enable_buildings.scale_limit.tooltip": "Desactivado porque los edificios solo están disponibles cuando la escala del mundo es 1:15 (15 m/bloque) o más detallada."
+  "property.tellus.enable_buildings.scale_limit.tooltip": "Desactivado porque los edificios solo están disponibles cuando la escala del mundo es 1:15 (15 m/bloque) o más detallada.",
+  "category.tellus.optimizations.name": "Optimizaciones",
+  "property.tellus.optimize_storage.name": "Optimizar almacenamiento",
+  "property.tellus.optimize_storage.tooltip": "Reduce el tamaño del archivo de guardado hasta un 60% eliminando datos redundantes de las secciones de chunks vacías.\nAdvertencia: Esto impide que las hojas de los árboles se rompan automáticamente."
 }

--- a/src/main/resources/tellus.mixins.json
+++ b/src/main/resources/tellus.mixins.json
@@ -6,7 +6,8 @@
 		"BiomeFreezeMixin",
 		"BiomePrecipitationMixin",
 		"OceanMonumentBuildingMixin",
-		"OceanMonumentStructureMixin"
+		"OceanMonumentStructureMixin",
+		"ReduceStorageSizeMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Hi,
Added a category of setting with an option to reduce storage size of saves.
It removes the block_ticks for leaves (which make them to not break automatically when there is no log near)
And remove Blocklight, Skylight and biomes from palettes which are of the same block.

In my case it seems to have reduce region size from 11Mo to 4Mo when there are trees present.
