### PR TITLE
Port Tellus to NeoForge 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,19 +11,19 @@ subprojects {
 }
 
 tasks.named('clean') {
-	dependsOn(':mc1201:clean', ':mc1211:clean', ':mc261:clean')
+	dependsOn(':mc1201:clean', ':mc1211:clean', ':mc261:clean', ':neoforge:clean')
 }
 
 tasks.named('assemble') {
-	dependsOn(':mc1201:assemble', ':mc1211:assemble', ':mc261:assemble')
+	dependsOn(':mc1201:assemble', ':mc1211:assemble', ':mc261:assemble', ':neoforge:assemble')
 }
 
 tasks.named('check') {
-	dependsOn(':mc1201:check', ':mc1211:check', ':mc261:check')
+	dependsOn(':mc1201:check', ':mc1211:check', ':mc261:check', ':neoforge:check')
 }
 
 tasks.named('build') {
-	dependsOn(':mc1201:build', ':mc1211:build', ':mc261:build')
+	dependsOn(':mc1201:build', ':mc1211:build', ':mc261:build', ':neoforge:build')
 }
 
 tasks.register('build1201') {
@@ -78,4 +78,22 @@ tasks.register('runServer261') {
 	group = 'fabric'
 	description = 'Runs the Minecraft 26.1.2 server target.'
 	dependsOn(':mc261:runServer')
+}
+
+tasks.register('buildNeoForge') {
+	group = 'build'
+	description = 'Builds the NeoForge 1.21.1 target.'
+	dependsOn(':neoforge:build')
+}
+
+tasks.register('runClientNeoForge') {
+	group = 'neoforge'
+	description = 'Runs the NeoForge 1.21.1 client.'
+	dependsOn(':neoforge:runClient')
+}
+
+tasks.register('runServerNeoForge') {
+	group = 'neoforge'
+	description = 'Runs the NeoForge 1.21.1 server.'
+	dependsOn(':neoforge:runServer')
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,0 +1,117 @@
+plugins {
+	id 'net.neoforged.moddev' version '2.0.21'
+	id 'maven-publish'
+}
+
+def minecraftVersion = '1.21.1'
+def neoForgeVersion = '21.1.172'
+def distantHorizonsApiVersion = '6.1.0'
+def javaVersion = 21
+
+base {
+	archivesName = "${rootProject.archives_base_name}-neoforge-${minecraftVersion}"
+}
+
+tasks.withType(AbstractArchiveTask).configureEach {
+	archiveVersion.set('')
+}
+
+sourceSets {
+	main {
+		java {
+			setSrcDirs([rootProject.file('src/main/java'), project.file('src/main/java')])
+		}
+		resources {
+			setSrcDirs([rootProject.file('src/main/resources'), project.file('src/main/resources')])
+		}
+	}
+	test {
+		java.setSrcDirs([rootProject.file('src/test/java')])
+		resources.setSrcDirs([rootProject.file('src/test/resources')])
+	}
+}
+
+repositories {
+	mavenCentral()
+	maven {
+		url = 'https://api.modrinth.com/maven/'
+		content {
+			includeGroup 'maven.modrinth'
+		}
+	}
+}
+
+neoForge {
+	version = neoForgeVersion
+
+	parchment {
+		// Optional: use parchment mappings
+	}
+
+	mods {
+		tellus {
+			sourceSet sourceSets.main
+		}
+	}
+}
+
+dependencies {
+	implementation 'org.tukaani:xz:1.10'
+	implementation 'io.github.sebasbaumh:mapbox-vector-tile-java:24.1.1'
+	implementation 'com.google.protobuf:protobuf-java:4.28.2'
+
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+
+	compileOnly "maven.modrinth:DistantHorizonsApi:${distantHorizonsApiVersion}"
+}
+
+jar {
+	from(rootProject.file('LICENSE')) {
+		rename { "${it}_${project.base.archivesName.get()}" }
+	}
+
+	// Bundle third-party libraries
+	from(configurations.runtimeClasspath.filter {
+		it.name.startsWith('xz') ||
+		it.name.startsWith('mapbox') ||
+		it.name.startsWith('protobuf')
+	}.collect { zipTree(it) }) {
+		exclude 'META-INF/MANIFEST.MF'
+		exclude 'META-INF/*.SF'
+		exclude 'META-INF/*.DSA'
+		exclude 'META-INF/*.RSA'
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.release = javaVersion
+}
+
+tasks.named('test').configure {
+	useJUnitPlatform()
+}
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(javaVersion)
+	}
+
+	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.toVersion(javaVersion)
+	targetCompatibility = JavaVersion.toVersion(javaVersion)
+}
+
+publishing {
+	publications {
+		create('mavenJava', MavenPublication) {
+			artifactId = project.base.archivesName.get()
+			from components.java
+		}
+	}
+
+	repositories {
+	}
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/Tellus.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/Tellus.java
@@ -1,0 +1,698 @@
+package com.yucareux.tellus;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+import com.yucareux.tellus.integration.distant_horizons.DistantHorizonsIntegration;
+import com.yucareux.tellus.integration.voxy.TellusVoxyPregenManager;
+import com.yucareux.tellus.network.GeoTpOpenMapPayload;
+import com.yucareux.tellus.network.GeoTpTeleportPayload;
+import com.yucareux.tellus.network.TellusWeatherPayload;
+import com.yucareux.tellus.world.realtime.TellusRealtimeManager;
+import com.yucareux.tellus.world.realtime.TellusRealtimeState;
+import com.yucareux.tellus.worldgen.EarthBiomeSource;
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import net.minecraft.ChatFormatting;
+import net.minecraft.SharedConstants;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.DataPackConfig;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.WorldDataConfiguration;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biome.Precipitation;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.storage.LevelResource;
+import net.minecraft.world.level.storage.WorldData;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.chunk.ChunkEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+import net.neoforged.neoforge.network.PacketDistributor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Mod("tellus")
+public class Tellus {
+
+   public static final String MOD_ID = "tellus";
+   private static final String DYNAMIC_DIMENSION_PACK_NAME = "tellus_dynamic_dimension";
+   private static final String DYNAMIC_DIMENSION_PACK_ID = "file/tellus_dynamic_dimension";
+
+   private static final ResourceLocation EARTH_DIMENSION_ID = Objects.requireNonNull(
+      ResourceLocation.fromNamespaceAndPath("tellus", "earth"), "earthDimensionId"
+   );
+   private static final ResourceLocation DYNAMIC_DIMENSION_ID = Objects.requireNonNull(
+      ResourceLocation.fromNamespaceAndPath("tellus", "earth_dynamic"), "dynamicDimensionId"
+   );
+   private static final ResourceKey<DimensionType> EARTH_DIMENSION_KEY = Objects.requireNonNull(
+      ResourceKey.create(Registries.DIMENSION_TYPE, EARTH_DIMENSION_ID), "earthDimensionKey"
+   );
+   private static final ResourceKey<DimensionType> DYNAMIC_DIMENSION_KEY = Objects.requireNonNull(
+      ResourceKey.create(Registries.DIMENSION_TYPE, DYNAMIC_DIMENSION_ID), "dynamicDimensionKey"
+   );
+   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+   private static final TellusRealtimeManager REALTIME_MANAGER = new TellusRealtimeManager();
+   private static final TellusVoxyPregenManager VOXY_PREGEN_MANAGER = new TellusVoxyPregenManager();
+   public static final Logger LOGGER = LoggerFactory.getLogger("tellus");
+
+   public static ResourceLocation id(String path) {
+      return Objects.requireNonNull(ResourceLocation.fromNamespaceAndPath("tellus", path), "identifier");
+   }
+
+   public Tellus(IEventBus modEventBus) {
+      // Register biome source and chunk generator codecs
+      Registry.register(BuiltInRegistries.BIOME_SOURCE, id("earth"), EarthBiomeSource.CODEC);
+      Registry.register(BuiltInRegistries.CHUNK_GENERATOR, id("earth"), EarthChunkGenerator.CODEC);
+
+      // Register network payloads
+      modEventBus.addListener(this::registerPayloads);
+
+      // Server-side lifecycle and tick events
+      NeoForge.EVENT_BUS.addListener(this::onServerStarted);
+      NeoForge.EVENT_BUS.addListener(this::onServerStopping);
+      NeoForge.EVENT_BUS.addListener(this::onServerTick);
+      NeoForge.EVENT_BUS.addListener(this::onChunkUnload);
+      NeoForge.EVENT_BUS.addListener(this::onPlayerJoin);
+      NeoForge.EVENT_BUS.addListener(this::onRegisterCommands);
+
+      // Client-only initialization (deferred to avoid server-side class loading)
+      if (FMLEnvironment.dist.isClient()) {
+         TellusClient.init(modEventBus);
+      }
+
+      if (ModList.get().isLoaded("distanthorizons")) {
+         DistantHorizonsIntegration.bootstrap();
+      }
+
+      LOGGER.info("Tellus worldgen initialized");
+   }
+
+   private void registerPayloads(RegisterPayloadHandlersEvent event) {
+      final PayloadRegistrar registrar = event.registrar("1");
+      registrar.playToServer(GeoTpTeleportPayload.TYPE, GeoTpTeleportPayload.CODEC, Tellus::handleGeoTeleport);
+      registrar.playToClient(GeoTpOpenMapPayload.TYPE, GeoTpOpenMapPayload.CODEC,
+         (payload, ctx) -> ctx.enqueueWork(() -> TellusClient.handleOpenMapPayload(payload)));
+      registrar.playToClient(TellusWeatherPayload.TYPE, TellusWeatherPayload.CODEC,
+         (payload, ctx) -> ctx.enqueueWork(() -> TellusClient.handleWeatherPayload(payload)));
+   }
+
+   private void onServerStarted(ServerStartedEvent event) {
+      MinecraftServer server = event.getServer();
+      server.execute(() -> {
+         ServerLevel world = server.getLevel(Level.OVERWORLD);
+         if (world != null) {
+            ChunkGenerator generator = world.getChunkSource().getGenerator();
+            logOverworldSettings(server, world, generator);
+            if (generator instanceof EarthChunkGenerator earthGenerator) {
+               BlockPos spawn = Objects.requireNonNull(earthGenerator.getSpawnPosition(world), "spawnPosition");
+               world.setDefaultSpawnPos(spawn, 0.0F);
+               ensureDynamicDimensionPack(server, world.dimensionTypeRegistration(), world.dimensionType(), earthGenerator);
+            }
+         }
+      });
+   }
+
+   private void onServerStopping(ServerStoppingEvent event) {
+      REALTIME_MANAGER.onServerStopping(event.getServer());
+      VOXY_PREGEN_MANAGER.shutdown();
+   }
+
+   private void onServerTick(ServerTickEvent.Post event) {
+      MinecraftServer server = event.getServer();
+      REALTIME_MANAGER.onServerTick(server);
+      VOXY_PREGEN_MANAGER.onServerTick(server);
+      for (ServerLevel level : server.getAllLevels()) {
+         ChunkGenerator generator = level.getChunkSource().getGenerator();
+         if (generator instanceof EarthChunkGenerator earthGenerator) {
+            earthGenerator.processDeferredChunkDetailTick(level);
+         }
+      }
+   }
+
+   private void onChunkUnload(ChunkEvent.Unload event) {
+      if (event.getLevel() instanceof ServerLevel serverLevel) {
+         ChunkGenerator generator = serverLevel.getChunkSource().getGenerator();
+         if (generator instanceof EarthChunkGenerator earthGenerator) {
+            earthGenerator.discardPreparedChunkState(event.getChunk().getPos());
+         }
+      }
+   }
+
+   private void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
+      if (event.getEntity() instanceof ServerPlayer player) {
+         MinecraftServer server = player.getServer();
+         if (server != null) {
+            REALTIME_MANAGER.onPlayerJoin(server, player);
+         }
+      }
+   }
+
+   private void onRegisterCommands(RegisterCommandsEvent event) {
+      event.getDispatcher().register(
+         ((Commands.literal("tellus")
+               .then(
+                  (Commands.literal("map")
+                        .requires(source -> source.hasPermission(2)))
+                     .executes(context -> openGeoTpMap((CommandSourceStack) context.getSource()))
+               ))
+            .then(
+               (Commands.literal("weather")
+                     .executes(context -> showTellusWeather((CommandSourceStack) context.getSource())))
+                  .then(
+                     Commands.literal("enable_realtime_time")
+                        .requires(source -> source.hasPermission(2))
+                        .then(
+                           Commands.argument("enabled", Objects.requireNonNull(BoolArgumentType.bool(), "enabledArgument"))
+                              .executes(
+                                 context -> setRealtimeTimeOverride(
+                                    (CommandSourceStack) context.getSource(), BoolArgumentType.getBool(context, "enabled")
+                                 )
+                              )
+                        )
+                  )
+                  .then(
+                     Commands.literal("enable_realtime_weather")
+                        .requires(source -> source.hasPermission(2))
+                        .then(
+                           Commands.argument("enabled", Objects.requireNonNull(BoolArgumentType.bool(), "enabledArgument"))
+                              .executes(
+                                 context -> setRealtimeWeatherOverride(
+                                    (CommandSourceStack) context.getSource(), BoolArgumentType.getBool(context, "enabled")
+                                 )
+                              )
+                        )
+                  )
+            )
+            .then(
+               ((Commands.literal("config")
+                        .requires(source -> source.hasPermission(2)))
+                     .then(
+                        (Commands.literal("weather")
+                              .then(
+                                 Commands.literal("enable_realtime_time")
+                                    .then(
+                                       Commands.argument("enabled", Objects.requireNonNull(BoolArgumentType.bool(), "enabledArgument"))
+                                          .executes(
+                                             context -> setRealtimeTimeOverride(
+                                                (CommandSourceStack) context.getSource(), BoolArgumentType.getBool(context, "enabled")
+                                             )
+                                          )
+                                    )
+                              ))
+                           .then(
+                              Commands.literal("enable_realtime_weather")
+                                 .then(
+                                    Commands.argument("enabled", Objects.requireNonNull(BoolArgumentType.bool(), "enabledArgument"))
+                                       .executes(
+                                          context -> setRealtimeWeatherOverride(
+                                             (CommandSourceStack) context.getSource(), BoolArgumentType.getBool(context, "enabled")
+                                          )
+                                       )
+                                 )
+                           )
+                     ))
+                  .then(
+                     ((((Commands.literal("voxy")
+                                    .then(Commands.literal("status").executes(context -> showVoxyPregenStatus((CommandSourceStack) context.getSource()))))
+                                 .then(
+                                    Commands.literal("enable_pregen")
+                                       .then(
+                                          Commands.argument("enabled", Objects.requireNonNull(BoolArgumentType.bool(), "enabledArgument"))
+                                             .executes(
+                                                context -> setVoxyPregenEnabledOverride(
+                                                   (CommandSourceStack) context.getSource(), BoolArgumentType.getBool(context, "enabled")
+                                                )
+                                             )
+                                       )
+                                 ))
+                              .then(
+                                 Commands.literal("max_radius")
+                                    .then(
+                                       Commands.argument("chunks", Objects.requireNonNull(IntegerArgumentType.integer(0, 1024), "maxRadiusArgument"))
+                                          .executes(
+                                             context -> setVoxyPregenMaxRadiusOverride(
+                                                (CommandSourceStack) context.getSource(), IntegerArgumentType.getInteger(context, "chunks")
+                                             )
+                                          )
+                                    )
+                              ))
+                           .then(
+                              Commands.literal("chunks_per_tick")
+                                 .then(
+                                    Commands.argument("value", Objects.requireNonNull(IntegerArgumentType.integer(1, 200), "chunksPerTickArgument"))
+                                       .executes(
+                                          context -> setVoxyPregenChunksPerTickOverride(
+                                             (CommandSourceStack) context.getSource(), IntegerArgumentType.getInteger(context, "value")
+                                          )
+                                       )
+                                 )
+                           ))
+                        .then(Commands.literal("reset").executes(context -> resetVoxyPregenOverrides((CommandSourceStack) context.getSource())))
+                  )
+            )
+         )
+      );
+   }
+
+   private static int openGeoTpMap(CommandSourceStack source) {
+      ServerPlayer player = source.getPlayer();
+      if (player == null) {
+         source.sendFailure(Component.literal("Tellus: GeoTP map can only be used by a player."));
+         return 0;
+      }
+      ServerLevel level = player.serverLevel();
+      if (level.getChunkSource().getGenerator() instanceof EarthChunkGenerator earthGenerator) {
+         double latitude = clampLatitude(earthGenerator.latitudeFromBlock(player.getZ()));
+         double longitude = clampLongitude(earthGenerator.longitudeFromBlock(player.getX()));
+         PacketDistributor.sendToPlayer(player, new GeoTpOpenMapPayload(latitude, longitude));
+         return 1;
+      } else {
+         source.sendFailure(Component.literal("Tellus: GeoTP map is only available in Tellus worlds."));
+         return 0;
+      }
+   }
+
+   private static int showTellusWeather(CommandSourceStack source) {
+      ServerPlayer player = source.getPlayer();
+      if (player == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus weather can only be used by a player."));
+         return 0;
+      }
+      ServerLevel level = player.serverLevel();
+      if (!(level.getChunkSource().getGenerator() instanceof EarthChunkGenerator earthGenerator)) {
+         source.sendFailure(Component.literal("Tellus: /tellus weather is only available in Tellus worlds."));
+         return 0;
+      }
+      BlockPos pos = player.blockPosition();
+      double latitude = clampLatitude(earthGenerator.latitudeFromBlock(pos.getZ()));
+      double longitude = clampLongitude(earthGenerator.longitudeFromBlock(pos.getX()));
+      EarthGeneratorSettings settings = earthGenerator.settings();
+      boolean realtimeWeather = REALTIME_MANAGER.isRealtimeWeatherEnabled(settings);
+      boolean realtimeWeatherActive = realtimeWeather && TellusRealtimeState.isWeatherEnabled();
+      TellusRealtimeState.PrecipitationMode mode = TellusRealtimeState.precipitationMode();
+      Tellus.WeatherDisplay weather = realtimeWeatherActive ? weatherFromRealtime(mode) : weatherFromVanilla(level, pos);
+      source.sendSuccess(() -> Component.literal("Tellus Weather").withStyle(new ChatFormatting[]{ChatFormatting.GOLD, ChatFormatting.BOLD}), false);
+      String locationText = Objects.requireNonNull(String.format(Locale.ROOT, "%.4f, %.4f", latitude, longitude), "locationText");
+      source.sendSuccess(
+         () -> Component.literal("Location: ").withStyle(ChatFormatting.GRAY).append(Component.literal(locationText).withStyle(ChatFormatting.AQUA)),
+         false
+      );
+      String gameTime = Objects.requireNonNull(formatGameTime(level), "gameTime");
+      source.sendSuccess(
+         () -> Component.literal("Game time: ").withStyle(ChatFormatting.GRAY).append(Component.literal(gameTime).withStyle(ChatFormatting.YELLOW)),
+         false
+      );
+      TellusRealtimeManager.WeatherSnapshot snapshot = REALTIME_MANAGER.lastWeatherSnapshot();
+      ZoneId zone = null;
+      boolean approximateTime = true;
+      if (snapshot != null) {
+         zone = resolveZoneId(snapshot.timeZoneId());
+         approximateTime = zone == null;
+      }
+      if (zone == null && REALTIME_MANAGER.isRealtimeTimeEnabled(settings) && REALTIME_MANAGER.hasTimeOffset()) {
+         ZoneId managerZone = REALTIME_MANAGER.currentTimeZone();
+         if (managerZone != null) {
+            zone = managerZone;
+            approximateTime = false;
+         }
+      }
+      if (zone == null) {
+         int offsetSeconds = approximateUtcOffsetSeconds(longitude);
+         zone = ZoneOffset.ofTotalSeconds(offsetSeconds);
+         approximateTime = true;
+      }
+      Instant now = REALTIME_MANAGER.currentInstant();
+      int offsetSeconds = zone.getRules().getOffset(now).getTotalSeconds();
+      String timeLabel = formatLocalTime(now, zone);
+      String utcOffsetLabel = formatUtcOffset(offsetSeconds);
+      MutableComponent timeLine = Component.literal("Real time: ")
+         .withStyle(ChatFormatting.GRAY)
+         .append(Component.literal(timeLabel + " " + utcOffsetLabel).withStyle(ChatFormatting.YELLOW));
+      if (approximateTime) {
+         timeLine.append(Component.literal(" (approx)").withStyle(ChatFormatting.DARK_GRAY));
+      }
+      source.sendSuccess(() -> timeLine, false);
+      MutableComponent tempLine = Component.literal("Temperature: ").withStyle(ChatFormatting.GRAY);
+      if (snapshot != null) {
+         String tempLabel = Objects.requireNonNull(String.format(Locale.ROOT, "%.1f C", snapshot.temperatureC()), "tempLabel");
+         tempLine.append(Component.literal(tempLabel).withStyle(ChatFormatting.YELLOW));
+      } else {
+         tempLine.append(Component.literal("n/a").withStyle(ChatFormatting.DARK_GRAY));
+      }
+      source.sendSuccess(() -> tempLine, false);
+      String weatherLabel = Objects.requireNonNull(weather.label(), "weatherLabel");
+      ChatFormatting weatherColor = Objects.requireNonNull(weather.color(), "weatherColor");
+      MutableComponent weatherLine = Component.literal("Weather: ")
+         .withStyle(ChatFormatting.GRAY)
+         .append(Component.literal(weatherLabel).withStyle(weatherColor));
+      if (!realtimeWeather) {
+         weatherLine.append(Component.literal(" (vanilla)").withStyle(ChatFormatting.DARK_GRAY));
+      } else if (!realtimeWeatherActive) {
+         weatherLine.append(Component.literal(" (real-time pending)").withStyle(ChatFormatting.DARK_GRAY));
+      }
+      source.sendSuccess(() -> weatherLine, false);
+      return 1;
+   }
+
+   private static int setRealtimeTimeOverride(CommandSourceStack source, boolean enabled) {
+      EarthChunkGenerator earthGenerator = resolveEarthGenerator(source);
+      if (earthGenerator == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config weather is only available in Tellus worlds."));
+         return 0;
+      }
+      REALTIME_MANAGER.setRealtimeTimeOverride(enabled);
+      source.sendSuccess(() -> Component.literal("Tellus: real-time time set to " + enabled + "."), false);
+      return 1;
+   }
+
+   private static int setRealtimeWeatherOverride(CommandSourceStack source, boolean enabled) {
+      EarthChunkGenerator earthGenerator = resolveEarthGenerator(source);
+      if (earthGenerator == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config weather is only available in Tellus worlds."));
+         return 0;
+      }
+      REALTIME_MANAGER.setRealtimeWeatherOverride(enabled);
+      source.sendSuccess(() -> Component.literal("Tellus: real-time weather set to " + enabled + "."), false);
+      return 1;
+   }
+
+   private static int setVoxyPregenEnabledOverride(CommandSourceStack source, boolean enabled) {
+      if (resolveEarthGenerator(source) == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config voxy is only available in Tellus worlds."));
+         return 0;
+      }
+      VOXY_PREGEN_MANAGER.setEnabledOverride(enabled);
+      source.sendSuccess(() -> Component.literal("Tellus: Voxy pregen enabled override set to " + enabled + "."), false);
+      return 1;
+   }
+
+   private static int setVoxyPregenMaxRadiusOverride(CommandSourceStack source, int chunks) {
+      if (resolveEarthGenerator(source) == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config voxy is only available in Tellus worlds."));
+         return 0;
+      }
+      VOXY_PREGEN_MANAGER.setMaxRadiusOverride(chunks);
+      source.sendSuccess(() -> Component.literal("Tellus: Voxy pregen max radius override set to " + chunks + " chunks."), false);
+      return 1;
+   }
+
+   private static int setVoxyPregenChunksPerTickOverride(CommandSourceStack source, int chunksPerTick) {
+      if (resolveEarthGenerator(source) == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config voxy is only available in Tellus worlds."));
+         return 0;
+      }
+      VOXY_PREGEN_MANAGER.setChunksPerTickOverride(chunksPerTick);
+      source.sendSuccess(() -> Component.literal("Tellus: Voxy pregen budget override set to " + chunksPerTick + " chunks/tick."), false);
+      return 1;
+   }
+
+   private static int resetVoxyPregenOverrides(CommandSourceStack source) {
+      if (resolveEarthGenerator(source) == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config voxy is only available in Tellus worlds."));
+         return 0;
+      }
+      VOXY_PREGEN_MANAGER.clearOverrides();
+      source.sendSuccess(() -> Component.literal("Tellus: Voxy pregen overrides reset to world settings."), false);
+      return 1;
+   }
+
+   private static int showVoxyPregenStatus(CommandSourceStack source) {
+      EarthChunkGenerator earthGenerator = resolveEarthGenerator(source);
+      if (earthGenerator == null) {
+         source.sendFailure(Component.literal("Tellus: /tellus config voxy is only available in Tellus worlds."));
+         return 0;
+      }
+      EarthGeneratorSettings settings = earthGenerator.settings();
+      boolean enabled = VOXY_PREGEN_MANAGER.effectiveEnabled(settings);
+      int maxRadius = VOXY_PREGEN_MANAGER.effectiveMaxRadius(settings);
+      int chunksPerTick = VOXY_PREGEN_MANAGER.effectiveChunksPerTick(settings);
+      source.sendSuccess(() -> Component.literal("Tellus Voxy pregen").withStyle(new ChatFormatting[]{ChatFormatting.GOLD, ChatFormatting.BOLD}), false);
+      source.sendSuccess(
+         () -> Component.literal("Enabled: " + enabled + " (world=" + settings.voxyChunkPregenEnabled() + ", override=" + VOXY_PREGEN_MANAGER.enabledOverride() + ")")
+            .withStyle(ChatFormatting.GRAY),
+         false
+      );
+      source.sendSuccess(
+         () -> Component.literal(
+               "Max radius: " + maxRadius + " chunks (world=" + settings.voxyChunkPregenMaxRadius() + ", override=" + VOXY_PREGEN_MANAGER.maxRadiusOverride() + ")"
+            )
+            .withStyle(ChatFormatting.GRAY),
+         false
+      );
+      source.sendSuccess(
+         () -> Component.literal(
+               "Budget: " + chunksPerTick + " chunks/tick (world=" + settings.voxyChunkPregenChunksPerTick() + ", override=" + VOXY_PREGEN_MANAGER.chunksPerTickOverride() + ")"
+            )
+            .withStyle(ChatFormatting.GRAY),
+         false
+      );
+      source.sendSuccess(
+         () -> Component.literal(
+               "Voxy radius: configured=" + VOXY_PREGEN_MANAGER.lastConfiguredVoxyRadiusChunks() + " chunks, effective=" + VOXY_PREGEN_MANAGER.lastEffectiveRadiusChunks() + " chunks"
+            )
+            .withStyle(ChatFormatting.DARK_AQUA),
+         false
+      );
+      source.sendSuccess(
+         () -> Component.literal("Queue: queued=" + VOXY_PREGEN_MANAGER.queuedChunkCount() + ", in-flight=" + VOXY_PREGEN_MANAGER.inFlightChunkCount())
+            .withStyle(ChatFormatting.DARK_AQUA),
+         false
+      );
+      return 1;
+   }
+
+   private static Tellus.WeatherDisplay weatherFromRealtime(TellusRealtimeState.PrecipitationMode mode) {
+      return switch (mode) {
+         case THUNDER -> new Tellus.WeatherDisplay("Thunder", ChatFormatting.DARK_PURPLE);
+         case SNOW -> new Tellus.WeatherDisplay("Snow", ChatFormatting.AQUA);
+         case RAIN -> new Tellus.WeatherDisplay("Rain", ChatFormatting.BLUE);
+         case CLEAR -> new Tellus.WeatherDisplay("Clear", ChatFormatting.GREEN);
+      };
+   }
+
+   private static Tellus.WeatherDisplay weatherFromVanilla(ServerLevel level, BlockPos pos) {
+      if (level.isThundering()) {
+         return new Tellus.WeatherDisplay("Thunder", ChatFormatting.DARK_PURPLE);
+      } else if (level.isRainingAt(pos)) {
+         Biome biome = (Biome) level.getBiome(pos).value();
+         boolean snow = biome.getPrecipitationAt(pos) == Precipitation.SNOW;
+         return new Tellus.WeatherDisplay(snow ? "Snow" : "Rain", snow ? ChatFormatting.AQUA : ChatFormatting.BLUE);
+      } else {
+         return new Tellus.WeatherDisplay("Clear", ChatFormatting.GREEN);
+      }
+   }
+
+   private static ZoneId resolveZoneId(String zoneId) {
+      if (zoneId != null && !zoneId.isBlank()) {
+         try {
+            return ZoneId.of(zoneId);
+         } catch (Exception var2) {
+            return null;
+         }
+      }
+      return null;
+   }
+
+   private static int approximateUtcOffsetSeconds(double longitude) {
+      double hours = longitude / 15.0;
+      return (int) Math.round(hours * 3600.0);
+   }
+
+   private static String formatLocalTime(Instant instant, ZoneId zone) {
+      int daySeconds = instant.atZone(zone).toLocalTime().toSecondOfDay();
+      int hour = daySeconds / 3600;
+      int minute = daySeconds % 3600 / 60;
+      return String.format(Locale.ROOT, "%02d:%02d", hour, minute);
+   }
+
+   private static String formatGameTime(ServerLevel level) {
+      long timeOfDay = Math.floorMod(level.getDayTime(), 24000L);
+      int totalMinutes = (int) Math.floor(timeOfDay * 60.0 / 1000.0);
+      int hour = (totalMinutes / 60 + 6) % 24;
+      int minute = totalMinutes % 60;
+      return String.format(Locale.ROOT, "%02d:%02d", hour, minute);
+   }
+
+   private static String formatUtcOffset(int offsetSeconds) {
+      int totalMinutes = offsetSeconds / 60;
+      int hours = totalMinutes / 60;
+      int minutes = Math.abs(totalMinutes % 60);
+      return String.format(Locale.ROOT, "UTC%+03d:%02d", hours, minutes);
+   }
+
+   private static void handleGeoTeleport(GeoTpTeleportPayload payload, net.neoforged.neoforge.network.handling.IPayloadContext ctx) {
+      if (Double.isFinite(payload.latitude()) && Double.isFinite(payload.longitude())) {
+         ctx.enqueueWork(() -> {
+            ServerPlayer player = (ServerPlayer) ctx.player();
+            if (!player.createCommandSourceStack().hasPermission(2)) {
+               player.sendSystemMessage(Component.literal("Tellus: You do not have permission to use GeoTP."));
+               return;
+            }
+            ServerLevel level = player.serverLevel();
+            if (level.getChunkSource().getGenerator() instanceof EarthChunkGenerator earthGenerator) {
+               double latitude = clampLatitude(payload.latitude());
+               double longitude = clampLongitude(payload.longitude());
+               BlockPos target = earthGenerator.getSurfacePosition(level, latitude, longitude);
+               player.teleportTo(target.getX() + 0.5, target.getY(), target.getZ() + 0.5);
+            } else {
+               player.sendSystemMessage(Component.literal("Tellus: GeoTP is only available in Tellus worlds."));
+            }
+         });
+      }
+   }
+
+   private static EarthChunkGenerator resolveEarthGenerator(CommandSourceStack source) {
+      MinecraftServer server = source.getServer();
+      ServerLevel level = server.getLevel(Level.OVERWORLD);
+      if (level == null) {
+         return null;
+      }
+      return level.getChunkSource().getGenerator() instanceof EarthChunkGenerator eg ? eg : null;
+   }
+
+   private static double clampLatitude(double latitude) {
+      return Mth.clamp(latitude, -85.05112878, 85.05112878);
+   }
+
+   private static double clampLongitude(double longitude) {
+      return Mth.clamp(longitude, -180.0, 180.0);
+   }
+
+   private static void logOverworldSettings(MinecraftServer server, Level world, ChunkGenerator generator) {
+      DimensionType worldType = world.dimensionType();
+      LOGGER.info("Overworld dimension type: {}", describeDimensionType(worldType));
+      LOGGER.info("Overworld generator: type={}, minY={}, height={}", generator.getClass().getSimpleName(), generator.getMinY(), generator.getGenDepth());
+      Registry<LevelStem> stems = server.registryAccess().registryOrThrow(Registries.LEVEL_STEM);
+      LevelStem stem = stems.get(LevelStem.OVERWORLD);
+      if (stem == null) {
+         LOGGER.warn("Overworld level stem missing from registry");
+      } else {
+         DimensionType stemType = (DimensionType) stem.type().value();
+         LOGGER.info("Overworld level stem: dimensionType={}, generatorType={}", describeDimensionType(stemType), stem.generator().getClass().getSimpleName());
+      }
+   }
+
+   private static String describeDimensionType(DimensionType type) {
+      return "minY=" + type.minY() + ",height=" + type.height() + ",logicalHeight=" + type.logicalHeight();
+   }
+
+   private static void ensureDynamicDimensionPack(
+      MinecraftServer server, Holder<DimensionType> dimensionTypeHolder, DimensionType currentDimensionType, EarthChunkGenerator earthGenerator
+   ) {
+      ResourceKey<DimensionType> dimensionKey = resolveTellusDimensionKey(dimensionTypeHolder).orElse(null);
+      if (dimensionKey != null) {
+         EarthGeneratorSettings settings = earthGenerator.settings();
+         EarthGeneratorSettings.HeightLimits limits = EarthGeneratorSettings.resolveHeightLimits(settings);
+         DimensionType updatedType = EarthGeneratorSettings.applyHeightLimits(currentDimensionType, limits);
+         DynamicOps<JsonElement> jsonOps = Objects.requireNonNull(JsonOps.INSTANCE, "jsonOps");
+         RegistryOps<JsonElement> registryOps = RegistryOps.create(jsonOps, server.registryAccess());
+         JsonElement dimensionJson = (JsonElement) DimensionType.DIRECT_CODEC
+            .encodeStart(registryOps, updatedType)
+            .resultOrPartial(message -> LOGGER.error("Failed to encode dynamic dimension type: {}", message))
+            .orElse(null);
+         if (dimensionJson != null) {
+            Path packDir = server.getWorldPath(LevelResource.DATAPACK_DIR).resolve(DYNAMIC_DIMENSION_PACK_NAME);
+            Path packMetaPath = packDir.resolve("pack.mcmeta");
+            ResourceLocation dimensionId = dimensionKey.location();
+            Path dimensionPath = packDir.resolve("data/" + dimensionId.getNamespace() + "/dimension_type/" + dimensionId.getPath() + ".json");
+            try {
+               Files.createDirectories(dimensionPath.getParent());
+               writeJson(packMetaPath, createPackMeta());
+               writeJson(dimensionPath, dimensionJson);
+            } catch (IOException var16) {
+               LOGGER.warn("Failed to persist dynamic dimension type pack", var16);
+               return;
+            }
+            enableDynamicPack(server.getWorldData());
+         }
+      }
+   }
+
+   private static Optional<ResourceKey<DimensionType>> resolveTellusDimensionKey(Holder<DimensionType> dimensionTypeHolder) {
+      return dimensionTypeHolder.unwrapKey().filter(Tellus::isTellusDimensionKey);
+   }
+
+   private static boolean isTellusDimensionKey(ResourceKey<DimensionType> key) {
+      return key.equals(DYNAMIC_DIMENSION_KEY) || key.equals(EARTH_DIMENSION_KEY);
+   }
+
+   private static JsonObject createPackMeta() {
+      JsonObject pack = new JsonObject();
+      int packFormat = SharedConstants.getCurrentVersion().getPackVersion(PackType.SERVER_DATA);
+      pack.addProperty("pack_format", packFormat);
+      pack.addProperty("description", "Tellus dynamic dimension settings");
+      JsonObject root = new JsonObject();
+      root.add("pack", pack);
+      return root;
+   }
+
+   private static void writeJson(Path path, JsonElement payload) throws IOException {
+      try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+         GSON.toJson(payload, writer);
+      }
+   }
+
+   private static void enableDynamicPack(WorldData worldData) {
+      WorldDataConfiguration configuration = worldData.getDataConfiguration();
+      DataPackConfig dataPacks = configuration.dataPacks();
+      List<String> enabled = new ArrayList<>(dataPacks.getEnabled());
+      List<String> disabled = new ArrayList<>(dataPacks.getDisabled());
+      if (!enabled.contains(DYNAMIC_DIMENSION_PACK_ID)) {
+         enabled.add(DYNAMIC_DIMENSION_PACK_ID);
+      }
+      disabled.remove(DYNAMIC_DIMENSION_PACK_ID);
+      if (!enabled.equals(dataPacks.getEnabled()) || !disabled.equals(dataPacks.getDisabled())) {
+         WorldDataConfiguration updated = new WorldDataConfiguration(new DataPackConfig(enabled, disabled), configuration.enabledFeatures());
+         worldData.setDataConfiguration(updated);
+      }
+   }
+
+   private record WeatherDisplay(String label, ChatFormatting color) {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/TellusClient.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/TellusClient.java
@@ -1,0 +1,39 @@
+package com.yucareux.tellus;
+
+import com.yucareux.tellus.client.screen.EarthTeleportScreen;
+import com.yucareux.tellus.network.GeoTpOpenMapPayload;
+import com.yucareux.tellus.network.TellusWeatherPayload;
+import com.yucareux.tellus.world.realtime.SnowGrid;
+import com.yucareux.tellus.world.realtime.TellusRealtimeState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.common.NeoForge;
+
+@OnlyIn(Dist.CLIENT)
+public class TellusClient {
+
+   static void init(IEventBus modEventBus) {
+      NeoForge.EVENT_BUS.addListener(TellusClient::onPlayerLogout);
+   }
+
+   private static void onPlayerLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+      TellusRealtimeState.clearRealtimeWeather();
+   }
+
+   static void handleOpenMapPayload(GeoTpOpenMapPayload payload) {
+      Minecraft minecraft = Minecraft.getInstance();
+      Screen parent = minecraft.screen;
+      minecraft.setScreen(new EarthTeleportScreen(parent, payload.latitude(), payload.longitude()));
+   }
+
+   static void handleWeatherPayload(TellusWeatherPayload payload) {
+      SnowGrid grid = payload.historicalSnowEnabled() && payload.spacingBlocks() > 0
+         ? new SnowGrid(payload.centerX(), payload.centerZ(), payload.spacingBlocks(), payload.snowIndex())
+         : SnowGrid.empty();
+      TellusRealtimeState.updateWeatherState(payload.weatherEnabled(), payload.precipitationMode(), payload.historicalSnowEnabled(), grid);
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/LoadingTerrainScreenTiming.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/LoadingTerrainScreenTiming.java
@@ -1,0 +1,73 @@
+package com.yucareux.tellus.client;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.mojang.logging.LogUtils;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import net.minecraft.client.gui.screens.LevelLoadingScreen;
+import net.minecraft.client.gui.screens.Screen;
+import org.slf4j.Logger;
+
+@OnlyIn(Dist.CLIENT)
+public final class LoadingTerrainScreenTiming {
+   private static final Logger LOGGER = LogUtils.getLogger();
+   private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("tellus.loadingTerrainTiming", "false"));
+   private static final long ACTIVE_LOG_INTERVAL_NANOS = 5000000000L;
+   private static final Map<Integer, LoadingTerrainScreenTiming.Session> SESSIONS = new HashMap<>();
+
+   private LoadingTerrainScreenTiming() {
+   }
+
+   public static void onScreenRender(LevelLoadingScreen screen, String reason) {
+      if (ENABLED) {
+         int key = System.identityHashCode(screen);
+         long now = System.nanoTime();
+         LoadingTerrainScreenTiming.Session session = SESSIONS.get(key);
+         if (session == null) {
+            session = new LoadingTerrainScreenTiming.Session(reason, now);
+            SESSIONS.put(key, session);
+            LOGGER.info("Loading terrain screen shown reason={} elapsed={}", reason, formatMillis(0L));
+         } else if (now - session.lastLogNanos >= ACTIVE_LOG_INTERVAL_NANOS) {
+            session.lastLogNanos = now;
+            LOGGER.info("Loading terrain screen active reason={} elapsed={}", session.reason, formatMillis(now - session.startNanos));
+         }
+      }
+   }
+
+   public static void onScreenChange(Screen previousScreen, Screen nextScreen) {
+      if (ENABLED && previousScreen instanceof LevelLoadingScreen previousLoading && previousScreen != nextScreen) {
+         LoadingTerrainScreenTiming.Session session = SESSIONS.remove(System.identityHashCode(previousLoading));
+         if (session != null) {
+            long elapsed = System.nanoTime() - session.startNanos;
+            LOGGER.info(
+               "Loading terrain screen finished reason={} elapsed={} nextScreen={}",
+               session.reason,
+               formatMillis(elapsed),
+               describeScreen(nextScreen)
+            );
+         }
+      }
+   }
+
+   private static String describeScreen(Screen screen) {
+      return screen == null ? "null" : screen.getClass().getSimpleName();
+   }
+
+   private static String formatMillis(long nanos) {
+      return String.format(Locale.ROOT, "%.3fms", (double)nanos / 1000000.0);
+   }
+
+   private static final class Session {
+      private final String reason;
+      private final long startNanos;
+      private long lastLogNanos;
+
+      private Session(String reason, long startNanos) {
+         this.reason = reason;
+         this.startNanos = startNanos;
+         this.lastLogNanos = startNanos;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/preview/TerrainPreview.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/preview/TerrainPreview.java
@@ -1,0 +1,3110 @@
+package com.yucareux.tellus.client.preview;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.world.data.cover.TellusLandCoverSource;
+import com.yucareux.tellus.world.data.elevation.TellusElevationSource;
+import com.yucareux.tellus.world.data.elevation.TellusElevationSource.DemUsage;
+import com.yucareux.tellus.world.data.elevation.TellusElevationSource.ElevationDiagnostic;
+import com.yucareux.tellus.world.data.koppen.TellusKoppenSource;
+import com.yucareux.tellus.world.data.mask.TellusLandMaskSource;
+import com.yucareux.tellus.world.data.osm.OsmBuildingFeature;
+import com.yucareux.tellus.world.data.osm.OsmBuildingKind;
+import com.yucareux.tellus.world.data.osm.OsmQueryMode;
+import com.yucareux.tellus.world.data.osm.RoadClass;
+import com.yucareux.tellus.world.data.osm.RoadFeature;
+import com.yucareux.tellus.world.data.osm.TellusOsmBuildingSource;
+import com.yucareux.tellus.world.data.osm.TellusOsmRoadSource;
+import com.yucareux.tellus.world.data.osm.TellusOsmWaterSource;
+import com.yucareux.tellus.world.data.osm.OsmWaterFeature;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.building.BuildingBlueprint;
+import com.yucareux.tellus.worldgen.building.BuildingProfile;
+import com.yucareux.tellus.worldgen.building.TellusBuildingBlueprints;
+import com.yucareux.tellus.worldgen.building.TellusBuildingProfiles;
+import com.yucareux.tellus.worldgen.building.TellusBuildingStyles;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import com.yucareux.tellus.worldgen.MountainSurfaceRules;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import com.yucareux.tellus.worldgen.TellusWorldgenSources;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import net.minecraft.Util;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.util.Mth;
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+
+@OnlyIn(Dist.CLIENT)
+public final class TerrainPreview implements AutoCloseable {
+   private static final int PREVIEW_GRID_SIZE = 257;
+   private static final double PREVIEW_RADIUS_BLOCKS = 256.0;
+   private static final int PREVIEW_INFO_PROVIDER_GRID_SIZE = 25;
+   private static final int PREVIEW_OSM_MARGIN_BLOCKS = 32;
+   private static final int PREVIEW_ELEVATION_PREFETCH_RADIUS = 1;
+   private static final int PREVIEW_LAND_COVER_PREFETCH_RADIUS = 1;
+   private static final int PREVIEW_LAND_MASK_PREFETCH_RADIUS = 1;
+   private static final int PREVIEW_OSM_PREFETCH_RADIUS = 1;
+   private static final long PREVIEW_WATER_OVERLAY_UNITS = 24576L;
+   private static final long PREVIEW_ROAD_OVERLAY_UNITS = 32768L;
+   private static final long PREVIEW_BUILDING_OVERLAY_UNITS = 24576L;
+   private static final String ACTIVITY_DOWNLOAD_ELEVATION = "Sampling elevation data";
+   private static final String ACTIVITY_DOWNLOAD_LAND_COVER = "Sampling land cover";
+   private static final String ACTIVITY_DOWNLOAD_CLIMATE = "Sampling climate data";
+   private static final String ACTIVITY_BUILD_HEIGHTS = "Normalizing terrain heights";
+   private static final String ACTIVITY_BUILD_CENTER = "Centering terrain";
+   private static final String ACTIVITY_BUILD_COLORS = "Coloring terrain";
+   private static final String ACTIVITY_BUILD_TREES = "Applying vegetation markers";
+   private static final String ACTIVITY_BUILD_HEIGHT_OFFSETS = "Applying feature heights";
+   private static final String ACTIVITY_BUILD_INFO = "Summarizing DEM coverage";
+   private static final String ACTIVITY_OSM_WATER_FETCH = "Loading OSM water";
+   private static final String ACTIVITY_OSM_WATER_RASTER = "Rasterizing OSM water";
+   private static final String ACTIVITY_OSM_ROADS_FETCH = "Loading OSM roads";
+   private static final String ACTIVITY_OSM_ROADS_RASTER = "Rasterizing OSM roads";
+   private static final String ACTIVITY_OSM_BUILDINGS_FETCH = "Loading OSM buildings";
+   private static final String ACTIVITY_OSM_BUILDINGS_RASTER = "Rasterizing OSM buildings";
+   private static final int ESA_NO_DATA = 0;
+   private static final int ESA_WATER = 80;
+   private static final double PREVIEW_INLAND_WATER_DEPTH_BLOCKS = 6.0;
+   private static final int PREVIEW_FLAT_WATER_COLOR = waterColorForDepth(PREVIEW_INLAND_WATER_DEPTH_BLOCKS);
+   private static final int BUILDING_PREVIEW_COLOR = 10000536;
+   private static final Vector3f LIGHT_DIR = new Vector3f(-0.4F, 0.8F, -0.4F).normalize();
+   private final TellusElevationSource elevationSource = new TellusElevationSource();
+   private final TellusLandCoverSource landCoverSource = new TellusLandCoverSource();
+   private final TellusKoppenSource koppenSource = new TellusKoppenSource();
+   private final TellusLandMaskSource landMaskSource = new TellusLandMaskSource();
+   private final TellusOsmRoadSource osmRoadSource = TellusWorldgenSources.osmRoads();
+   private final TellusOsmBuildingSource osmBuildingSource = TellusWorldgenSources.osmBuildings();
+   private final TellusOsmWaterSource osmWaterSource = TellusWorldgenSources.osmWater();
+   private final ExecutorService executor;
+   private final AtomicInteger requestId = new AtomicInteger();
+   private final AtomicReference<TerrainPreview.PreviewStatus> status = new AtomicReference<>(
+      new TerrainPreview.PreviewStatus(TerrainPreview.PreviewStage.COMPLETE, 1.0F, null)
+   );
+   private final AtomicReference<TerrainPreview.PreviewInfo> info = new AtomicReference<>();
+   private Future<TerrainPreview.PreviewMesh> pending;
+   private volatile TerrainPreview.PreviewMesh mesh;
+   private volatile TerrainPreview.PreviewBaseSnapshot baseSnapshot;
+   private volatile EarthGeneratorSettings lastSettings;
+
+   public TerrainPreview() {
+      this.executor = Executors.newSingleThreadExecutor(new TerrainPreview.PreviewThreadFactory());
+   }
+
+   public void requestRebuild(EarthGeneratorSettings settings) {
+      int id = this.requestId.incrementAndGet();
+      if (this.pending != null) {
+         this.pending.cancel(true);
+      }
+
+      this.lastSettings = settings;
+      TerrainPreview.PreviewBaseSnapshot cached = this.baseSnapshot;
+      if (this.canReuseBaseSnapshot(settings, cached)) {
+         this.info.set(cached.info());
+         this.updateStatus(id, TerrainPreview.PreviewStage.LOADING, 0.0F, ACTIVITY_BUILD_COLORS);
+      } else {
+         this.info.set(null);
+         this.updateStatus(id, TerrainPreview.PreviewStage.DOWNLOADING, 0.0F, ACTIVITY_DOWNLOAD_ELEVATION);
+      }
+
+      this.pending = this.executor.submit(() -> this.buildMesh(settings, id));
+   }
+
+   public void tick() {
+      Future<TerrainPreview.PreviewMesh> future = this.pending;
+      if (future != null && future.isDone()) {
+         this.pending = null;
+
+         try {
+            TerrainPreview.PreviewMesh preview = future.get();
+            if (preview != null) {
+               this.mesh = preview;
+               this.info.set(preview.info);
+            }
+         } catch (CancellationException var3) {
+         } catch (InterruptedException var4) {
+            Thread.currentThread().interrupt();
+         } catch (ExecutionException var5) {
+            Tellus.LOGGER.warn("Preview render update failed", var5.getCause() != null ? var5.getCause() : var5);
+         }
+      }
+   }
+
+   public boolean isLoading() {
+      return this.pending != null;
+   }
+
+   public TerrainPreview.PreviewStatus getStatus() {
+      return Objects.requireNonNull(this.status.get(), "status");
+   }
+
+   public TerrainPreview.PreviewInfo getInfo() {
+      return this.info.get();
+   }
+
+   public EarthGeneratorSettings getLastSettings() {
+      return this.lastSettings;
+   }
+
+   public void render(
+      GuiGraphics graphics,
+      int x,
+      int y,
+      int width,
+      int height,
+      float rotationX,
+      float rotationY,
+      float zoom,
+      TerrainPreviewWidget.RenderMode renderMode
+   ) {
+      TerrainPreview.PreviewMesh preview = this.mesh;
+      if (preview != null && width > 0 && height > 0) {
+         Matrix4f modelView = buildModelView(rotationX, rotationY);
+         Matrix4f projection = buildProjection(width, height, zoom);
+         graphics.enableScissor(x, y, x + width, y + height);
+         renderPreviewMesh(preview, renderMode, modelView, projection, x, y, width, height);
+         graphics.disableScissor();
+      }
+   }
+
+   private static void renderPreviewMesh(
+      TerrainPreview.PreviewMesh mesh,
+      TerrainPreviewWidget.RenderMode renderMode,
+      Matrix4f modelView,
+      Matrix4f projection,
+      int x,
+      int y,
+      int width,
+      int height
+   ) {
+      float[] heights = mesh.heightsFor(renderMode);
+      int[] colors = mesh.colorsFor(renderMode);
+      int stride = mesh.granularity;
+      if (mesh.size <= stride) {
+         return;
+      }
+
+      int quadsX = (mesh.size - 1) / stride;
+      int quadsZ = (mesh.size - 1) / stride;
+      int quadCount = quadsX * quadsZ;
+      int[] quadTopLeft = new int[quadCount];
+      float[] quadDepth = new float[quadCount];
+      Vector3f view = new Vector3f();
+      Vector3f normal = new Vector3f();
+      float depthScale = 0.25F;
+      int quadIndex = 0;
+
+      for (int zIndex = 0; zIndex < mesh.size - stride; zIndex += stride) {
+         float z0 = mesh.axis[zIndex];
+         float z1 = mesh.axis[zIndex + stride];
+         int rowIndex = zIndex * mesh.size;
+         int nextRowIndex = (zIndex + stride) * mesh.size;
+
+         for (int xIndex = 0; xIndex < mesh.size - stride; xIndex += stride) {
+            int idx = rowIndex + xIndex;
+            int idxRight = idx + stride;
+            int idxDown = nextRowIndex + xIndex;
+            int idxDownRight = idxDown + stride;
+            float v0 = modelView.transformPosition(mesh.axis[xIndex], heights[idx], z0, view).z;
+            float v1 = modelView.transformPosition(mesh.axis[xIndex + stride], heights[idxRight], z0, view).z;
+            float v2 = modelView.transformPosition(mesh.axis[xIndex], heights[idxDown], z1, view).z;
+            float v3 = modelView.transformPosition(mesh.axis[xIndex + stride], heights[idxDownRight], z1, view).z;
+            float maxZ = Math.max(Math.max(v0, v1), Math.max(v2, v3));
+            if (maxZ > -0.05F) {
+               quadTopLeft[quadIndex] = -1;
+               quadDepth[quadIndex] = Float.POSITIVE_INFINITY;
+            } else {
+               quadTopLeft[quadIndex] = idx;
+               quadDepth[quadIndex] = (v0 + v1 + v2 + v3) * depthScale;
+            }
+
+            quadIndex++;
+         }
+      }
+
+      if (quadCount > 1) {
+         sortPreviewQuads(quadTopLeft, quadDepth, 0, quadCount - 1);
+      }
+
+      BufferBuilder buffer = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+      Vector3f projected = new Vector3f();
+      float x0 = x;
+      float y0 = y;
+      float drawWidth = width;
+      float drawHeight = height;
+
+      for (int i = 0; i < quadCount; i++) {
+         int idx = quadTopLeft[i];
+         if (idx >= 0) {
+            int xIndex = idx % mesh.size;
+            int zIndex = idx / mesh.size;
+            int idxRight = idx + stride;
+            int idxDown = idx + stride * mesh.size;
+            int idxDownRight = idxDown + stride;
+            float worldX0 = mesh.axis[xIndex];
+            float worldX1 = mesh.axis[xIndex + stride];
+            float worldZ0 = mesh.axis[zIndex];
+            float worldZ1 = mesh.axis[zIndex + stride];
+            float shade = computePreviewQuadShade(
+               worldX0,
+               heights[idx],
+               worldZ0,
+               worldX1,
+               heights[idxRight],
+               worldZ0,
+               worldX0,
+               heights[idxDown],
+               worldZ1,
+               worldX1,
+               heights[idxDownRight],
+               worldZ1,
+               normal
+            );
+            int quadColor = applyPreviewShade(colors[idx], shade);
+            emitPreviewVertex(buffer, modelView, projection, worldX0, heights[idxDown], worldZ1, quadColor, x0, y0, drawWidth, drawHeight, view, projected);
+            emitPreviewVertex(buffer, modelView, projection, worldX1, heights[idxDownRight], worldZ1, quadColor, x0, y0, drawWidth, drawHeight, view, projected);
+            emitPreviewVertex(buffer, modelView, projection, worldX1, heights[idxRight], worldZ0, quadColor, x0, y0, drawWidth, drawHeight, view, projected);
+            emitPreviewVertex(buffer, modelView, projection, worldX0, heights[idx], worldZ0, quadColor, x0, y0, drawWidth, drawHeight, view, projected);
+         }
+      }
+
+      RenderSystem.enableBlend();
+      RenderSystem.defaultBlendFunc();
+      RenderSystem.setShader(GameRenderer::getPositionColorShader);
+      BufferUploader.drawWithShader(buffer.buildOrThrow());
+      RenderSystem.disableBlend();
+   }
+
+   private static Matrix4f buildProjection(int width, int height, float zoom) {
+      float aspect = (float)width / height;
+      float effectiveFov = Mth.clamp(50.0F / Math.max(zoom, 0.01F), 15.0F, 120.0F);
+      return new Matrix4f().setPerspective((float)Math.toRadians(effectiveFov), aspect, 0.05F, 100.0F);
+   }
+
+   private static Matrix4f buildModelView(float rotationX, float rotationY) {
+      return new Matrix4f().identity().translate(0.0F, 0.0F, -2.35F).rotateX(rotationX).rotateY(rotationY);
+   }
+
+   private TerrainPreview.PreviewMesh buildMesh(EarthGeneratorSettings settings, int id) {
+      if (this.shouldAbortRequest(id)) {
+         return null;
+      }
+
+      TerrainPreview.PreviewBaseSnapshot cached = this.baseSnapshot;
+      if (this.canReuseBaseSnapshot(settings, cached)) {
+         return this.buildMeshFromSnapshot(settings, id, cached);
+      }
+
+      int size = PREVIEW_GRID_SIZE;
+      double[] blockHeights = new double[size * size];
+      boolean[] esaWaterMask = new boolean[size * size];
+      double[] elevations = new double[size * size];
+      int coverStride = 2;
+      int coverSize = (size + coverStride - 1) / coverStride;
+      int climateStride = 4;
+      int climateSize = (size + climateStride - 1) / climateStride;
+      long downloadDone = 0L;
+      boolean roadsPreviewEnabled = settings.enableRoads() && settings.worldScale() > 0.0 && settings.worldScale() <= 15.0;
+      boolean buildingsPreviewEnabled = settings.enableBuildings() && settings.worldScale() > 0.0 && settings.worldScale() <= 15.0 && this.osmBuildingSource.available();
+      double worldScale = settings.worldScale();
+      boolean useVisualCover = worldScale > 0.0 && worldScale < 10.0;
+      long coverDownloadUnits = (long)coverSize * coverSize * (useVisualCover ? 2L : 1L);
+      long downloadTotal = (long)size * size + coverDownloadUnits + (long)climateSize * climateSize;
+      boolean waterPreviewEnabled = settings.enableWater() && worldScale > 0.0 && this.osmWaterSource.available();
+      boolean remaSnowEnabled = TellusElevationSource.usesPolarDem(settings.demSelection()) && worldScale > 0.0;
+      double remaSnowBoundaryZ = remaSnowEnabled ? TellusElevationSource.remaBoundaryBlockZ(worldScale) : Double.POSITIVE_INFINITY;
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double centerX = settings.spawnLongitude() * blocksPerDegree;
+      double centerZ = EarthProjection.latToBlockZ(settings.spawnLatitude(), worldScale);
+      double radius = PREVIEW_RADIUS_BLOCKS;
+      double step = radius * 2.0 / (size - 1);
+      double previewResolutionMeters = Math.max(worldScale, step * worldScale);
+      double minWorldX = centerX - radius;
+      double minWorldZ = centerZ - radius;
+      double maxWorldX = centerX + radius;
+      double maxWorldZ = centerZ + radius;
+      float[] xCoords = buildAxisCoordinates(size);
+      this.queueBasePreviewPrefetch(centerX, centerZ, worldScale, settings.demSelection(), previewResolutionMeters);
+      this.queueOsmPreviewPrefetch(centerX, centerZ, worldScale, minWorldX, minWorldZ, maxWorldX, maxWorldZ, waterPreviewEnabled, roadsPreviewEnabled, buildingsPreviewEnabled);
+
+      TerrainPreview.DownloadNetworkTracker downloadTracker = new TerrainPreview.DownloadNetworkTracker();
+      int[] coverClasses = new int[coverSize * coverSize];
+      int[] visualCoverClasses = new int[coverSize * coverSize];
+      byte[] climateGroups = new byte[climateSize * climateSize];
+      double minElevation = Double.POSITIVE_INFINITY;
+      double maxElevation = Double.NEGATIVE_INFINITY;
+      int minSurfaceY = Integer.MAX_VALUE;
+      int maxSurfaceY = Integer.MIN_VALUE;
+
+      try (DownloadProgressReporter.Scope ignored = DownloadProgressReporter.push(downloadTracker)) {
+         for (int z = 0; z < size; z++) {
+            if (this.shouldAbortRequest(id)) {
+               return null;
+            }
+
+            double blockZ = centerZ - radius + z * step;
+
+            for (int x = 0; x < size; x++) {
+               if (this.shouldAbortRequest(id)) {
+                  return null;
+               }
+
+               double blockX = centerX - radius + x * step;
+               int idx = x + z * size;
+               TellusLandMaskSource.LandMaskSample landMaskSample = this.landMaskSource.sampleLandMask(blockX, blockZ, worldScale);
+               int pointCoverClass = landMaskSample.known() && landMaskSample.land()
+                  ? ESA_NO_DATA
+                  : this.landCoverSource.sampleCoverClass(blockX, blockZ, worldScale, previewResolutionMeters);
+               boolean oceanZoom = useOceanZoom(landMaskSample, pointCoverClass);
+               double elevation = this.elevationSource.samplePreviewElevationMeters(
+                  blockX,
+                  blockZ,
+                  worldScale,
+                  oceanZoom,
+                  settings.demSelection(),
+                  previewResolutionMeters
+               );
+               if (this.shouldAbortRequest(id)) {
+                  return null;
+               }
+
+               int surfaceY = scaledSurfaceY(elevation, settings);
+               elevations[idx] = elevation;
+               blockHeights[idx] = surfaceY;
+               esaWaterMask[idx] = pointCoverClass == ESA_WATER;
+               minElevation = Math.min(minElevation, elevation);
+               maxElevation = Math.max(maxElevation, elevation);
+               minSurfaceY = Math.min(minSurfaceY, surfaceY);
+               maxSurfaceY = Math.max(maxSurfaceY, surfaceY);
+               if ((++downloadDone & 255L) == 0L) {
+                  this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_ELEVATION);
+               }
+            }
+
+            this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_ELEVATION);
+         }
+
+         for (int z = 0; z < coverSize; z++) {
+            if (this.shouldAbortRequest(id)) {
+               return null;
+            }
+
+            int sampleZ = Math.min(size - 1, z * coverStride);
+            double blockZ = centerZ - radius + sampleZ * step;
+
+            for (int xx = 0; xx < coverSize; xx++) {
+               if (this.shouldAbortRequest(id)) {
+                  return null;
+               }
+
+               int sampleX = Math.min(size - 1, xx * coverStride);
+               double blockX = centerX - radius + sampleX * step;
+               int idx = xx + z * coverSize;
+               int rawCoverClass = this.landCoverSource.sampleCoverClass(blockX, blockZ, worldScale, previewResolutionMeters);
+               coverClasses[idx] = rawCoverClass;
+               visualCoverClasses[idx] = rawCoverClass;
+               if (this.shouldAbortRequest(id)) {
+                  return null;
+               }
+
+               if ((++downloadDone & 255L) == 0L) {
+                  this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_LAND_COVER);
+               }
+
+               if (useVisualCover) {
+                  visualCoverClasses[idx] = this.landCoverSource.sampleVisualCoverClass(blockX, blockZ, worldScale, previewResolutionMeters);
+                  if (this.shouldAbortRequest(id)) {
+                     return null;
+                  }
+
+                  if ((++downloadDone & 255L) == 0L) {
+                     this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_LAND_COVER);
+                  }
+               }
+            }
+
+            this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_LAND_COVER);
+         }
+
+         for (int z = 0; z < climateSize; z++) {
+            if (this.shouldAbortRequest(id)) {
+               return null;
+            }
+
+            int sampleZ = Math.min(size - 1, z * climateStride);
+            double blockZ = centerZ - radius + sampleZ * step;
+
+            for (int xxx = 0; xxx < climateSize; xxx++) {
+               if (this.shouldAbortRequest(id)) {
+                  return null;
+               }
+
+               int sampleX = Math.min(size - 1, xxx * climateStride);
+               double blockX = centerX - radius + sampleX * step;
+               int idx = xxx + z * climateSize;
+               String koppen = this.koppenSource.sampleDitheredCode(blockX, blockZ, worldScale);
+               if (this.shouldAbortRequest(id)) {
+                  return null;
+               }
+
+               climateGroups[idx] = climateGroup(koppen);
+               if ((++downloadDone & 255L) == 0L) {
+                  this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_CLIMATE);
+               }
+            }
+
+            this.updateDownloadStatus(id, downloadDone, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_CLIMATE);
+         }
+
+         this.updateDownloadStatus(id, downloadTotal, downloadTotal, downloadTracker, ACTIVITY_DOWNLOAD_CLIMATE);
+      }
+
+      if (this.shouldAbortRequest(id)) {
+         return null;
+      }
+
+      float[] heights = new float[size * size];
+      float min = Float.POSITIVE_INFINITY;
+      float max = Float.NEGATIVE_INFINITY;
+      long gridArea = (long)size * size;
+      long treeOverlayUnits = gridArea;
+      long heightOffsetUnits = gridArea;
+      long infoUnits = (long)PREVIEW_INFO_PROVIDER_GRID_SIZE * PREVIEW_INFO_PROVIDER_GRID_SIZE;
+      long buildTotal = gridArea * 3L
+         + treeOverlayUnits
+         + heightOffsetUnits
+         + infoUnits
+         + (waterPreviewEnabled ? PREVIEW_WATER_OVERLAY_UNITS : 0L)
+         + (roadsPreviewEnabled ? PREVIEW_ROAD_OVERLAY_UNITS : 0L)
+         + (buildingsPreviewEnabled ? PREVIEW_BUILDING_OVERLAY_UNITS : 0L);
+      long buildDone = 0L;
+      this.updateStatus(id, TerrainPreview.PreviewStage.LOADING, 0.0F, ACTIVITY_BUILD_HEIGHTS);
+
+      for (int i = 0; i < blockHeights.length; i++) {
+         float value = (float)((blockHeights[i] - settings.heightOffset()) / radius * 0.7F);
+         heights[i] = value;
+         min = Math.min(min, value);
+         max = Math.max(max, value);
+         if ((i + 1) % size == 0) {
+            if (this.shouldAbortRequest(id)) {
+               return null;
+            }
+
+            buildDone += size;
+            this.updateBuildStatus(id, buildDone, buildTotal, ACTIVITY_BUILD_HEIGHTS);
+         }
+      }
+
+      float center = (min + max) * 0.5F;
+
+      for (int ix = 0; ix < heights.length; ix++) {
+         heights[ix] -= center;
+         if ((ix + 1) % size == 0) {
+            if (this.shouldAbortRequest(id)) {
+               return null;
+            }
+
+            buildDone += size;
+            this.updateBuildStatus(id, buildDone, buildTotal, ACTIVITY_BUILD_CENTER);
+         }
+      }
+
+      this.updateBuildStatus(id, buildDone, buildTotal, ACTIVITY_BUILD_COLORS);
+      int seaLevel = settings.resolveSeaLevel();
+      float[] terrainHeights = heights.clone();
+      float[] detailHeights = heights.clone();
+      int[] terrainColors = new int[size * size];
+      int[] detailColors = new int[size * size];
+      float[] detailHeightOffsets = new float[size * size];
+
+      for (int z = 0; z < size; z++) {
+         if (this.shouldAbortRequest(id)) {
+            return null;
+         }
+
+         double blockZ = minWorldZ + z * step;
+         int coverZ = Math.min(coverSize - 1, z / coverStride);
+         int climateZ = Math.min(climateSize - 1, z / climateStride);
+
+         for (int xxxx = 0; xxxx < size; xxxx++) {
+            int idx = xxxx + z * size;
+            int coverX = Math.min(coverSize - 1, xxxx / coverStride);
+            int climateX = Math.min(climateSize - 1, xxxx / climateStride);
+            int coverIdx = coverX + coverZ * coverSize;
+            int climateIdx = climateX + climateZ * climateSize;
+            int rawCoverClass = coverClasses[coverIdx];
+            int visualCoverClass = visualCoverClasses[coverIdx];
+            byte climateGroup = climateGroups[climateIdx];
+            int slopeDiff = previewSlopeDiff(blockHeights, size, idx, step);
+            int convexity = previewConvexity(blockHeights, size, idx, step);
+            double slope = computeSlope(blockHeights, size, idx, step);
+            int color = colorForPreview(
+               rawCoverClass,
+               visualCoverClass,
+               climateGroup,
+               elevations[idx],
+               blockHeights[idx],
+               slopeDiff,
+               convexity,
+               slope,
+               seaLevel,
+               esaWaterMask[idx],
+               !waterPreviewEnabled,
+               settings.enableWater(),
+               remaSnowEnabled && blockZ >= remaSnowBoundaryZ
+            );
+            terrainColors[idx] = color;
+            detailColors[idx] = color;
+         }
+
+         buildDone += size;
+         this.updateBuildStatus(id, buildDone, buildTotal, ACTIVITY_BUILD_COLORS);
+      }
+
+      TerrainPreview.PreviewInfo placeholderInfo = previewInfoPlaceholder(minElevation, maxElevation, minSurfaceY, maxSurfaceY);
+      this.publishInterimMesh(id, size, terrainHeights, terrainColors, detailHeights, detailColors, xCoords, placeholderInfo);
+
+      if (!this.overlayTreePreviewMarkers(
+         id,
+         buildTotal,
+         buildDone,
+         detailColors,
+         detailHeightOffsets,
+         coverClasses,
+         visualCoverClasses,
+         coverSize,
+         coverStride,
+         settings,
+         minWorldX,
+         minWorldZ,
+         step
+      )) {
+         return null;
+      }
+
+      buildDone += treeOverlayUnits;
+      if (waterPreviewEnabled) {
+         if (!this.processWaterPreviewOverlay(
+            id, buildTotal, buildDone, terrainColors, detailColors, detailHeightOffsets, settings, minWorldX, minWorldZ, maxWorldX, maxWorldZ, step
+         )) {
+            return null;
+         }
+
+         buildDone += PREVIEW_WATER_OVERLAY_UNITS;
+      }
+
+      if (roadsPreviewEnabled) {
+         if (!this.processRoadPreviewOverlay(id, buildTotal, buildDone, terrainColors, detailColors, settings, centerX, centerZ, radius, step)) {
+            return null;
+         }
+
+         buildDone += PREVIEW_ROAD_OVERLAY_UNITS;
+      }
+
+      if (!this.applyFeatureHeightOffsets(id, buildTotal, buildDone, detailHeights, detailHeightOffsets, size)) {
+         return null;
+      }
+
+      buildDone += heightOffsetUnits;
+      if (buildingsPreviewEnabled) {
+         if (!this.processBuildingPreviewOverlay(
+            id, buildTotal, buildDone, terrainHeights, terrainColors, detailHeights, detailColors, blockHeights, settings, centerX, centerZ, radius, step, center
+         )) {
+            return null;
+         }
+
+         buildDone += PREVIEW_BUILDING_OVERLAY_UNITS;
+      }
+
+      if (this.shouldAbortRequest(id)) {
+         return null;
+      }
+
+      TerrainPreview.PreviewInfo previewInfo = this.buildPreviewInfo(
+         id, settings, centerX, centerZ, minElevation, maxElevation, minSurfaceY, maxSurfaceY, buildTotal, buildDone
+      );
+      if (previewInfo == null || this.shouldAbortRequest(id)) {
+         return null;
+      }
+
+      buildDone += infoUnits;
+      this.baseSnapshot = new TerrainPreview.PreviewBaseSnapshot(
+         worldScale,
+         settings.terrestrialHeightScale(),
+         settings.oceanicHeightScale(),
+         settings.heightOffset(),
+         settings.spawnLatitude(),
+         settings.spawnLongitude(),
+         settings.demSelection(),
+         size,
+         coverStride,
+         coverSize,
+         climateStride,
+         climateSize,
+         centerX,
+         centerZ,
+         radius,
+         step,
+         minWorldX,
+         minWorldZ,
+         maxWorldX,
+         maxWorldZ,
+         blockHeights,
+         esaWaterMask,
+         elevations,
+         coverClasses,
+         visualCoverClasses,
+         climateGroups,
+         heights,
+         center,
+         xCoords,
+         previewInfo
+      );
+      this.updateStatus(id, TerrainPreview.PreviewStage.COMPLETE, 1.0F);
+      return new TerrainPreview.PreviewMesh(size, 1, terrainHeights, terrainColors, detailHeights, detailColors, xCoords, previewInfo);
+   }
+
+   private TerrainPreview.PreviewMesh buildMeshFromSnapshot(EarthGeneratorSettings settings, int id, TerrainPreview.PreviewBaseSnapshot snapshot) {
+      if (this.shouldAbortRequest(id)) {
+         return null;
+      }
+
+      int size = snapshot.size();
+      double worldScale = snapshot.worldScale();
+      boolean roadsPreviewEnabled = settings.enableRoads() && worldScale > 0.0 && worldScale <= 15.0;
+      boolean buildingsPreviewEnabled = settings.enableBuildings() && worldScale > 0.0 && worldScale <= 15.0 && this.osmBuildingSource.available();
+      boolean waterPreviewEnabled = settings.enableWater() && worldScale > 0.0 && this.osmWaterSource.available();
+      boolean remaSnowEnabled = TellusElevationSource.usesPolarDem(settings.demSelection()) && worldScale > 0.0;
+      double remaSnowBoundaryZ = remaSnowEnabled ? TellusElevationSource.remaBoundaryBlockZ(worldScale) : Double.POSITIVE_INFINITY;
+      this.queueOsmPreviewPrefetch(
+         snapshot.centerX(),
+         snapshot.centerZ(),
+         worldScale,
+         snapshot.minWorldX(),
+         snapshot.minWorldZ(),
+         snapshot.maxWorldX(),
+         snapshot.maxWorldZ(),
+         waterPreviewEnabled,
+         roadsPreviewEnabled,
+         buildingsPreviewEnabled
+      );
+      long gridArea = (long)size * size;
+      long buildTotal = gridArea * 3L
+         + (waterPreviewEnabled ? PREVIEW_WATER_OVERLAY_UNITS : 0L)
+         + (roadsPreviewEnabled ? PREVIEW_ROAD_OVERLAY_UNITS : 0L)
+         + (buildingsPreviewEnabled ? PREVIEW_BUILDING_OVERLAY_UNITS : 0L);
+      long buildDone = 0L;
+      this.updateStatus(id, TerrainPreview.PreviewStage.LOADING, 0.0F, ACTIVITY_BUILD_COLORS);
+      int seaLevel = settings.resolveSeaLevel();
+      float[] terrainHeights = snapshot.heights().clone();
+      float[] detailHeights = snapshot.heights().clone();
+      int[] terrainColors = new int[size * size];
+      int[] detailColors = new int[size * size];
+      float[] detailHeightOffsets = new float[size * size];
+
+      for (int z = 0; z < size; z++) {
+         if (this.shouldAbortRequest(id)) {
+            return null;
+         }
+
+         double blockZ = snapshot.minWorldZ() + z * snapshot.step();
+         int coverZ = Math.min(snapshot.coverSize() - 1, z / snapshot.coverStride());
+         int climateZ = Math.min(snapshot.climateSize() - 1, z / snapshot.climateStride());
+
+         for (int x = 0; x < size; x++) {
+            int idx = x + z * size;
+            int coverX = Math.min(snapshot.coverSize() - 1, x / snapshot.coverStride());
+            int climateX = Math.min(snapshot.climateSize() - 1, x / snapshot.climateStride());
+            int coverIdx = coverX + coverZ * snapshot.coverSize();
+            int climateIdx = climateX + climateZ * snapshot.climateSize();
+            int rawCoverClass = snapshot.coverClasses()[coverIdx];
+            int visualCoverClass = snapshot.visualCoverClasses()[coverIdx];
+            byte climateGroup = snapshot.climateGroups()[climateIdx];
+            int slopeDiff = previewSlopeDiff(snapshot.blockHeights(), size, idx, snapshot.step());
+            int convexity = previewConvexity(snapshot.blockHeights(), size, idx, snapshot.step());
+            double slope = computeSlope(snapshot.blockHeights(), size, idx, snapshot.step());
+            int color = colorForPreview(
+               rawCoverClass,
+               visualCoverClass,
+               climateGroup,
+               snapshot.elevations()[idx],
+               snapshot.blockHeights()[idx],
+               slopeDiff,
+               convexity,
+               slope,
+               seaLevel,
+               snapshot.esaWaterMask()[idx],
+               !waterPreviewEnabled,
+               settings.enableWater(),
+               remaSnowEnabled && blockZ >= remaSnowBoundaryZ
+            );
+            terrainColors[idx] = color;
+            detailColors[idx] = color;
+         }
+
+         buildDone += size;
+         this.updateBuildStatus(id, buildDone, buildTotal, ACTIVITY_BUILD_COLORS);
+      }
+
+      this.publishInterimMesh(id, size, terrainHeights, terrainColors, detailHeights, detailColors, snapshot.xCoords(), snapshot.info());
+
+      if (!this.overlayTreePreviewMarkers(
+         id,
+         buildTotal,
+         buildDone,
+         detailColors,
+         detailHeightOffsets,
+         snapshot.coverClasses(),
+         snapshot.visualCoverClasses(),
+         snapshot.coverSize(),
+         snapshot.coverStride(),
+         settings,
+         snapshot.minWorldX(),
+         snapshot.minWorldZ(),
+         snapshot.step()
+      )) {
+         return null;
+      }
+
+      buildDone += gridArea;
+      if (waterPreviewEnabled) {
+         if (!this.processWaterPreviewOverlay(
+            id,
+            buildTotal,
+            buildDone,
+            terrainColors,
+            detailColors,
+            detailHeightOffsets,
+            settings,
+            snapshot.minWorldX(),
+            snapshot.minWorldZ(),
+            snapshot.maxWorldX(),
+            snapshot.maxWorldZ(),
+            snapshot.step()
+         )) {
+            return null;
+         }
+
+         buildDone += PREVIEW_WATER_OVERLAY_UNITS;
+      }
+
+      if (roadsPreviewEnabled) {
+         if (!this.processRoadPreviewOverlay(
+            id,
+            buildTotal,
+            buildDone,
+            terrainColors,
+            detailColors,
+            settings,
+            snapshot.centerX(),
+            snapshot.centerZ(),
+            snapshot.radius(),
+            snapshot.step()
+         )) {
+            return null;
+         }
+
+         buildDone += PREVIEW_ROAD_OVERLAY_UNITS;
+      }
+
+      if (!this.applyFeatureHeightOffsets(id, buildTotal, buildDone, detailHeights, detailHeightOffsets, size)) {
+         return null;
+      }
+
+      buildDone += gridArea;
+      if (buildingsPreviewEnabled) {
+         if (!this.processBuildingPreviewOverlay(
+            id,
+            buildTotal,
+            buildDone,
+            terrainHeights,
+            terrainColors,
+            detailHeights,
+            detailColors,
+            snapshot.blockHeights(),
+            settings,
+            snapshot.centerX(),
+            snapshot.centerZ(),
+            snapshot.radius(),
+            snapshot.step(),
+            snapshot.heightCenter()
+         )) {
+            return null;
+         }
+
+         buildDone += PREVIEW_BUILDING_OVERLAY_UNITS;
+      }
+
+      if (this.shouldAbortRequest(id)) {
+         return null;
+      }
+
+      this.updateStatus(id, TerrainPreview.PreviewStage.COMPLETE, 1.0F);
+      return new TerrainPreview.PreviewMesh(
+         size, 1, terrainHeights, terrainColors, detailHeights, detailColors, snapshot.xCoords(), snapshot.info()
+      );
+   }
+
+   private boolean canReuseBaseSnapshot(EarthGeneratorSettings settings, TerrainPreview.PreviewBaseSnapshot snapshot) {
+      return snapshot != null
+         && Double.compare(snapshot.worldScale(), settings.worldScale()) == 0
+         && Double.compare(snapshot.terrestrialHeightScale(), settings.terrestrialHeightScale()) == 0
+         && Double.compare(snapshot.oceanicHeightScale(), settings.oceanicHeightScale()) == 0
+         && snapshot.heightOffset() == settings.heightOffset()
+         && Double.compare(snapshot.spawnLatitude(), settings.spawnLatitude()) == 0
+         && Double.compare(snapshot.spawnLongitude(), settings.spawnLongitude()) == 0
+         && snapshot.demSelection().equals(settings.demSelection());
+   }
+
+   private void queueBasePreviewPrefetch(
+      double centerX,
+      double centerZ,
+      double worldScale,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (worldScale > 0.0) {
+         Util.backgroundExecutor().execute(() -> {
+            try {
+               this.elevationSource.prefetchTiles(
+                  centerX, centerZ, worldScale, PREVIEW_ELEVATION_PREFETCH_RADIUS, demSelection, previewResolutionMeters
+               );
+            } catch (RuntimeException ignored) {
+            }
+         });
+         Util.backgroundExecutor().execute(() -> {
+            try {
+               this.landCoverSource.prefetchTiles(centerX, centerZ, worldScale, PREVIEW_LAND_COVER_PREFETCH_RADIUS, previewResolutionMeters);
+            } catch (RuntimeException ignored) {
+            }
+         });
+         Util.backgroundExecutor().execute(() -> {
+            try {
+               this.landMaskSource.prefetchTiles(centerX, centerZ, worldScale, PREVIEW_LAND_MASK_PREFETCH_RADIUS);
+            } catch (RuntimeException ignored) {
+            }
+         });
+      }
+   }
+
+   private void queueOsmPreviewPrefetch(
+      double centerX,
+      double centerZ,
+      double worldScale,
+      double minWorldX,
+      double minWorldZ,
+      double maxWorldX,
+      double maxWorldZ,
+      boolean waterPreviewEnabled,
+      boolean roadsPreviewEnabled,
+      boolean buildingsPreviewEnabled
+   ) {
+      if (waterPreviewEnabled) {
+         this.queueWaterPreviewPrefetch(minWorldX, minWorldZ, maxWorldX, maxWorldZ, worldScale);
+      }
+
+      if (roadsPreviewEnabled) {
+         this.osmRoadSource.prefetchTiles(centerX, centerZ, worldScale, PREVIEW_OSM_PREFETCH_RADIUS);
+      }
+
+      if (buildingsPreviewEnabled) {
+         this.osmBuildingSource.prefetchTiles(centerX, centerZ, worldScale, PREVIEW_OSM_PREFETCH_RADIUS);
+      }
+   }
+
+   public static int scaledSurfaceY(double elevation, EarthGeneratorSettings settings) {
+      double scale = elevation >= 0.0 ? settings.terrestrialHeightScale() : settings.oceanicHeightScale();
+      double scaled = elevation * scale / settings.worldScale();
+      int base = elevation >= 0.0 ? Mth.ceil(scaled) : Mth.floor(scaled);
+      return base + settings.heightOffset();
+   }
+
+   private void publishInterimMesh(
+      int id,
+      int size,
+      float[] terrainHeights,
+      int[] terrainColors,
+      float[] detailHeights,
+      int[] detailColors,
+      float[] xCoords,
+      TerrainPreview.PreviewInfo info
+   ) {
+      if (!this.shouldAbortRequest(id)) {
+         this.mesh = new TerrainPreview.PreviewMesh(
+            size,
+            1,
+            terrainHeights.clone(),
+            terrainColors.clone(),
+            detailHeights.clone(),
+            detailColors.clone(),
+            xCoords,
+            info
+         );
+         this.info.set(info);
+      }
+   }
+
+   private static float[] buildAxisCoordinates(int size) {
+      float[] xCoords = new float[size];
+
+      for (int i = 0; i < size; i++) {
+         xCoords[i] = (float)(-1.0 + 2.0 * i / (size - 1));
+      }
+
+      return xCoords;
+   }
+
+   private static TerrainPreview.PreviewInfo previewInfoPlaceholder(
+      double minElevation, double maxElevation, int minSurfaceY, int maxSurfaceY
+   ) {
+      return new TerrainPreview.PreviewInfo(List.of(), List.of(), 0, minElevation, maxElevation, minSurfaceY, maxSurfaceY);
+   }
+
+   private TerrainPreview.PreviewInfo buildPreviewInfo(
+      int id,
+      EarthGeneratorSettings settings,
+      double centerX,
+      double centerZ,
+      double minElevation,
+      double maxElevation,
+      int minSurfaceY,
+      int maxSurfaceY,
+      long buildTotal,
+      long buildBaseDone
+   ) {
+      double radius = PREVIEW_RADIUS_BLOCKS;
+      int providerGridSize = PREVIEW_INFO_PROVIDER_GRID_SIZE;
+      double providerStep = radius * 2.0 / (providerGridSize - 1);
+      double imageStep = radius * 2.0 / (PREVIEW_GRID_SIZE - 1);
+      double previewResolutionMeters = Math.max(settings.worldScale(), imageStep * settings.worldScale());
+      EnumMap<DemUsage, Integer> primaryCounts = new EnumMap<>(DemUsage.class);
+      Map<Integer, Integer> resolutionCounts = new HashMap<>();
+      int providerSampleCount = 0;
+      int blendedMask = 0;
+      long progressDone = 0L;
+
+      for (int z = 0; z < providerGridSize; z++) {
+         if (this.shouldAbortRequest(id)) {
+            return null;
+         }
+
+         double blockZ = centerZ - radius + z * providerStep;
+
+         for (int x = 0; x < providerGridSize; x++) {
+            double blockX = centerX - radius + x * providerStep;
+            boolean oceanZoom = this.useOceanZoom(blockX, blockZ, settings.worldScale(), previewResolutionMeters);
+            ElevationDiagnostic diagnostic = this.elevationSource.samplePreviewDiagnostic(
+               blockX,
+               blockZ,
+               settings.worldScale(),
+               oceanZoom,
+               settings.demSelection(),
+               previewResolutionMeters
+            );
+            if (this.shouldAbortRequest(id)) {
+               return null;
+            }
+
+            primaryCounts.merge(diagnostic.primaryProvider(), 1, Integer::sum);
+            double displayResolutionMeters = diagnostic.displayResolutionMeters();
+            if (Double.isFinite(displayResolutionMeters) && displayResolutionMeters > 0.0) {
+               resolutionCounts.merge(resolutionBucketKey(displayResolutionMeters), 1, Integer::sum);
+            }
+
+            if (diagnostic.usesMultipleProviders()) {
+               blendedMask |= diagnostic.providerMask() & ~diagnostic.primaryProvider().bit();
+            }
+
+            providerSampleCount++;
+         }
+
+         progressDone += providerGridSize;
+         this.updateBuildStatus(id, buildBaseDone + progressDone, buildTotal, ACTIVITY_BUILD_INFO);
+      }
+
+      List<TerrainPreview.PreviewProviderShare> primaryProviders = new ArrayList<>(primaryCounts.size());
+      for (DemUsage provider : DemUsage.values()) {
+         Integer count = primaryCounts.get(provider);
+         if (count != null && count > 0) {
+            primaryProviders.add(new TerrainPreview.PreviewProviderShare(provider, count / (double)Math.max(1, providerSampleCount)));
+         }
+      }
+
+      primaryProviders.sort((left, right) -> Double.compare(right.share(), left.share()));
+      List<TerrainPreview.PreviewResolutionShare> primaryResolutions = new ArrayList<>(resolutionCounts.size());
+      for (Map.Entry<Integer, Integer> entry : resolutionCounts.entrySet()) {
+         int count = entry.getValue();
+         if (count > 0) {
+            primaryResolutions.add(
+               new TerrainPreview.PreviewResolutionShare(resolutionBucketMeters(entry.getKey()), count / (double)Math.max(1, providerSampleCount))
+            );
+         }
+      }
+
+      primaryResolutions.sort((left, right) -> {
+         int shareCompare = Double.compare(right.share(), left.share());
+         return shareCompare != 0 ? shareCompare : Double.compare(left.resolutionMeters(), right.resolutionMeters());
+      });
+      return new TerrainPreview.PreviewInfo(
+         List.copyOf(primaryProviders),
+         List.copyOf(primaryResolutions),
+         blendedMask,
+         minElevation,
+         maxElevation,
+         minSurfaceY,
+         maxSurfaceY
+      );
+   }
+
+   private static int resolutionBucketKey(double resolutionMeters) {
+      return Math.max(1, (int)Math.round(resolutionMeters * 100.0));
+   }
+
+   private static double resolutionBucketMeters(int bucketKey) {
+      return bucketKey / 100.0;
+   }
+
+   private static double computeSlope(double[] heights, int size, int idx, double step) {
+      int x = idx % size;
+      int z = idx / size;
+      int idxRight = x + 1 < size ? idx + 1 : idx;
+      int idxDown = z + 1 < size ? idx + size : idx;
+      double dx = Math.abs(heights[idxRight] - heights[idx]);
+      double dz = Math.abs(heights[idxDown] - heights[idx]);
+      double diff = Math.max(dx, dz);
+      return step <= 0.0 ? diff : diff / step;
+   }
+
+   private static int previewSlopeDiff(double[] heights, int size, int idx, double step) {
+      int x = idx % size;
+      int z = idx / size;
+      double center = heights[idx];
+      double east = heights[z * size + Math.min(size - 1, x + 1)];
+      double west = heights[z * size + Math.max(0, x - 1)];
+      double north = heights[Math.max(0, z - 1) * size + x];
+      double south = heights[Math.min(size - 1, z + 1) * size + x];
+      double maxDiff = Math.max(Math.max(Math.abs(east - center), Math.abs(west - center)), Math.max(Math.abs(north - center), Math.abs(south - center)));
+      double scaledStep = Math.max(4.0, step);
+      return (int)Math.round(maxDiff * 4.0 / scaledStep);
+   }
+
+   private static int previewConvexity(double[] heights, int size, int idx, double step) {
+      int x = idx % size;
+      int z = idx / size;
+      double center = heights[idx];
+      double east = heights[z * size + Math.min(size - 1, x + 1)];
+      double west = heights[z * size + Math.max(0, x - 1)];
+      double north = heights[Math.max(0, z - 1) * size + x];
+      double south = heights[Math.min(size - 1, z + 1) * size + x];
+      double neighborAverage = (east + west + north + south) * 0.25;
+      double scaledStep = Math.max(4.0, step);
+      return (int)Math.round((neighborAverage - center) * 4.0 / scaledStep);
+   }
+
+   private boolean overlayTreePreviewMarkers(
+      int requestId,
+      long buildTotal,
+      long buildBaseDone,
+      int[] colors,
+      float[] heightOffsets,
+      int[] coverClasses,
+      int[] visualCoverClasses,
+      int coverSize,
+      int coverStride,
+      EarthGeneratorSettings settings,
+      double minWorldX,
+      double minWorldZ,
+      double step
+   ) {
+      if (!(settings.worldScale() <= 0.0) && !(settings.worldScale() > 60.0) && !(step <= 0.0)) {
+         int size = PREVIEW_GRID_SIZE;
+         float density = treeMarkerDensity(settings.worldScale());
+         if (!(density <= 0.0F)) {
+            float treeHeight = treePreviewHeight(settings.worldScale());
+            boolean expandedMarkers = settings.worldScale() <= 12.0;
+
+            for (int z = 0; z < size; z++) {
+               if (this.shouldAbortRequest(requestId)) {
+                  return false;
+               }
+
+               int coverZ = Math.min(coverSize - 1, z / coverStride);
+
+               for (int x = 0; x < size; x++) {
+                  int coverX = Math.min(coverSize - 1, x / coverStride);
+                  int coverIdx = coverX + coverZ * coverSize;
+                  if (MountainSurfaceRules.isTreeMarkerCoverClass(coverClasses[coverIdx], visualCoverClasses[coverIdx])) {
+                     long blockX = Mth.floor(minWorldX + x * step);
+                     long blockZ = Mth.floor(minWorldZ + z * step);
+                     if (!(hashToUnitDouble(blockX, blockZ) > density)) {
+                        float centerBlend = 0.56F * (0.68F + (float)hashToUnitDouble(blockX, blockZ, 967164898L) * 0.32F);
+                        float centerHeight = treeHeight * (0.7F + (float)hashToUnitDouble(blockX, blockZ, 1837846289L) * 0.45F);
+                        paintTreePreviewPoint(colors, heightOffsets, size, x, z, centerBlend, centerHeight);
+                        float ringBlend = centerBlend * (0.5F + (float)hashToUnitDouble(blockX, blockZ, 3257595197L) * 0.2F);
+                        float ringHeight = centerHeight * (0.32F + (float)hashToUnitDouble(blockX, blockZ, 182545271L) * 0.2F);
+                        paintTreeCardinalLobe(colors, heightOffsets, size, x, z, 1, 0, blockX, blockZ, 1090592539L, ringBlend, ringHeight);
+                        paintTreeCardinalLobe(colors, heightOffsets, size, x, z, -1, 0, blockX, blockZ, 2553043431L, ringBlend, ringHeight);
+                        paintTreeCardinalLobe(colors, heightOffsets, size, x, z, 0, 1, blockX, blockZ, 1601858105L, ringBlend, ringHeight);
+                        paintTreeCardinalLobe(colors, heightOffsets, size, x, z, 0, -1, blockX, blockZ, 3074239821L, ringBlend, ringHeight);
+                        if (expandedMarkers) {
+                           float diagonalChance = 0.23F + (float)hashToUnitDouble(blockX, blockZ, 2765689601L) * 0.22F;
+                           float diagonalBlend = centerBlend * 0.44F;
+                           float diagonalHeight = centerHeight * 0.24F;
+                           paintTreeDiagonalLobe(
+                              colors, heightOffsets, size, x, z, 1, 1, blockX, blockZ, 3539041045L, diagonalChance, diagonalBlend, diagonalHeight
+                           );
+                           paintTreeDiagonalLobe(
+                              colors, heightOffsets, size, x, z, 1, -1, blockX, blockZ, 431787567L, diagonalChance, diagonalBlend, diagonalHeight
+                           );
+                           paintTreeDiagonalLobe(
+                              colors, heightOffsets, size, x, z, -1, 1, blockX, blockZ, 2120467777L, diagonalChance, diagonalBlend, diagonalHeight
+                           );
+                           paintTreeDiagonalLobe(
+                              colors, heightOffsets, size, x, z, -1, -1, blockX, blockZ, 1254269913L, diagonalChance, diagonalBlend, diagonalHeight
+                           );
+                        }
+                     }
+                  }
+               }
+
+               this.updateBuildStatus(requestId, buildBaseDone + (long)(z + 1) * size, buildTotal, ACTIVITY_BUILD_TREES);
+            }
+         }
+      }
+
+      return !this.shouldAbortRequest(requestId);
+   }
+
+   private boolean applyFeatureHeightOffsets(int requestId, long buildTotal, long buildBaseDone, float[] heights, float[] offsets, int rowSize) {
+      int count = Math.min(heights.length, offsets.length);
+      if (count <= 0) {
+         return !this.shouldAbortRequest(requestId);
+      } else {
+         int safeRowSize = Math.max(1, rowSize);
+
+         for (int rowStart = 0; rowStart < count; rowStart += safeRowSize) {
+            if (this.shouldAbortRequest(requestId)) {
+               return false;
+            }
+
+            int rowEnd = Math.min(count, rowStart + safeRowSize);
+
+            for (int i = rowStart; i < rowEnd; i++) {
+               float offset = offsets[i];
+               if (offset > 0.0F) {
+                  heights[i] += offset;
+               }
+            }
+
+            this.updateBuildStatus(requestId, buildBaseDone + rowEnd, buildTotal, ACTIVITY_BUILD_HEIGHT_OFFSETS);
+         }
+
+         return !this.shouldAbortRequest(requestId);
+      }
+   }
+
+   private static float treeMarkerDensity(double worldScale) {
+      if (worldScale <= 8.0) {
+         return 0.085F;
+      } else if (worldScale <= 20.0) {
+         return 0.065F;
+      } else {
+         return worldScale <= 35.0 ? 0.05F : 0.04F;
+      }
+   }
+
+   private static void paintTreePreviewPoint(int[] colors, float[] heightOffsets, int size, int x, int z, float blend, float height) {
+      blendPreviewColor(colors, size, x, z, 2976308, blend);
+      setPreviewHeightOffset(heightOffsets, size, x, z, height);
+   }
+
+   private static void paintTreeCardinalLobe(
+      int[] colors, float[] heightOffsets, int size, int baseX, int baseZ, int dx, int dz, long blockX, long blockZ, long salt, float blend, float height
+   ) {
+      double chanceRoll = hashToUnitDouble(blockX, blockZ, salt);
+      if (!(chanceRoll < 0.2)) {
+         float lobeBlend = blend * (0.78F + (float)hashToUnitDouble(blockX + dx, blockZ + dz, salt ^ 23063L) * 0.34F);
+         float lobeHeight = height * (0.75F + (float)hashToUnitDouble(blockX + dx, blockZ + dz, salt ^ 39985L) * 0.35F);
+         paintTreePreviewPoint(colors, heightOffsets, size, baseX + dx, baseZ + dz, lobeBlend, lobeHeight);
+      }
+   }
+
+   private static void paintTreeDiagonalLobe(
+      int[] colors,
+      float[] heightOffsets,
+      int size,
+      int baseX,
+      int baseZ,
+      int dx,
+      int dz,
+      long blockX,
+      long blockZ,
+      long salt,
+      float chance,
+      float blend,
+      float height
+   ) {
+      if (!(hashToUnitDouble(blockX, blockZ, salt) >= chance)) {
+         float lobeBlend = blend * (0.8F + (float)hashToUnitDouble(blockX + dx, blockZ + dz, salt ^ 10001L) * 0.3F);
+         float lobeHeight = height * (0.7F + (float)hashToUnitDouble(blockX + dx, blockZ + dz, salt ^ 28215L) * 0.4F);
+         paintTreePreviewPoint(colors, heightOffsets, size, baseX + dx, baseZ + dz, lobeBlend, lobeHeight);
+      }
+   }
+
+   private static float treePreviewHeight(double worldScale) {
+      if (worldScale <= 8.0) {
+         return 0.034F;
+      } else {
+         return worldScale <= 25.0 ? 0.028F : 0.022F;
+      }
+   }
+
+   private static void blendPreviewColor(int[] colors, int size, int x, int z, int targetColor, float amount) {
+      if (x >= 0 && z >= 0 && x < size && z < size) {
+         int idx = x + z * size;
+         colors[idx] = blendColor(colors[idx], targetColor, amount);
+      }
+   }
+
+   private static void setPreviewHeightOffset(float[] heightOffsets, int size, int x, int z, float height) {
+      if (!(height <= 0.0F) && x >= 0 && z >= 0 && x < size && z < size) {
+         int idx = x + z * size;
+         heightOffsets[idx] = Math.max(heightOffsets[idx], height);
+      }
+   }
+
+   private static double hashToUnitDouble(long x, long z) {
+      return hashToUnitDouble(x, z, 1609587929392839161L);
+   }
+
+   private static double hashToUnitDouble(long x, long z, long salt) {
+      long mixed = mix64(x * -7046029254386353131L ^ z * -4417276706812531889L ^ salt);
+      return (mixed >>> 11 & 9007199254740991L) * 1.110223E-16F;
+   }
+
+   private static long mix64(long value) {
+      long mixed = value ^ value >>> 33;
+      mixed *= -49064778989728563L;
+      mixed ^= mixed >>> 33;
+      mixed *= -4265267296055464877L;
+      return mixed ^ mixed >>> 33;
+   }
+
+   private void queueWaterPreviewPrefetch(double minWorldX, double minWorldZ, double maxWorldX, double maxWorldZ, double worldScale) {
+      if (this.osmWaterSource.available() && worldScale > 0.0) {
+         this.osmWaterSource.waterForAreaWithStatus(
+            Mth.floor(minWorldX), Mth.floor(minWorldZ), Mth.ceil(maxWorldX), Mth.ceil(maxWorldZ), worldScale, PREVIEW_OSM_MARGIN_BLOCKS, OsmQueryMode.NON_BLOCKING
+         );
+      }
+   }
+
+   private boolean processWaterPreviewOverlay(
+      int id,
+      long buildTotal,
+      long overlayBaseDone,
+      int[] terrainColors,
+      int[] detailColors,
+      float[] detailHeightOffsets,
+      EarthGeneratorSettings settings,
+      double minWorldX,
+      double minWorldZ,
+      double maxWorldX,
+      double maxWorldZ,
+      double step
+   ) {
+      if (this.shouldAbortRequest(id) || !(settings.worldScale() > 0.0) || !(step > 0.0)) {
+         return false;
+      }
+
+      final TerrainPreview.OsmOverlayStageProgress overlayProgress = new TerrainPreview.OsmOverlayStageProgress(
+         id, buildTotal, overlayBaseDone, PREVIEW_WATER_OVERLAY_UNITS, 0.4F, 0.6F, ACTIVITY_OSM_WATER_FETCH, ACTIVITY_OSM_WATER_RASTER
+      );
+      overlayProgress.publish();
+      final TerrainPreview.DownloadNetworkTracker networkTracker = new TerrainPreview.DownloadNetworkTracker();
+
+      List<OsmWaterFeature> features;
+      try (DownloadProgressReporter.Scope ignored = DownloadProgressReporter.push(new DownloadProgressReporter.Listener() {
+            @Override
+            public void onRequestStarted(long expectedBytes) {
+               networkTracker.onRequestStarted(expectedBytes);
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+
+            @Override
+            public void onBytesRead(int bytes) {
+               networkTracker.onBytesRead(bytes);
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+
+            @Override
+            public void onRequestFinished() {
+               networkTracker.onRequestFinished();
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+         })) {
+         features = this.osmWaterSource
+            .waterForAreaWithStatus(
+               Mth.floor(minWorldX), Mth.floor(minWorldZ), Mth.ceil(maxWorldX), Mth.ceil(maxWorldZ), settings.worldScale(), PREVIEW_OSM_MARGIN_BLOCKS, OsmQueryMode.BLOCKING
+            )
+            .features();
+      }
+
+      if (this.shouldAbortRequest(id)) {
+         return false;
+      }
+
+      overlayProgress.updateFetch(1.0F);
+      if (features.isEmpty()) {
+         overlayProgress.updateRaster(1.0F);
+         overlayProgress.finish();
+      } else {
+         if (!this.overlayWaterPreviewColors(
+            id, terrainColors, detailColors, detailHeightOffsets, settings, minWorldX, minWorldZ, step, features, overlayProgress::updateRaster
+         )) {
+            return false;
+         }
+
+         overlayProgress.finish();
+      }
+
+      return !this.shouldAbortRequest(id);
+   }
+
+   private boolean processRoadPreviewOverlay(
+      int id,
+      long buildTotal,
+      long overlayBaseDone,
+      int[] terrainColors,
+      int[] detailColors,
+      EarthGeneratorSettings settings,
+      double centerX,
+      double centerZ,
+      double radius,
+      double step
+   ) {
+      if (this.shouldAbortRequest(id)) {
+         return false;
+      }
+
+      double minWorldX = centerX - radius;
+      double minWorldZ = centerZ - radius;
+      double maxWorldX = centerX + radius;
+      double maxWorldZ = centerZ + radius;
+      final TerrainPreview.OsmOverlayStageProgress overlayProgress = new TerrainPreview.OsmOverlayStageProgress(
+         id, buildTotal, overlayBaseDone, 32768L, 0.35F, 0.65F, ACTIVITY_OSM_ROADS_FETCH, ACTIVITY_OSM_ROADS_RASTER
+      );
+      overlayProgress.publish();
+      final TerrainPreview.DownloadNetworkTracker networkTracker = new TerrainPreview.DownloadNetworkTracker();
+
+      List<RoadFeature> roads;
+      try (DownloadProgressReporter.Scope ignored = DownloadProgressReporter.push(new DownloadProgressReporter.Listener() {
+            @Override
+            public void onRequestStarted(long expectedBytes) {
+               networkTracker.onRequestStarted(expectedBytes);
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+
+            @Override
+            public void onBytesRead(int bytes) {
+               networkTracker.onBytesRead(bytes);
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+
+            @Override
+            public void onRequestFinished() {
+               networkTracker.onRequestFinished();
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+         })) {
+         roads = this.osmRoadSource
+            .roadsForArea(Mth.floor(minWorldX), Mth.floor(minWorldZ), Mth.ceil(maxWorldX), Mth.ceil(maxWorldZ), settings.worldScale(), 64);
+      }
+
+      if (this.shouldAbortRequest(id)) {
+         return false;
+      }
+
+      overlayProgress.updateFetch(1.0F);
+      if (roads.isEmpty()) {
+         overlayProgress.updateRaster(1.0F);
+         overlayProgress.finish();
+      } else {
+         if (!this.overlayRoadPreviewColors(id, terrainColors, detailColors, settings, minWorldX, minWorldZ, step, roads, overlayProgress::updateRaster)) {
+            return false;
+         }
+
+         overlayProgress.finish();
+      }
+
+      return !this.shouldAbortRequest(id);
+   }
+
+   private boolean processBuildingPreviewOverlay(
+      int id,
+      long buildTotal,
+      long overlayBaseDone,
+      float[] terrainHeights,
+      int[] terrainColors,
+      float[] detailHeights,
+      int[] detailColors,
+      double[] blockHeights,
+      EarthGeneratorSettings settings,
+      double centerX,
+      double centerZ,
+      double radius,
+      double step,
+      float heightCenter
+   ) {
+      if (this.shouldAbortRequest(id) || !(step > 0.0)) {
+         return false;
+      }
+
+      double minWorldX = centerX - radius;
+      double minWorldZ = centerZ - radius;
+      double maxWorldX = centerX + radius;
+      double maxWorldZ = centerZ + radius;
+      final TerrainPreview.OsmOverlayStageProgress overlayProgress = new TerrainPreview.OsmOverlayStageProgress(
+         id,
+         buildTotal,
+         overlayBaseDone,
+         PREVIEW_BUILDING_OVERLAY_UNITS,
+         0.35F,
+         0.65F,
+         ACTIVITY_OSM_BUILDINGS_FETCH,
+         ACTIVITY_OSM_BUILDINGS_RASTER
+      );
+      overlayProgress.publish();
+      final TerrainPreview.DownloadNetworkTracker networkTracker = new TerrainPreview.DownloadNetworkTracker();
+
+      List<OsmBuildingFeature> features;
+      try (DownloadProgressReporter.Scope ignored = DownloadProgressReporter.push(new DownloadProgressReporter.Listener() {
+            @Override
+            public void onRequestStarted(long expectedBytes) {
+               networkTracker.onRequestStarted(expectedBytes);
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+
+            @Override
+            public void onBytesRead(int bytes) {
+               networkTracker.onBytesRead(bytes);
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+
+            @Override
+            public void onRequestFinished() {
+               networkTracker.onRequestFinished();
+               overlayProgress.updateFetch(networkTracker.progress());
+            }
+         })) {
+         features = this.osmBuildingSource.buildingsForArea(
+            Mth.floor(minWorldX), Mth.floor(minWorldZ), Mth.ceil(maxWorldX), Mth.ceil(maxWorldZ), settings.worldScale(), PREVIEW_OSM_MARGIN_BLOCKS
+         );
+      }
+
+      if (this.shouldAbortRequest(id)) {
+         return false;
+      }
+
+      overlayProgress.updateFetch(1.0F);
+      if (features.isEmpty()) {
+         overlayProgress.updateRaster(1.0F);
+         overlayProgress.finish();
+      } else {
+         if (!this.overlayBuildingPreviewMeshes(
+            id, terrainHeights, terrainColors, detailHeights, detailColors, blockHeights, settings, minWorldX, minWorldZ, step, heightCenter, features, overlayProgress::updateRaster
+         )) {
+            return false;
+         }
+
+         overlayProgress.finish();
+      }
+
+      return !this.shouldAbortRequest(id);
+   }
+
+   private boolean overlayWaterPreviewColors(
+      int requestId,
+      int[] terrainColors,
+      int[] detailColors,
+      float[] detailHeightOffsets,
+      EarthGeneratorSettings settings,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      List<OsmWaterFeature> features,
+      TerrainPreview.RoadRasterProgress progress
+   ) {
+      if (this.shouldAbortRequest(requestId)) {
+         return false;
+      }
+
+      progress.onProgress(0.0F);
+      if (features.isEmpty() || !(settings.worldScale() > 0.0) || !(step > 0.0)) {
+         progress.onProgress(1.0F);
+         return !this.shouldAbortRequest(requestId);
+      }
+
+      int size = PREVIEW_GRID_SIZE;
+      int area = size * size;
+      byte[] waterKind = new byte[area];
+      double worldScale = settings.worldScale();
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double[] sampleWorldX = new double[size];
+      double[] sampleWorldZ = new double[size];
+      double[] sampleLon = new double[size];
+      double[] sampleLat = new double[size];
+
+      for (int i = 0; i < size; i++) {
+         double worldX = minWorldX + i * step;
+         double worldZ = minWorldZ + i * step;
+         sampleWorldX[i] = worldX;
+         sampleWorldZ[i] = worldZ;
+         sampleLon[i] = worldX / blocksPerDegree;
+         sampleLat[i] = EarthProjection.blockZToLat(worldZ, worldScale);
+      }
+
+      int totalFeatures = Math.max(1, features.size());
+      int processedFeatures = 0;
+
+      for (OsmWaterFeature feature : features) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         if (!this.rasterizeWaterPreviewFeature(
+            requestId, feature, sampleWorldX, sampleWorldZ, sampleLon, sampleLat, blocksPerDegree, worldScale, minWorldX, minWorldZ, step, size, waterKind
+         )) {
+            return false;
+         }
+
+         processedFeatures++;
+         progress.onProgress((float)processedFeatures / (float)totalFeatures * 0.82F);
+      }
+
+      for (int z = 0; z < size; z++) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         int row = z * size;
+
+         for (int x = 0; x < size; x++) {
+            int idx = row + x;
+            byte kind = waterKind[idx];
+            if (kind != 0) {
+               int color = PREVIEW_FLAT_WATER_COLOR;
+               terrainColors[idx] = color;
+               detailColors[idx] = color;
+               detailHeightOffsets[idx] = 0.0F;
+            }
+         }
+
+         progress.onProgress(0.82F + (float)(z + 1) / (float)size * 0.18F);
+      }
+
+      progress.onProgress(1.0F);
+      return !this.shouldAbortRequest(requestId);
+   }
+
+   private boolean overlayRoadPreviewColors(
+      int requestId,
+      int[] terrainColors,
+      int[] detailColors,
+      EarthGeneratorSettings settings,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      List<RoadFeature> roads,
+      TerrainPreview.RoadRasterProgress progress
+   ) {
+      if (this.shouldAbortRequest(requestId)) {
+         return false;
+      }
+
+      progress.onProgress(0.0F);
+      double worldScale = settings.worldScale();
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      TerrainPreview.PreviewRoadWidths widths = previewRoadWidths(settings.worldScale());
+      List<RoadFeature> main = new ArrayList<>();
+      List<RoadFeature> normal = new ArrayList<>();
+      List<RoadFeature> dirt = new ArrayList<>();
+
+      for (RoadFeature road : roads) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         switch (road.roadClass()) {
+            case MAIN:
+               main.add(road);
+               break;
+            case NORMAL:
+               normal.add(road);
+               break;
+            case DIRT:
+               dirt.add(road);
+         }
+      }
+
+      int size = PREVIEW_GRID_SIZE;
+      int area = size * size;
+      byte[] selectedClass = new byte[area];
+      boolean[] blocked = new boolean[area];
+      TerrainPreview.RoadRasterProgressTracker rasterProgress = new TerrainPreview.RoadRasterProgressTracker(
+         countRoadSegments(main) + countRoadSegments(normal) + countRoadSegments(dirt), size, progress
+      );
+      if (!this.rasterizeRoadPreviewClass(requestId, main, 1, widths.main(), blocksPerDegree, worldScale, minWorldX, minWorldZ, step, size, selectedClass, blocked, rasterProgress)) {
+         return false;
+      }
+
+      if (!this.rasterizeRoadPreviewClass(requestId, normal, 2, widths.normal(), blocksPerDegree, worldScale, minWorldX, minWorldZ, step, size, selectedClass, blocked, rasterProgress)) {
+         return false;
+      }
+
+      if (!this.rasterizeRoadPreviewClass(requestId, dirt, 3, widths.dirt(), blocksPerDegree, worldScale, minWorldX, minWorldZ, step, size, selectedClass, blocked, rasterProgress)) {
+         return false;
+      }
+
+      for (int z = 0; z < size; z++) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         int row = z * size;
+
+         for (int x = 0; x < size; x++) {
+            int idx = row + x;
+            byte cls = selectedClass[idx];
+            if (cls > 0) {
+               int roadColor = switch (cls) {
+                  case 1 -> 6712174;
+                  case 2 -> 11776947;
+                  default -> 9071178;
+               };
+               terrainColors[idx] = roadColor;
+               detailColors[idx] = roadColor;
+            }
+         }
+
+         rasterProgress.onPaintRow();
+      }
+
+      rasterProgress.finish();
+      return !this.shouldAbortRequest(requestId);
+   }
+
+   private boolean overlayBuildingPreviewMeshes(
+      int requestId,
+      float[] terrainHeights,
+      int[] terrainColors,
+      float[] detailHeights,
+      int[] detailColors,
+      double[] blockHeights,
+      EarthGeneratorSettings settings,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      float heightCenter,
+      List<OsmBuildingFeature> features,
+      TerrainPreview.RoadRasterProgress progress
+   ) {
+      if (this.shouldAbortRequest(requestId) || features.isEmpty()) {
+         return false;
+      }
+
+      progress.onProgress(0.0F);
+      int size = PREVIEW_GRID_SIZE;
+      int area = size * size;
+      double worldScale = settings.worldScale();
+      Map<String, TerrainPreview.PreviewBuildingGroupScratch> groups = new HashMap<>();
+      List<TerrainPreview.PreviewRasterizedBuildingFeature> partFeatures = new ArrayList<>();
+      List<TerrainPreview.PreviewRasterizedBuildingFeature> footprintFeatures = new ArrayList<>();
+      int totalFeatures = Math.max(1, features.size());
+      int processedFeatures = 0;
+
+      for (OsmBuildingFeature feature : features) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         boolean groundContact = feature.kind() != OsmBuildingKind.PART || this.previewBuildingMinHeightBlocks(feature.minHeightMeters(), worldScale) <= 0;
+         TerrainPreview.PreviewRasterizedBuildingFeature rasterized = this.rasterizePreviewBuildingFeature(
+            feature, resolvePreviewBuildingGroupId(feature), groundContact, minWorldX, minWorldZ, step, size, worldScale
+         );
+         if (rasterized != null) {
+            TerrainPreview.PreviewBuildingGroupScratch group = groups.computeIfAbsent(rasterized.groupId(), key -> new TerrainPreview.PreviewBuildingGroupScratch());
+            for (int index : rasterized.occupiedIndices()) {
+               int surface = (int)Math.round(blockHeights[index]);
+               group.fallbackSamples().add(surface);
+               if (groundContact) {
+                  group.groundSamples().add(surface);
+               }
+            }
+
+            if (feature.kind() == OsmBuildingKind.PART) {
+               partFeatures.add(rasterized);
+            } else {
+               footprintFeatures.add(rasterized);
+            }
+         }
+
+         processedFeatures++;
+         if ((processedFeatures & 7) == 0 || processedFeatures == totalFeatures) {
+            progress.onProgress((float)processedFeatures / (float)totalFeatures * 0.72F);
+         }
+      }
+
+      if (partFeatures.isEmpty() && footprintFeatures.isEmpty()) {
+         progress.onProgress(1.0F);
+         return !this.shouldAbortRequest(requestId);
+      }
+
+      for (TerrainPreview.PreviewBuildingGroupScratch group : groups.values()) {
+         IntArrayList samples = !group.groundSamples().isEmpty() ? group.groundSamples() : group.fallbackSamples();
+         if (!samples.isEmpty()) {
+            group.setBaseY(medianValue(samples));
+         }
+      }
+
+      boolean[] partCoverage = new boolean[area];
+      boolean[] terrainBuildingMask = new boolean[area];
+      boolean[] detailBuildingMask = new boolean[area];
+      float[] detailBuildingHeights = new float[area];
+      Arrays.fill(detailBuildingHeights, Float.NEGATIVE_INFINITY);
+      int totalRasterFeatures = Math.max(1, partFeatures.size() + footprintFeatures.size());
+      int rasterizedCount = 0;
+
+      for (TerrainPreview.PreviewRasterizedBuildingFeature rasterized : partFeatures) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         TerrainPreview.PreviewBuildingGroupScratch group = groups.get(rasterized.groupId());
+         if (group != null && group.baseY() != Integer.MIN_VALUE) {
+            BuildingProfile profile = TellusBuildingProfiles.resolveProfile(rasterized.feature(), worldScale, null, worldScale == 1.0);
+            BuildingBlueprint blueprint = this.previewBlueprintForFeature(rasterized.feature(), rasterized.groupId(), group.baseY(), profile, worldScale);
+            TerrainPreview.PreviewBoundaryInfo boundaryInfo = this.computePreviewBoundaryInfo(rasterized);
+            int previewColor = previewColorForProfile(profile, blueprint);
+
+            for (int order = 0; order < rasterized.occupiedIndices().length; order++) {
+               int index = rasterized.occupiedIndices()[order];
+               int gridX = index % size;
+               int gridZ = index / size;
+               int roofY = blueprint.roofTopY((int)Math.round(minWorldX + gridX * step), (int)Math.round(minWorldZ + gridZ * step), boundaryInfo.boundaryDistance(order));
+               float roofHeight = previewHeightForSurfaceY(roofY, settings, heightCenter);
+               partCoverage[index] = true;
+               detailBuildingMask[index] = true;
+               terrainColors[index] = previewColor;
+               detailColors[index] = previewColor;
+               detailBuildingHeights[index] = Math.max(detailBuildingHeights[index], roofHeight);
+               if (rasterized.groundContact()) {
+                  terrainBuildingMask[index] = true;
+               }
+            }
+         }
+
+         rasterizedCount++;
+         progress.onProgress(0.72F + (float)rasterizedCount / (float)totalRasterFeatures * 0.28F);
+      }
+
+      for (TerrainPreview.PreviewRasterizedBuildingFeature rasterized : footprintFeatures) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         TerrainPreview.PreviewBuildingGroupScratch group = groups.get(rasterized.groupId());
+         if (group != null && group.baseY() != Integer.MIN_VALUE) {
+            BuildingProfile profile = TellusBuildingProfiles.resolveProfile(rasterized.feature(), worldScale, null, worldScale == 1.0);
+            BuildingBlueprint blueprint = this.previewBlueprintForFeature(rasterized.feature(), rasterized.groupId(), group.baseY(), profile, worldScale);
+            TerrainPreview.PreviewBoundaryInfo boundaryInfo = this.computePreviewBoundaryInfo(rasterized);
+            int previewColor = previewColorForProfile(profile, blueprint);
+
+            for (int order = 0; order < rasterized.occupiedIndices().length; order++) {
+               int index = rasterized.occupiedIndices()[order];
+               if (!partCoverage[index]) {
+                  int gridX = index % size;
+                  int gridZ = index / size;
+                  int roofY = blueprint.roofTopY((int)Math.round(minWorldX + gridX * step), (int)Math.round(minWorldZ + gridZ * step), boundaryInfo.boundaryDistance(order));
+                  float roofHeight = previewHeightForSurfaceY(roofY, settings, heightCenter);
+                  terrainBuildingMask[index] = true;
+                  detailBuildingMask[index] = true;
+                  terrainColors[index] = previewColor;
+                  detailColors[index] = previewColor;
+                  detailBuildingHeights[index] = Math.max(detailBuildingHeights[index], roofHeight);
+               }
+            }
+         }
+
+         rasterizedCount++;
+         progress.onProgress(0.72F + (float)rasterizedCount / (float)totalRasterFeatures * 0.28F);
+      }
+
+      for (int index = 0; index < area; index++) {
+         if (terrainBuildingMask[index]) {
+            terrainColors[index] = terrainColors[index] == 0 ? BUILDING_PREVIEW_COLOR : terrainColors[index];
+         }
+
+         if (detailBuildingMask[index]) {
+            detailColors[index] = detailColors[index] == 0 ? BUILDING_PREVIEW_COLOR : detailColors[index];
+            if (Float.isFinite(detailBuildingHeights[index])) {
+               detailHeights[index] = Math.max(terrainHeights[index], detailBuildingHeights[index]);
+            }
+         }
+      }
+
+      progress.onProgress(1.0F);
+      return !this.shouldAbortRequest(requestId);
+   }
+
+   private TerrainPreview.PreviewRasterizedBuildingFeature rasterizePreviewBuildingFeature(
+      OsmBuildingFeature feature,
+      String groupId,
+      boolean groundContact,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      int size,
+      double worldScale
+   ) {
+      if (!(worldScale > 0.0) || !(step > 0.0)) {
+         return null;
+      }
+
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double minBlockX = feature.minBlockX(blocksPerDegree);
+      double maxBlockX = feature.maxBlockX(blocksPerDegree);
+      double minBlockZ = feature.minBlockZ(worldScale);
+      double maxBlockZ = feature.maxBlockZ(worldScale);
+      int minGridX = (int)Math.floor((minBlockX - minWorldX) / step) - 1;
+      int maxGridX = (int)Math.ceil((maxBlockX - minWorldX) / step) + 1;
+      int minGridZ = (int)Math.floor((minBlockZ - minWorldZ) / step) - 1;
+      int maxGridZ = (int)Math.ceil((maxBlockZ - minWorldZ) / step) + 1;
+      if (maxGridX < 0 || maxGridZ < 0 || minGridX >= size || minGridZ >= size) {
+         return null;
+      }
+
+      minGridX = Mth.clamp(minGridX, 0, size - 1);
+      maxGridX = Mth.clamp(maxGridX, 0, size - 1);
+      minGridZ = Mth.clamp(minGridZ, 0, size - 1);
+      maxGridZ = Mth.clamp(maxGridZ, 0, size - 1);
+      int localWidth = maxGridX - minGridX + 1;
+      int localHeight = maxGridZ - minGridZ + 1;
+      boolean[] occupiedMask = new boolean[Math.max(1, localWidth * localHeight)];
+      IntArrayList occupied = new IntArrayList();
+
+      for (int gridZ = minGridZ; gridZ <= maxGridZ; gridZ++) {
+         double worldZ = minWorldZ + gridZ * step;
+
+         for (int gridX = minGridX; gridX <= maxGridX; gridX++) {
+            double worldX = minWorldX + gridX * step;
+            if (feature.containsWorld(worldX, worldZ, worldScale)) {
+               int localIndex = (gridX - minGridX) + (gridZ - minGridZ) * localWidth;
+               occupiedMask[localIndex] = true;
+               occupied.add(gridX + gridZ * size);
+            }
+         }
+      }
+
+      if (occupied.isEmpty()) {
+         int fallbackX = Mth.clamp((int)Math.round(((minBlockX + maxBlockX) * 0.5 - minWorldX) / step), 0, size - 1);
+         int fallbackZ = Mth.clamp((int)Math.round(((minBlockZ + maxBlockZ) * 0.5 - minWorldZ) / step), 0, size - 1);
+         occupiedMask[Math.min(occupiedMask.length - 1, Math.max(0, (fallbackX - minGridX) + (fallbackZ - minGridZ) * localWidth))] = true;
+         occupied.add(fallbackX + fallbackZ * size);
+      }
+
+      return new TerrainPreview.PreviewRasterizedBuildingFeature(
+         feature, groupId, groundContact, minGridX, minGridZ, localWidth, localHeight, occupiedMask, occupied.toIntArray()
+      );
+   }
+
+   private boolean rasterizeRoadPreviewClass(
+      int requestId,
+      List<RoadFeature> roads,
+      int classId,
+      int widthBlocks,
+      double blocksPerDegree,
+      double worldScale,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      int size,
+      byte[] selectedClass,
+      boolean[] blocked,
+      TerrainPreview.RoadRasterProgressTracker progressTracker
+   ) {
+      if (!roads.isEmpty() && widthBlocks > 0 && !(step <= 0.0)) {
+         int area = size * size;
+         boolean[] candidates = new boolean[area];
+         double halfWidth = Math.max(0.5, (widthBlocks - 1) * 0.5);
+         double radiusSq = halfWidth * halfWidth + 1.0E-6;
+
+         for (RoadFeature road : roads) {
+            if (this.shouldAbortRequest(requestId)) {
+               return false;
+            }
+
+            int points = road.pointCount();
+            if (points >= 2) {
+               double[] worldX = new double[points];
+               double[] worldZ = new double[points];
+
+               for (int i = 0; i < points; i++) {
+                  worldX[i] = road.lonAt(i) * blocksPerDegree;
+                  worldZ[i] = EarthProjection.latToBlockZ(road.latAt(i), worldScale);
+               }
+
+               for (int i = 1; i < points; i++) {
+                  if (this.shouldAbortRequest(requestId)) {
+                     return false;
+                  }
+
+                  double x1 = worldX[i - 1];
+                  double z1 = worldZ[i - 1];
+                  double x2 = worldX[i];
+                  double z2 = worldZ[i];
+                  double dx = x2 - x1;
+                  double dz = z2 - z1;
+                  double lenSq = dx * dx + dz * dz;
+                  if (lenSq <= 1.0E-6) {
+                     progressTracker.onSegmentProcessed();
+                  } else {
+                     int minGridX = Mth.clamp((int)Math.floor((Math.min(x1, x2) - halfWidth - minWorldX) / step), 0, size - 1);
+                     int maxGridX = Mth.clamp((int)Math.floor((Math.max(x1, x2) + halfWidth - minWorldX) / step), 0, size - 1);
+                     int minGridZ = Mth.clamp((int)Math.floor((Math.min(z1, z2) - halfWidth - minWorldZ) / step), 0, size - 1);
+                     int maxGridZ = Mth.clamp((int)Math.floor((Math.max(z1, z2) + halfWidth - minWorldZ) / step), 0, size - 1);
+
+                     for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+                        double sampleZ = minWorldZ + gz * step;
+                        int row = gz * size;
+
+                        for (int gx = minGridX; gx <= maxGridX; gx++) {
+                           double sampleX = minWorldX + gx * step;
+                           double t = ((sampleX - x1) * dx + (sampleZ - z1) * dz) / lenSq;
+                           t = Mth.clamp(t, 0.0, 1.0);
+                           double px = x1 + t * dx;
+                           double pz = z1 + t * dz;
+                           double ddx = sampleX - px;
+                           double ddz = sampleZ - pz;
+                           double distSq = ddx * ddx + ddz * ddz;
+                           if (distSq <= radiusSq) {
+                              candidates[row + gx] = true;
+                           }
+                        }
+                     }
+
+                     progressTracker.onSegmentProcessed();
+                  }
+               }
+            }
+         }
+
+         for (int ix = 0; ix < area; ix++) {
+            if (this.shouldAbortRequest(requestId)) {
+               return false;
+            }
+
+            if (candidates[ix] && !blocked[ix]) {
+               selectedClass[ix] = (byte)classId;
+               blocked[ix] = true;
+            }
+         }
+      }
+
+      return !this.shouldAbortRequest(requestId);
+   }
+
+   private boolean rasterizeWaterPreviewFeature(
+      int requestId,
+      OsmWaterFeature feature,
+      double[] sampleWorldX,
+      double[] sampleWorldZ,
+      double[] sampleLon,
+      double[] sampleLat,
+      double blocksPerDegree,
+      double worldScale,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      int size,
+      byte[] waterKind
+   ) {
+      byte kind = (byte)(feature.oceanHint() ? 2 : 1);
+      return feature.lineGeometry()
+         ? this.rasterizeWaterPreviewLineFeature(
+            requestId, feature, kind, sampleWorldX, sampleWorldZ, blocksPerDegree, worldScale, minWorldX, minWorldZ, step, size, waterKind
+         )
+         : this.rasterizeWaterPreviewPolygonFeature(
+            requestId, feature, kind, sampleLon, sampleLat, blocksPerDegree, worldScale, minWorldX, minWorldZ, step, size, waterKind
+         );
+   }
+
+   private boolean rasterizeWaterPreviewPolygonFeature(
+      int requestId,
+      OsmWaterFeature feature,
+      byte kind,
+      double[] sampleLon,
+      double[] sampleLat,
+      double blocksPerDegree,
+      double worldScale,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      int size,
+      byte[] waterKind
+   ) {
+      double minBlockX = feature.minLon() * blocksPerDegree;
+      double maxBlockX = feature.maxLon() * blocksPerDegree;
+      double z0 = EarthProjection.latToBlockZ(feature.minLat(), worldScale);
+      double z1 = EarthProjection.latToBlockZ(feature.maxLat(), worldScale);
+      double minBlockZ = Math.min(z0, z1);
+      double maxBlockZ = Math.max(z0, z1);
+      int minGridX = (int)Math.floor((minBlockX - minWorldX) / step) - 1;
+      int maxGridX = (int)Math.ceil((maxBlockX - minWorldX) / step) + 1;
+      int minGridZ = (int)Math.floor((minBlockZ - minWorldZ) / step) - 1;
+      int maxGridZ = (int)Math.ceil((maxBlockZ - minWorldZ) / step) + 1;
+      if (maxGridX < 0 || maxGridZ < 0 || minGridX >= size || minGridZ >= size) {
+         return true;
+      }
+
+      minGridX = Mth.clamp(minGridX, 0, size - 1);
+      maxGridX = Mth.clamp(maxGridX, 0, size - 1);
+      minGridZ = Mth.clamp(minGridZ, 0, size - 1);
+      maxGridZ = Mth.clamp(maxGridZ, 0, size - 1);
+
+      for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+         if (this.shouldAbortRequest(requestId)) {
+            return false;
+         }
+
+         double lat = sampleLat[gz];
+         int row = gz * size;
+
+         for (int gx = minGridX; gx <= maxGridX; gx++) {
+            if (feature.containsLonLat(sampleLon[gx], lat)) {
+               markWaterPreviewCell(waterKind, row + gx, kind);
+            }
+         }
+      }
+
+      return true;
+   }
+
+   private boolean rasterizeWaterPreviewLineFeature(
+      int requestId,
+      OsmWaterFeature feature,
+      byte kind,
+      double[] sampleWorldX,
+      double[] sampleWorldZ,
+      double blocksPerDegree,
+      double worldScale,
+      double minWorldX,
+      double minWorldZ,
+      double step,
+      int size,
+      byte[] waterKind
+   ) {
+      double halfWidth = Math.max(0.5, step * 0.55);
+      double radiusSq = halfWidth * halfWidth + 1.0E-6;
+
+      for (int part = 0; part < feature.partCount(); part++) {
+         int points = feature.pointCount(part);
+         if (points < 2) {
+            continue;
+         }
+
+         double previousX = feature.lonAt(part, 0) * blocksPerDegree;
+         double previousZ = EarthProjection.latToBlockZ(feature.latAt(part, 0), worldScale);
+
+         for (int point = 1; point < points; point++) {
+            if (this.shouldAbortRequest(requestId)) {
+               return false;
+            }
+
+            double currentX = feature.lonAt(part, point) * blocksPerDegree;
+            double currentZ = EarthProjection.latToBlockZ(feature.latAt(part, point), worldScale);
+            double dx = currentX - previousX;
+            double dz = currentZ - previousZ;
+            double lenSq = dx * dx + dz * dz;
+            if (lenSq > 1.0E-6) {
+               int minGridX = Mth.clamp((int)Math.floor((Math.min(previousX, currentX) - halfWidth - minWorldX) / step), 0, size - 1);
+               int maxGridX = Mth.clamp((int)Math.floor((Math.max(previousX, currentX) + halfWidth - minWorldX) / step), 0, size - 1);
+               int minGridZ = Mth.clamp((int)Math.floor((Math.min(previousZ, currentZ) - halfWidth - minWorldZ) / step), 0, size - 1);
+               int maxGridZ = Mth.clamp((int)Math.floor((Math.max(previousZ, currentZ) + halfWidth - minWorldZ) / step), 0, size - 1);
+
+               for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+                  double sampleZ = sampleWorldZ[gz];
+                  int row = gz * size;
+
+                  for (int gx = minGridX; gx <= maxGridX; gx++) {
+                     double sampleX = sampleWorldX[gx];
+                     double t = ((sampleX - previousX) * dx + (sampleZ - previousZ) * dz) / lenSq;
+                     t = Mth.clamp(t, 0.0, 1.0);
+                     double projX = previousX + t * dx;
+                     double projZ = previousZ + t * dz;
+                     double ddx = sampleX - projX;
+                     double ddz = sampleZ - projZ;
+                     if (ddx * ddx + ddz * ddz <= radiusSq) {
+                        markWaterPreviewCell(waterKind, row + gx, kind);
+                     }
+                  }
+               }
+            }
+
+            previousX = currentX;
+            previousZ = currentZ;
+         }
+      }
+
+      return true;
+   }
+
+   private static void markWaterPreviewCell(byte[] waterKind, int index, byte kind) {
+      if (kind > waterKind[index]) {
+         waterKind[index] = kind;
+      }
+   }
+
+   private static TerrainPreview.PreviewRoadWidths previewRoadWidths(double worldScale) {
+      double factor = roadWidthFactorForScale(worldScale);
+
+      return new TerrainPreview.PreviewRoadWidths(
+         widthForScale(RoadClass.MAIN.baseWidth(), factor),
+         widthForScale(RoadClass.NORMAL.baseWidth(), factor),
+         widthForScale(RoadClass.DIRT.baseWidth(), factor)
+      );
+   }
+
+   private static int widthForScale(int baseWidth, double factor) {
+      return Math.max(1, (int)Math.round(baseWidth * factor));
+   }
+
+   private static double roadWidthFactorForScale(double worldScale) {
+      if (!(worldScale > 0.0)) {
+         return 0.25;
+      } else if (worldScale <= 1.0) {
+         return 1.8;
+      } else if (worldScale <= 5.0) {
+         double t = (worldScale - 1.0) / 4.0;
+         return Mth.lerp(Mth.clamp(t, 0.0, 1.0), 1.8, 1.0);
+      } else if (worldScale <= 10.0) {
+         double t = (worldScale - 5.0) / 5.0;
+         return Mth.lerp(Mth.clamp(t, 0.0, 1.0), 1.0, 0.5);
+      } else {
+         return 0.25;
+      }
+   }
+
+   private static int countRoadSegments(List<RoadFeature> roads) {
+      int count = 0;
+
+      for (RoadFeature road : roads) {
+         count += Math.max(0, road.pointCount() - 1);
+      }
+
+      return count;
+   }
+
+   private BuildingBlueprint previewBlueprintForFeature(OsmBuildingFeature feature, String groupId, int baseY, BuildingProfile profile, double worldScale) {
+      int floorY = baseY + this.previewBuildingMinHeightBlocks(feature.minHeightMeters(), worldScale) + 1;
+      int roofBaseY = Math.max(baseY + this.previewBuildingHeightBlocks(feature.heightMeters(), worldScale), floorY + profile.floorCount() * profile.storeyHeightBlocks());
+      int topY = roofBaseY + Math.max(profile.parapetHeight(), profile.roofRise());
+      return TellusBuildingBlueprints.create(groupId, feature, profile, 0L, baseY, floorY, roofBaseY, topY, List.of(), worldScale);
+   }
+
+   private TerrainPreview.PreviewBoundaryInfo computePreviewBoundaryInfo(TerrainPreview.PreviewRasterizedBuildingFeature rasterized) {
+      int width = rasterized.width();
+      int height = rasterized.height();
+      int area = width * height;
+      int[] distance = new int[area];
+      Arrays.fill(distance, Integer.MAX_VALUE);
+      ArrayDeque<Integer> queue = new ArrayDeque<>();
+      boolean[] occupied = rasterized.occupiedMask();
+
+      for (int localZ = 0; localZ < height; localZ++) {
+         for (int localX = 0; localX < width; localX++) {
+            int index = localX + localZ * width;
+            if (!occupied[index]) {
+               continue;
+            }
+
+            boolean boundary = localX == 0
+               || localX == width - 1
+               || localZ == 0
+               || localZ == height - 1
+               || !occupied[Math.max(0, localX - 1) + localZ * width]
+               || !occupied[Math.min(width - 1, localX + 1) + localZ * width]
+               || !occupied[localX + Math.max(0, localZ - 1) * width]
+               || !occupied[localX + Math.min(height - 1, localZ + 1) * width];
+            if (boundary) {
+               distance[index] = 0;
+               queue.add(index);
+            }
+         }
+      }
+
+      while (!queue.isEmpty()) {
+         int index = queue.removeFirst();
+         int localX = index % width;
+         int localZ = index / width;
+         int nextDistance = distance[index] + 1;
+         if (localX > 0) {
+            this.propagatePreviewBoundaryDistance(occupied, distance, queue, index - 1, nextDistance);
+         }
+         if (localX + 1 < width) {
+            this.propagatePreviewBoundaryDistance(occupied, distance, queue, index + 1, nextDistance);
+         }
+         if (localZ > 0) {
+            this.propagatePreviewBoundaryDistance(occupied, distance, queue, index - width, nextDistance);
+         }
+         if (localZ + 1 < height) {
+            this.propagatePreviewBoundaryDistance(occupied, distance, queue, index + width, nextDistance);
+         }
+      }
+
+      int[] ordered = new int[rasterized.occupiedIndices().length];
+      for (int order = 0; order < rasterized.occupiedIndices().length; order++) {
+         int globalIndex = rasterized.occupiedIndices()[order];
+         int gridX = globalIndex % PREVIEW_GRID_SIZE;
+         int gridZ = globalIndex / PREVIEW_GRID_SIZE;
+         int localIndex = (gridX - rasterized.minGridX()) + (gridZ - rasterized.minGridZ()) * width;
+         ordered[order] = localIndex >= 0 && localIndex < distance.length && distance[localIndex] != Integer.MAX_VALUE ? distance[localIndex] : 0;
+      }
+
+      return new TerrainPreview.PreviewBoundaryInfo(ordered);
+   }
+
+   private void propagatePreviewBoundaryDistance(boolean[] occupied, int[] distance, ArrayDeque<Integer> queue, int index, int nextDistance) {
+      if (occupied[index] && nextDistance < distance[index]) {
+         distance[index] = nextDistance;
+         queue.add(index);
+      }
+   }
+
+   private int previewBuildingHeightBlocks(double meters, double worldScale) {
+      return Math.max(3, (int)Math.round(meters / worldScale));
+   }
+
+   private int previewBuildingMinHeightBlocks(double meters, double worldScale) {
+      return Math.max(0, (int)Math.round(meters / worldScale));
+   }
+
+   private static float previewHeightForSurfaceY(int surfaceY, EarthGeneratorSettings settings, float center) {
+      return (float)((surfaceY - settings.heightOffset()) / PREVIEW_RADIUS_BLOCKS * 0.7F) - center;
+   }
+
+   private static int medianValue(IntArrayList values) {
+      int[] sorted = values.toIntArray();
+      Arrays.sort(sorted);
+      return sorted[sorted.length >> 1];
+   }
+
+   private static int previewColorForProfile(BuildingProfile profile, BuildingBlueprint blueprint) {
+      return TellusBuildingStyles.previewColor(profile, blueprint.blueprintSeed());
+   }
+
+   private static String resolvePreviewBuildingGroupId(OsmBuildingFeature feature) {
+      if (feature.kind() == OsmBuildingKind.PART) {
+         String buildingId = feature.buildingId();
+         return buildingId != null ? "part:" + buildingId : "part:" + feature.featureId();
+      } else {
+         return "footprint:" + feature.featureId();
+      }
+   }
+
+   private void updateDownloadStatus(
+      int id, long downloadDone, long downloadTotal, TerrainPreview.DownloadNetworkTracker tracker, String activity
+   ) {
+      float sampleProgress;
+      if (downloadTotal <= 0L) {
+         sampleProgress = 1.0F;
+      } else {
+         sampleProgress = Mth.clamp((float)downloadDone / (float)downloadTotal, 0.0F, 1.0F);
+      }
+
+      float networkProgress = tracker == null ? 0.0F : tracker.progress();
+      this.updateStatus(id, TerrainPreview.PreviewStage.DOWNLOADING, Math.max(sampleProgress, networkProgress), activity);
+   }
+
+   private void updateBuildStatus(int id, long buildDone, long buildTotal, String activity) {
+      float progress = buildTotal <= 0L ? 1.0F : Mth.clamp((float)buildDone / (float)buildTotal, 0.0F, 1.0F);
+      this.updateStatus(id, TerrainPreview.PreviewStage.LOADING, progress, activity);
+   }
+
+   private static byte climateGroup(String koppen) {
+      if (koppen != null && !koppen.isEmpty()) {
+         char group = Character.toUpperCase(koppen.charAt(0));
+
+         return switch (group) {
+            case 'A' -> 1;
+            case 'B' -> 2;
+            case 'C' -> 3;
+            case 'D' -> 4;
+            case 'E' -> 5;
+            default -> 0;
+         };
+      } else {
+         return 0;
+      }
+   }
+
+   private static int colorForPreview(
+      int terrainCoverClass,
+      int visualCoverClass,
+      byte climateGroup,
+      double elevationMeters,
+      double terrainHeight,
+      int slopeDiff,
+      int convexity,
+      double slope,
+      int seaLevel,
+      boolean esaWater,
+      boolean fallbackWaterEnabled,
+      boolean flattenWaterColor,
+      boolean remaSnowTerrain
+   ) {
+      int surfaceCoverClass = MountainSurfaceRules.resolveSurfaceCoverClass(terrainCoverClass, visualCoverClass);
+      double waterDepth = previewWaterDepthBlocks(surfaceCoverClass, esaWater, terrainHeight, seaLevel, fallbackWaterEnabled);
+      if (waterDepth >= 0.0) {
+         return flattenWaterColor ? PREVIEW_FLAT_WATER_COLOR : waterColorForDepth(waterDepth);
+      } else {
+         int heightAboveSea = (int)Math.round(terrainHeight) - seaLevel;
+         MountainSurfaceRules.ApproximateSurface mountainSurface = MountainSurfaceRules.classifyApproximateSurface(
+            terrainCoverClass, visualCoverClass, heightAboveSea, slopeDiff, convexity, remaSnowTerrain
+         );
+         if (mountainSurface.isSnow()) {
+            return 16119285;
+         } else if (mountainSurface.isMountain()) {
+            return mountainPreviewColor(mountainSurface.palette());
+         } else {
+            int base = baseColorForCover(surfaceCoverClass, elevationMeters);
+            int tinted = applyClimateTint(base, climateGroup, surfaceCoverClass);
+            return applyRockTint(tinted, slope);
+         }
+      }
+   }
+
+   private static int mountainPreviewColor(MountainSurfaceRules.ApproximatePalette palette) {
+      return switch (palette) {
+         case DEEPSLATE -> 0x545A60;
+         case DEEPSLATE_TALUS -> 0x666C71;
+         case DEEPSLATE_SCREE -> 0x787D82;
+         case WEATHERED_ANDESITE -> 0x898D92;
+         case TUFF -> 0x7B8175;
+         case SNOW -> 16119285;
+         default -> 0x545A60;
+      };
+   }
+
+   // Keep preview shading lightweight; the full water resolver is too expensive to run per pixel.
+   private static double previewWaterDepthBlocks(int coverClass, boolean esaWater, double terrainHeight, int seaLevel, boolean enabled) {
+      if (!enabled) {
+         return -1.0;
+      }
+
+      if (esaWater || coverClass == ESA_WATER) {
+         return Math.max(PREVIEW_INLAND_WATER_DEPTH_BLOCKS, seaLevel - terrainHeight);
+      } else {
+         return coverClass == ESA_NO_DATA && terrainHeight <= (double)seaLevel ? Math.max(0.0, seaLevel - terrainHeight) : -1.0;
+      }
+   }
+
+   private static int baseColorForCover(int coverClass, double elevationMeters) {
+      return switch (coverClass) {
+         case 10 -> 4168275;
+         case 20 -> 9413460;
+         case 30 -> 8240987;
+         case 40 -> 10991978;
+         case 50 -> 9079434;
+         case 60 -> 13087354;
+         case 90 -> 4951130;
+         case 95 -> 3107646;
+         case 100 -> 8367723;
+         default -> colorForElevation(elevationMeters);
+      };
+   }
+
+   private static int waterColorForDepth(double depthBlocks) {
+      if (depthBlocks <= 2.0) {
+         return lerpColor(13218686, 4958171, depthBlocks / 2.0);
+      } else if (depthBlocks <= 12.0) {
+         return lerpColor(4958171, 1924763, (depthBlocks - 2.0) / 10.0);
+      } else {
+         return depthBlocks <= 80.0 ? lerpColor(1924763, 466493, (depthBlocks - 12.0) / 68.0) : 466493;
+      }
+   }
+
+   private boolean useOceanZoom(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      TellusLandMaskSource.LandMaskSample landSample = this.landMaskSource.sampleLandMask(blockX, blockZ, worldScale);
+      int coverClass = landSample.known() && landSample.land()
+         ? ESA_NO_DATA
+         : this.landCoverSource.sampleCoverClass(blockX, blockZ, worldScale, previewResolutionMeters);
+      return useOceanZoom(landSample, coverClass);
+   }
+
+   private static boolean useOceanZoom(TellusLandMaskSource.LandMaskSample landSample, int coverClass) {
+      if (!landSample.known()) {
+         return true;
+      } else if (landSample.land()) {
+         return false;
+      } else {
+         return coverClass == ESA_NO_DATA || coverClass == ESA_WATER;
+      }
+   }
+
+   private static int applyClimateTint(int base, byte climateGroup, int coverClass) {
+      float amount = climateBlendStrength(coverClass);
+      if (!(amount <= 0.0F) && climateGroup != 0) {
+         int tint = tintForClimate(climateGroup);
+         if (tint == 0) {
+            return base;
+         } else {
+            if (climateGroup == 5) {
+               amount = Math.min(0.65F, amount + 0.2F);
+            }
+
+            return blendColor(base, tint, amount);
+         }
+      } else {
+         return base;
+      }
+   }
+
+   private static float climateBlendStrength(int coverClass) {
+      return switch (coverClass) {
+         case 10, 30, 40, 90, 100 -> 0.35F;
+         case 20 -> 0.25F;
+         case 60 -> 0.15F;
+         case 95 -> 0.2F;
+         default -> 0.0F;
+      };
+   }
+
+   private static int tintForClimate(byte climateGroup) {
+      return switch (climateGroup) {
+         case 1 -> 3054935;
+         case 2 -> 13676658;
+         case 3 -> 8367971;
+         case 4 -> 7176850;
+         case 5 -> 13227746;
+         default -> 0;
+      };
+   }
+
+   private static int applyRockTint(int base, double slope) {
+      if (slope <= 1.2) {
+         return base;
+      } else {
+         double amount = (slope - 1.2) / 1.6;
+         return blendColor(base, 10526880, (float)Mth.clamp(amount, 0.0, 1.0));
+      }
+   }
+
+   private static int colorForElevation(double elevation) {
+      if (elevation < 0.0) {
+         double depth = -elevation;
+         if (depth < 60.0) {
+            return lerpColor(4958171, 1924763, depth / 60.0);
+         } else {
+            return depth < 2000.0 ? lerpColor(1924763, 466493, (depth - 60.0) / 1940.0) : 466493;
+         }
+      } else if (elevation < 120.0) {
+         return lerpColor(13218686, 4168275, elevation / 120.0);
+      } else if (elevation < 900.0) {
+         return lerpColor(4168275, 8359757, (elevation - 120.0) / 780.0);
+      } else if (elevation < 2200.0) {
+         return lerpColor(8359757, 9206372, (elevation - 900.0) / 1300.0);
+      } else if (elevation < 3800.0) {
+         return lerpColor(9206372, 10526880, (elevation - 2200.0) / 1600.0);
+      } else {
+         return elevation < 5200.0 ? lerpColor(10526880, 16119285, (elevation - 3800.0) / 1400.0) : 16119285;
+      }
+   }
+
+   private static int lerpColor(int a, int b, double t) {
+      double clamped = Mth.clamp(t, 0.0, 1.0);
+      int ar = a >> 16 & 0xFF;
+      int ag = a >> 8 & 0xFF;
+      int ab = a & 0xFF;
+      int br = b >> 16 & 0xFF;
+      int bg = b >> 8 & 0xFF;
+      int bb = b & 0xFF;
+      int r = (int)Math.round(ar + (br - ar) * clamped);
+      int g = (int)Math.round(ag + (bg - ag) * clamped);
+      int bch = (int)Math.round(ab + (bb - ab) * clamped);
+      return r << 16 | g << 8 | bch;
+   }
+
+   private static int blendColor(int base, int tint, float amount) {
+      if (amount <= 0.0F) {
+         return base;
+      } else {
+         float clamped = Mth.clamp(amount, 0.0F, 1.0F);
+         int br = base >> 16 & 0xFF;
+         int bg = base >> 8 & 0xFF;
+         int bb = base & 0xFF;
+         int tr = tint >> 16 & 0xFF;
+         int tg = tint >> 8 & 0xFF;
+         int tb = tint & 0xFF;
+         int r = Math.round(br + (tr - br) * clamped);
+         int g = Math.round(bg + (tg - bg) * clamped);
+         int b = Math.round(bb + (tb - bb) * clamped);
+         return r << 16 | g << 8 | b;
+      }
+   }
+
+   @Override
+   public void close() {
+      if (this.pending != null) {
+         this.pending.cancel(true);
+      }
+
+      this.executor.shutdownNow();
+   }
+
+   private void updateStatus(int id, TerrainPreview.PreviewStage stage, float progress) {
+      this.updateStatus(id, stage, progress, null);
+   }
+
+   private void updateStatus(int id, TerrainPreview.PreviewStage stage, float progress, String activity) {
+      if (id == this.requestId.get()) {
+         this.status.set(new TerrainPreview.PreviewStatus(stage, Mth.clamp(progress, 0.0F, 1.0F), activity));
+      }
+   }
+
+   private boolean shouldAbortRequest(int id) {
+      return Thread.currentThread().isInterrupted() || id != this.requestId.get();
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class DownloadNetworkTracker implements DownloadProgressReporter.Listener {
+      private long knownBytesTotal;
+      private long knownBytesRead;
+      private long requestsStarted;
+      private long requestsCompleted;
+      private long unknownSizeRequests;
+
+      @Override
+      public void onRequestStarted(long expectedBytes) {
+         this.requestsStarted++;
+         if (expectedBytes > 0L) {
+            this.knownBytesTotal += expectedBytes;
+         } else {
+            this.unknownSizeRequests++;
+         }
+      }
+
+      @Override
+      public void onBytesRead(int bytes) {
+         if (bytes > 0) {
+            this.knownBytesRead += bytes;
+         }
+      }
+
+      @Override
+      public void onRequestFinished() {
+         this.requestsCompleted++;
+      }
+
+      private float progress() {
+         float requestProgress = this.requestsStarted <= 0L ? 0.0F : Mth.clamp((float)this.requestsCompleted / (float)this.requestsStarted, 0.0F, 1.0F);
+         float byteProgress = this.knownBytesTotal <= 0L ? 0.0F : Mth.clamp((float)this.knownBytesRead / (float)this.knownBytesTotal, 0.0F, 1.0F);
+         if (this.knownBytesTotal > 0L && this.unknownSizeRequests <= 0L) {
+            return Math.max(byteProgress, requestProgress);
+         } else {
+            return this.knownBytesTotal > 0L ? Mth.clamp(byteProgress * 0.85F + requestProgress * 0.15F, 0.0F, 1.0F) : requestProgress;
+         }
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private final class OsmOverlayStageProgress {
+      private final int requestId;
+      private final long buildTotal;
+      private final long overlayBaseDone;
+      private final long overlayProcessUnits;
+      private final float fetchWeight;
+      private final float rasterWeight;
+      private final String fetchActivity;
+      private final String rasterActivity;
+      private float fetchProgress;
+      private float rasterProgress;
+      private float emittedStageProgress;
+      private long lastPublishMs;
+      private String activity;
+
+      private OsmOverlayStageProgress(
+         int requestId,
+         long buildTotal,
+         long overlayBaseDone,
+         long overlayProcessUnits,
+         float fetchWeight,
+         float rasterWeight,
+         String fetchActivity,
+         String rasterActivity
+      ) {
+         this.requestId = requestId;
+         this.buildTotal = Math.max(1L, buildTotal);
+         this.overlayBaseDone = overlayBaseDone;
+         this.overlayProcessUnits = Math.max(1L, overlayProcessUnits);
+         this.fetchWeight = Math.max(0.0F, fetchWeight);
+         this.rasterWeight = Math.max(0.0F, rasterWeight);
+         this.fetchActivity = fetchActivity;
+         this.rasterActivity = rasterActivity;
+         this.activity = fetchActivity;
+      }
+
+      private void updateFetch(float value) {
+         this.fetchProgress = Math.max(this.fetchProgress, Mth.clamp(value, 0.0F, 1.0F));
+         this.activity = this.fetchActivity;
+         this.publish();
+      }
+
+      private void updateRaster(float value) {
+         this.rasterProgress = Math.max(this.rasterProgress, Mth.clamp(value, 0.0F, 1.0F));
+         this.activity = this.rasterActivity;
+         this.publish();
+      }
+
+      private void finish() {
+         this.fetchProgress = 1.0F;
+         this.rasterProgress = 1.0F;
+         this.activity = this.rasterActivity;
+         this.publishNow();
+      }
+
+      private void publish() {
+         long now = System.currentTimeMillis();
+         float stageProgress = this.overlayStageProgress();
+         if (!(stageProgress < this.emittedStageProgress + 0.0015F) || now - this.lastPublishMs >= 40L) {
+            this.publishNow();
+         }
+      }
+
+      private void publishNow() {
+         this.lastPublishMs = System.currentTimeMillis();
+         this.emittedStageProgress = Math.max(this.emittedStageProgress, this.overlayStageProgress());
+         long overlayUnits = Math.round(this.emittedStageProgress * (float)this.overlayProcessUnits);
+         float totalProgress = Mth.clamp((float)(this.overlayBaseDone + overlayUnits) / (float)this.buildTotal, 0.0F, 1.0F);
+         TerrainPreview.this.updateStatus(this.requestId, TerrainPreview.PreviewStage.PROCESSING_OSM, totalProgress, this.activity);
+      }
+
+      private float overlayStageProgress() {
+         float weightSum = this.fetchWeight + this.rasterWeight;
+         return weightSum <= 0.0F
+            ? Math.max(this.fetchProgress, this.rasterProgress)
+            : Mth.clamp((this.fetchProgress * this.fetchWeight + this.rasterProgress * this.rasterWeight) / weightSum, 0.0F, 1.0F);
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record PreviewBaseSnapshot(
+      double worldScale,
+      double terrestrialHeightScale,
+      double oceanicHeightScale,
+      int heightOffset,
+      double spawnLatitude,
+      double spawnLongitude,
+      EarthGeneratorSettings.DemSelection demSelection,
+      int size,
+      int coverStride,
+      int coverSize,
+      int climateStride,
+      int climateSize,
+      double centerX,
+      double centerZ,
+      double radius,
+      double step,
+      double minWorldX,
+      double minWorldZ,
+      double maxWorldX,
+      double maxWorldZ,
+      double[] blockHeights,
+      boolean[] esaWaterMask,
+      double[] elevations,
+      int[] coverClasses,
+      int[] visualCoverClasses,
+      byte[] climateGroups,
+      float[] heights,
+      float heightCenter,
+      float[] xCoords,
+      TerrainPreview.PreviewInfo info
+   ) {
+      private PreviewBaseSnapshot {
+         demSelection = Objects.requireNonNull(demSelection, "demSelection");
+         info = Objects.requireNonNull(info, "info");
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class PreviewMesh {
+      private final int size;
+      private final int granularity;
+      private final float[] terrainHeights;
+      private final int[] terrainColors;
+      private final float[] detailHeights;
+      private final int[] detailColors;
+      private final float[] axis;
+      private final TerrainPreview.PreviewInfo info;
+
+      private PreviewMesh(
+         int size,
+         int granularity,
+         float[] terrainHeights,
+         int[] terrainColors,
+         float[] detailHeights,
+         int[] detailColors,
+         float[] axis,
+         TerrainPreview.PreviewInfo info
+      ) {
+         this.size = size;
+         this.granularity = granularity;
+         this.terrainHeights = terrainHeights;
+         this.terrainColors = terrainColors;
+         this.detailHeights = detailHeights;
+         this.detailColors = detailColors;
+         this.axis = axis;
+         this.info = Objects.requireNonNull(info, "info");
+      }
+
+      private float[] heightsFor(TerrainPreviewWidget.RenderMode renderMode) {
+         return renderMode == TerrainPreviewWidget.RenderMode.FULL_DETAIL ? this.detailHeights : this.terrainHeights;
+      }
+
+      private int[] colorsFor(TerrainPreviewWidget.RenderMode renderMode) {
+         return renderMode == TerrainPreviewWidget.RenderMode.FULL_DETAIL ? this.detailColors : this.terrainColors;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public record PreviewInfo(
+      List<TerrainPreview.PreviewProviderShare> primaryProviders,
+      List<TerrainPreview.PreviewResolutionShare> primaryResolutions,
+      int blendedProviderMask,
+      double minElevationMeters,
+      double maxElevationMeters,
+      int minSurfaceY,
+      int maxSurfaceY
+   ) {
+      public PreviewInfo {
+         primaryProviders = List.copyOf(primaryProviders);
+         primaryResolutions = List.copyOf(primaryResolutions);
+      }
+
+      public TerrainPreview.PreviewProviderShare mainProvider() {
+         return this.primaryProviders.isEmpty() ? null : this.primaryProviders.get(0);
+      }
+
+      public boolean hasMixedPrimaryProviders() {
+         return this.primaryProviders.size() > 1;
+      }
+
+      public TerrainPreview.PreviewResolutionShare mainResolution() {
+         return this.primaryResolutions.isEmpty() ? null : this.primaryResolutions.get(0);
+      }
+
+      public boolean hasMixedPrimaryResolutions() {
+         return this.primaryResolutions.size() > 1;
+      }
+
+      public boolean hasBlendedProviders() {
+         return this.blendedProviderMask != 0;
+      }
+
+      public boolean minWithinLimits() {
+         return this.minSurfaceY >= EarthGeneratorSettings.MIN_WORLD_Y;
+      }
+
+      public boolean maxWithinLimits() {
+         return this.maxSurfaceY <= EarthGeneratorSettings.MAX_WORLD_Y;
+      }
+
+      public List<DemUsage> blendedProviders() {
+         List<DemUsage> providers = new ArrayList<>();
+         for (DemUsage provider : DemUsage.values()) {
+            if ((this.blendedProviderMask & provider.bit()) != 0) {
+               providers.add(provider);
+            }
+         }
+
+         return providers;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public record PreviewProviderShare(DemUsage provider, double share) {
+      public PreviewProviderShare {
+         provider = Objects.requireNonNull(provider, "provider");
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public record PreviewResolutionShare(double resolutionMeters, double share) {
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record PreviewRoadWidths(int main, int normal, int dirt) {
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public static enum PreviewStage {
+      DOWNLOADING,
+      LOADING,
+      PROCESSING_OSM,
+      COMPLETE;
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public record PreviewStatus(TerrainPreview.PreviewStage stage, float progress, String activity) {
+      public PreviewStatus(TerrainPreview.PreviewStage stage, float progress, String activity) {
+         Objects.requireNonNull(stage, "stage");
+         this.stage = stage;
+         this.progress = progress;
+         this.activity = activity == null || activity.isBlank() ? null : activity;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class PreviewThreadFactory implements ThreadFactory {
+      @Override
+      public Thread newThread(Runnable runnable) {
+         Thread thread = new Thread(runnable, "tellus-preview");
+         thread.setDaemon(true);
+         return thread;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class PreviewBuildingGroupScratch {
+      private final IntArrayList groundSamples = new IntArrayList();
+      private final IntArrayList fallbackSamples = new IntArrayList();
+      private int baseY = Integer.MIN_VALUE;
+
+      private IntArrayList groundSamples() {
+         return this.groundSamples;
+      }
+
+      private IntArrayList fallbackSamples() {
+         return this.fallbackSamples;
+      }
+
+      private int baseY() {
+         return this.baseY;
+      }
+
+      private void setBaseY(int value) {
+         this.baseY = value;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record PreviewRasterizedBuildingFeature(
+      OsmBuildingFeature feature,
+      String groupId,
+      boolean groundContact,
+      int minGridX,
+      int minGridZ,
+      int width,
+      int height,
+      boolean[] occupiedMask,
+      int[] occupiedIndices
+   ) {
+      private PreviewRasterizedBuildingFeature {
+         feature = Objects.requireNonNull(feature, "feature");
+         groupId = Objects.requireNonNull(groupId, "groupId");
+         occupiedMask = occupiedMask.clone();
+         occupiedIndices = occupiedIndices.clone();
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record PreviewBoundaryInfo(int[] boundaryDistance) {
+      private PreviewBoundaryInfo {
+         boundaryDistance = boundaryDistance.clone();
+      }
+
+      private int boundaryDistance(int order) {
+         return this.boundaryDistance[order];
+      }
+   }
+
+   @FunctionalInterface
+   @OnlyIn(Dist.CLIENT)
+   private interface RoadRasterProgress {
+      void onProgress(float var1);
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class RoadRasterProgressTracker {
+      private final int totalSegments;
+      private final int totalPaintRows;
+      private final TerrainPreview.RoadRasterProgress callback;
+      private int processedSegments;
+      private int paintedRows;
+      private float emittedProgress;
+
+      private RoadRasterProgressTracker(int totalSegments, int totalPaintRows, TerrainPreview.RoadRasterProgress callback) {
+         this.totalSegments = Math.max(1, totalSegments);
+         this.totalPaintRows = Math.max(1, totalPaintRows);
+         this.callback = callback;
+         this.emittedProgress = 0.0F;
+      }
+
+      private void onSegmentProcessed() {
+         this.processedSegments = Math.min(this.totalSegments, this.processedSegments + 1);
+         this.publish(false);
+      }
+
+      private void onPaintRow() {
+         this.paintedRows = Math.min(this.totalPaintRows, this.paintedRows + 1);
+         this.publish(false);
+      }
+
+      private void finish() {
+         this.processedSegments = this.totalSegments;
+         this.paintedRows = this.totalPaintRows;
+         this.publish(true);
+      }
+
+      private void publish(boolean force) {
+         float segmentProgress = Mth.clamp((float)this.processedSegments / this.totalSegments, 0.0F, 1.0F);
+         float paintProgress = Mth.clamp((float)this.paintedRows / this.totalPaintRows, 0.0F, 1.0F);
+         float progress = Mth.clamp(segmentProgress * 0.9F + paintProgress * 0.1F, 0.0F, 1.0F);
+         if (force || !(progress < this.emittedProgress + 0.003F)) {
+            this.emittedProgress = Math.max(this.emittedProgress, progress);
+            this.callback.onProgress(this.emittedProgress);
+         }
+      }
+   }
+
+   private static void emitPreviewVertex(
+      VertexConsumer consumer,
+      Matrix4f modelView,
+      Matrix4f projection,
+      float worldX,
+      float worldY,
+      float worldZ,
+      int rgb,
+      float x0,
+      float y0,
+      float width,
+      float height,
+      Vector3f view,
+      Vector3f projected
+   ) {
+      modelView.transformPosition(worldX, worldY, worldZ, view);
+      projection.transformProject(view, projected);
+      float screenX = x0 + (projected.x + 1.0F) * 0.5F * width;
+      float screenY = y0 + (1.0F - projected.y) * 0.5F * height;
+      int argb = 0xFF000000 | rgb & 16777215;
+      consumer.addVertex(screenX, screenY, 0.0F).setColor(argb);
+   }
+
+   private static float computePreviewQuadShade(
+      float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3, Vector3f normal
+   ) {
+      float a1x = x1 - x0;
+      float a1y = y1 - y0;
+      float a1z = z1 - z0;
+      float b1x = x2 - x0;
+      float b1y = y2 - y0;
+      float b1z = z2 - z0;
+      float n1x = a1y * b1z - a1z * b1y;
+      float n1y = a1z * b1x - a1x * b1z;
+      float n1z = a1x * b1y - a1y * b1x;
+      float a2x = x3 - x1;
+      float a2y = y3 - y1;
+      float a2z = z3 - z1;
+      float b2x = x2 - x1;
+      float b2y = y2 - y1;
+      float b2z = z2 - z1;
+      float n2x = a2y * b2z - a2z * b2y;
+      float n2y = a2z * b2x - a2x * b2z;
+      float n2z = a2x * b2y - a2y * b2x;
+      normal.set(n1x + n2x, n1y + n2y, n1z + n2z);
+      if (normal.lengthSquared() < 1.0E-9F) {
+         normal.set(n1x, n1y, n1z);
+      }
+
+      if (normal.y < 0.0F) {
+         normal.negate();
+      }
+
+      normal.normalize();
+      float shade = Mth.clamp(normal.dot(LIGHT_DIR), 0.0F, 1.0F);
+      shade = 0.45F + shade * 0.55F;
+      return Math.round(shade * 16.0F) / 16.0F;
+   }
+
+   private static int applyPreviewShade(int rgb, float shade) {
+      int r = rgb >> 16 & 0xFF;
+      int g = rgb >> 8 & 0xFF;
+      int b = rgb & 0xFF;
+      r = Mth.clamp(Math.round(r * shade), 0, 255);
+      g = Mth.clamp(Math.round(g * shade), 0, 255);
+      b = Mth.clamp(Math.round(b * shade), 0, 255);
+      return r << 16 | g << 8 | b;
+   }
+
+   private static void sortPreviewQuads(int[] quadTopLeft, float[] quadDepth, int left, int right) {
+      int i = left;
+      int j = right;
+      float pivot = quadDepth[left + right >>> 1];
+
+      while (i <= j) {
+         while (quadDepth[i] < pivot) {
+            i++;
+         }
+
+         while (quadDepth[j] > pivot) {
+            j--;
+         }
+
+         if (i <= j) {
+            swapPreviewQuads(quadTopLeft, quadDepth, i, j);
+            i++;
+            j--;
+         }
+      }
+
+      if (left < j) {
+         sortPreviewQuads(quadTopLeft, quadDepth, left, j);
+      }
+
+      if (i < right) {
+         sortPreviewQuads(quadTopLeft, quadDepth, i, right);
+      }
+   }
+
+   private static void swapPreviewQuads(int[] quadTopLeft, float[] quadDepth, int i, int j) {
+      int tempIndex = quadTopLeft[i];
+      quadTopLeft[i] = quadTopLeft[j];
+      quadTopLeft[j] = tempIndex;
+      float tempDepth = quadDepth[i];
+      quadDepth[i] = quadDepth[j];
+      quadDepth[j] = tempDepth;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/preview/TerrainPreviewWidget.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/preview/TerrainPreviewWidget.java
@@ -1,0 +1,618 @@
+package com.yucareux.tellus.client.preview;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.world.data.elevation.TellusElevationSource;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Function;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+
+@OnlyIn(Dist.CLIENT)
+public final class TerrainPreviewWidget extends AbstractWidget implements AutoCloseable {
+   private static final float DEFAULT_ROTATION_X = (float)Math.toRadians(18.0);
+   private static final float DEFAULT_ROTATION_Y = (float)Math.toRadians(18.0);
+   private static final float DEFAULT_ZOOM = 1.4F;
+   private static final float MIN_ROTATION_X = (float)Math.toRadians(0.0);
+   private static final float MAX_ROTATION_X = (float)Math.toRadians(80.0);
+   private static final float MIN_ZOOM = 0.5F;
+   private static final float MAX_ZOOM = 4.0F;
+   private static final float ROTATION_SPEED = 0.01F;
+   private static final float ZOOM_SPEED = 0.1F;
+   private static final float AUTO_ROTATION_SPEED = -0.0022F;
+   private static final long AUTO_RESUME_DELAY_MS = 1200L;
+   private static final int MODE_BUTTON_WIDTH = 36;
+   private static final int MODE_BUTTON_HEIGHT = 20;
+   private static final int MODE_BUTTON_PADDING = 6;
+   private static final int INFO_BUTTON_SIZE = 20;
+   private static final int INFO_BUTTON_PADDING = 6;
+   private static final int INFO_PANEL_WIDTH = 320;
+   private static final int INFO_PANEL_PADDING = 8;
+   private static final int INFO_TITLE_SPACING = 14;
+   private static final int INFO_LINE_SPACING = 11;
+   private static final int INFO_SECTION_SPACING = 8;
+   private static final int INFO_PANEL_BG = -1609957376;
+   private static final int INFO_PANEL_BORDER = -12961222;
+   private static final int INFO_TEXT = -1710619;
+   private static final int INFO_SUBTLE = -4605511;
+   private static final int INFO_GOOD = 0xFF6ED470;
+   private static final int INFO_BAD = 0xFFF06262;
+   private static final int FULLSCREEN_BUTTON_SIZE = 20;
+   private static final int FULLSCREEN_BUTTON_PADDING = 6;
+   
+   private static final Component FULLSCREEN_LABEL = Component.literal("[ ]");
+   private static final Component INFO_LABEL = Component.literal("i");
+   private static final int LOADING_PANEL_BG = -871362544;
+   private static final int LOADING_PANEL_BORDER = -12961222;
+   private static final int LOADING_BAR_BG = -15066598;
+   private static final int LOADING_BAR_BORDER = -13816531;
+   private static final int LOADING_BAR_FILL = -12599473;
+   private static final int LOADING_TEXT = -1;
+   private final TerrainPreview preview;
+   private final boolean ownsPreview;
+   private final Button modeButton;
+   private final Button infoButton;
+   private final Button autoAdjustButton;
+   private final Button fullscreenButton;
+   
+   private Function<TerrainPreview.PreviewInfo, EarthGeneratorSettings> autoAdjustAction;
+   private Runnable fullscreenAction;
+   private boolean dragging;
+   private boolean infoPanelVisible;
+   private float rotationX = DEFAULT_ROTATION_X;
+   private float rotationY = DEFAULT_ROTATION_Y;
+   private float zoom = DEFAULT_ZOOM;
+   private TerrainPreviewWidget.RenderMode renderMode = TerrainPreviewWidget.RenderMode.FULL_DETAIL;
+   private long lastInteractionTime;
+
+   public TerrainPreviewWidget(int x, int y, int width, int height) {
+      this(x, y, width, height, new TerrainPreview(), true);
+   }
+
+   public TerrainPreviewWidget(int x, int y, int width, int height, TerrainPreview preview) {
+      this(x, y, width, height, preview, false);
+   }
+
+   private TerrainPreviewWidget(int x, int y, int width, int height, TerrainPreview preview, boolean ownsPreview) {
+      super(x, y, width, height, Objects.requireNonNull(Component.empty(), "widgetMessage"));
+      this.preview = preview;
+      this.ownsPreview = ownsPreview;
+      this.modeButton = Button.builder(this.renderMode.buttonLabel(), button -> this.toggleRenderMode())
+         .bounds(0, 0, MODE_BUTTON_WIDTH, MODE_BUTTON_HEIGHT)
+         .build();
+      this.modeButton.setTooltip(Tooltip.create(Component.literal("Switch between terrain-only 3D and 3D with preview trees/roads")));
+      this.infoButton = Button.builder(Objects.requireNonNull(INFO_LABEL, "infoLabel"), button -> this.toggleInfoPanel())
+         .bounds(0, 0, INFO_BUTTON_SIZE, INFO_BUTTON_SIZE)
+         .build();
+      this.infoButton.setTooltip(Tooltip.create(Component.translatable("tellus.preview.info.button.tooltip")));
+      this.autoAdjustButton = Button.builder(Component.translatable("tellus.preview.info.auto_adjust"), button -> this.runAutoAdjust())
+         .bounds(0, 0, 110, 20)
+         .build();
+      this.fullscreenButton = Button.builder(Objects.requireNonNull(FULLSCREEN_LABEL, "fullscreenLabel"), button -> {
+         if (this.fullscreenAction != null) {
+            this.fullscreenAction.run();
+         }
+      }).bounds(0, 0, FULLSCREEN_BUTTON_SIZE, FULLSCREEN_BUTTON_SIZE).build();
+      this.fullscreenButton.active = false;
+   }
+
+   public void requestRebuild(EarthGeneratorSettings settings) {
+      this.preview.requestRebuild(settings);
+   }
+
+   public void setFullscreenAction(Runnable action) {
+      this.fullscreenAction = action;
+      this.fullscreenButton.active = action != null;
+   }
+
+   public void setAutoAdjustAction(Function<TerrainPreview.PreviewInfo, EarthGeneratorSettings> action) {
+      this.autoAdjustAction = action;
+   }
+
+   public TerrainPreview getPreview() {
+      return this.preview;
+   }
+
+   public TerrainPreviewWidget.ViewState getViewState() {
+      return new TerrainPreviewWidget.ViewState(this.rotationX, this.rotationY, this.zoom, this.renderMode);
+   }
+
+   public void setViewState(TerrainPreviewWidget.ViewState state) {
+      this.rotationX = Mth.clamp(state.rotationX(), MIN_ROTATION_X, MAX_ROTATION_X);
+      this.rotationY = state.rotationY();
+      this.zoom = Mth.clamp(state.zoom(), MIN_ZOOM, MAX_ZOOM);
+      this.renderMode = state.renderMode();
+      this.updateModeButtonLabel();
+   }
+
+   public void tick() {
+      this.preview.tick();
+      long now = System.currentTimeMillis();
+      if (!this.dragging && now - this.lastInteractionTime > AUTO_RESUME_DELAY_MS) {
+         this.rotationY += AUTO_ROTATION_SPEED;
+      }
+   }
+
+   protected void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      this.renderBlurredBackground(graphics);
+      int inset = 0;
+      int contentX = this.getX() + inset;
+      int contentY = this.getY() + inset;
+      int contentWidth = Math.max(1, this.width - inset * 2);
+      int contentHeight = Math.max(1, this.height - inset * 2);
+      this.preview.render(graphics, contentX, contentY, contentWidth, contentHeight, this.rotationX, this.rotationY, this.zoom, this.renderMode);
+      this.renderLoadingOverlay(graphics, contentX, contentY, contentWidth, contentHeight);
+      this.renderModeButton(graphics, mouseX, mouseY, delta);
+      this.renderInfoButton(graphics, mouseX, mouseY, delta);
+      this.renderInfoPanel(graphics, mouseX, mouseY, delta);
+      this.renderFullscreenButton(graphics, mouseX, mouseY, delta);
+   }
+
+   @Override
+   public boolean mouseClicked(double mouseX, double mouseY, int button) {
+      if (!this.active || !this.visible || !this.isMouseOver(mouseX, mouseY)) {
+         return false;
+      } else if (this.modeButton.isMouseOver(mouseX, mouseY)) {
+         this.modeButton.mouseClicked(mouseX, mouseY, button);
+         this.lastInteractionTime = System.currentTimeMillis();
+         return true;
+      } else if (this.infoButton.isMouseOver(mouseX, mouseY)) {
+         this.infoButton.mouseClicked(mouseX, mouseY, button);
+         this.lastInteractionTime = System.currentTimeMillis();
+         return true;
+      } else if (this.infoPanelVisible && this.autoAdjustButton.isMouseOver(mouseX, mouseY)) {
+         this.autoAdjustButton.mouseClicked(mouseX, mouseY, button);
+         this.lastInteractionTime = System.currentTimeMillis();
+         return true;
+      } else if (this.fullscreenAction != null && this.fullscreenButton.isMouseOver(mouseX, mouseY)) {
+         this.fullscreenButton.mouseClicked(mouseX, mouseY, button);
+         return true;
+      } else if (this.infoPanelVisible && this.isMouseOverInfoPanel(mouseX, mouseY)) {
+         this.lastInteractionTime = System.currentTimeMillis();
+         return true;
+      } else {
+         if (button == 0) {
+            this.dragging = true;
+            this.lastInteractionTime = System.currentTimeMillis();
+         }
+
+         return true;
+      }
+   }
+
+   public void onClick(double mouseX, double mouseY) {
+      if (this.modeButton.isMouseOver(mouseX, mouseY)) {
+         this.modeButton.mouseClicked(mouseX, mouseY, 0);
+         this.lastInteractionTime = System.currentTimeMillis();
+      } else if (this.infoButton.isMouseOver(mouseX, mouseY)) {
+         this.infoButton.mouseClicked(mouseX, mouseY, 0);
+         this.lastInteractionTime = System.currentTimeMillis();
+      } else if (this.infoPanelVisible && this.autoAdjustButton.isMouseOver(mouseX, mouseY)) {
+         this.autoAdjustButton.mouseClicked(mouseX, mouseY, 0);
+         this.lastInteractionTime = System.currentTimeMillis();
+      } else if (this.fullscreenAction != null && this.fullscreenButton.isMouseOver(mouseX, mouseY)) {
+         this.fullscreenButton.mouseClicked(mouseX, mouseY, 0);
+      } else if (this.infoPanelVisible && this.isMouseOverInfoPanel(mouseX, mouseY)) {
+         this.lastInteractionTime = System.currentTimeMillis();
+      } else {
+         this.dragging = true;
+         this.lastInteractionTime = System.currentTimeMillis();
+      }
+   }
+
+   protected void onDrag(double mouseX, double mouseY, double deltaX, double deltaY) {
+      if (this.dragging) {
+         this.rotationY += (float)deltaX * ROTATION_SPEED;
+         this.rotationX = Mth.clamp(this.rotationX + (float)deltaY * ROTATION_SPEED, MIN_ROTATION_X, MAX_ROTATION_X);
+         this.lastInteractionTime = System.currentTimeMillis();
+      }
+   }
+
+   public void onRelease(double mouseX, double mouseY) {
+      this.modeButton.mouseReleased(mouseX, mouseY, 0);
+      this.infoButton.mouseReleased(mouseX, mouseY, 0);
+      this.autoAdjustButton.mouseReleased(mouseX, mouseY, 0);
+      if (this.fullscreenAction != null) {
+         this.fullscreenButton.mouseReleased(mouseX, mouseY, 0);
+      }
+
+      this.dragging = false;
+      this.lastInteractionTime = System.currentTimeMillis();
+   }
+
+   public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+      if (this.modeButton.isMouseOver(mouseX, mouseY)
+         || this.infoButton.isMouseOver(mouseX, mouseY)
+         || this.infoPanelVisible && this.isMouseOverInfoPanel(mouseX, mouseY)
+         || this.fullscreenAction != null && this.fullscreenButton.isMouseOver(mouseX, mouseY)) {
+         return false;
+      } else if (this.isMouseOver(mouseX, mouseY)) {
+         this.zoom = Mth.clamp(this.zoom + (float)verticalAmount * ZOOM_SPEED, MIN_ZOOM, MAX_ZOOM);
+         this.lastInteractionTime = System.currentTimeMillis();
+         return true;
+      } else {
+         return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+      }
+   }
+
+   protected void updateWidgetNarration(NarrationElementOutput narration) {
+   }
+
+   private void renderBlurredBackground(GuiGraphics graphics) {
+      int left = this.getX();
+      int top = this.getY();
+      int right = this.getX() + this.width;
+      int bottom = this.getY() + this.height;
+      graphics.fill(left, top, right, bottom, -2013265920);
+      graphics.fill(left + 1, top + 1, right - 1, bottom - 1, 855638016);
+      graphics.fillGradient(left, top, right, top + 8, 1140850688, 335544320);
+      graphics.fillGradient(left, bottom - 8, right, bottom, 335544320, 1140850688);
+      graphics.renderOutline(left, top, this.width, this.height, 402653184);
+   }
+
+   private void renderLoadingOverlay(GuiGraphics graphics, int x, int y, int width, int height) {
+      if (this.preview.isLoading()) {
+         TerrainPreview.PreviewStatus status = this.preview.getStatus();
+         if (status.stage() != TerrainPreview.PreviewStage.COMPLETE) {
+            String label = status.activity();
+            if (label == null) {
+               label = Objects.requireNonNull(switch (status.stage()) {
+                  case DOWNLOADING -> "Downloading data";
+                  case PROCESSING_OSM -> "Processing OSM data";
+                  case LOADING -> "Processing data";
+                  case COMPLETE -> "Processing data";
+               }, "loadingLabel");
+            }
+            float displayedProgress = displayedProgress(status);
+            float percentValue = status.stage() == TerrainPreview.PreviewStage.COMPLETE ? 100.0F : Mth.clamp(displayedProgress * 100.0F, 0.0F, 99.9F);
+            String percentText = Objects.requireNonNull(
+               percentValue >= 10.0F ? String.format(Locale.ROOT, "%.0f%%", percentValue) : String.format(Locale.ROOT, "%.1f%%", percentValue),
+               "loadingPercent"
+            );
+            Font font = Minecraft.getInstance().font;
+            int padding = 6;
+            int maxInnerWidth = Math.max(20, width - padding * 2 - 4);
+            int barWidth = Math.min(180, maxInnerWidth);
+            int textLineWidth = font.width(label) + font.width(percentText) + 12;
+            int innerWidth = Math.min(maxInnerWidth, Math.max(barWidth, textLineWidth));
+            int panelWidth = innerWidth + padding * 2;
+            int barHeight = 8;
+            int panelHeight = padding * 3 + 9 + barHeight;
+            int panelX = x + (width - panelWidth) / 2;
+            int panelY = y + height - panelHeight - 10;
+            panelY = Mth.clamp(panelY, y + 6, y + height - panelHeight - 6);
+            graphics.fill(panelX, panelY, panelX + panelWidth, panelY + panelHeight, LOADING_PANEL_BG);
+            graphics.renderOutline(panelX, panelY, panelWidth, panelHeight, LOADING_PANEL_BORDER);
+            int textY = panelY + padding;
+            graphics.drawString(font, label, panelX + padding, textY, LOADING_TEXT, true);
+            graphics.drawString(font, percentText, panelX + panelWidth - padding - font.width(percentText), textY, LOADING_TEXT, true);
+            int barX = panelX + padding;
+            int barY = textY + 9 + padding;
+            int barInnerWidth = innerWidth - 2;
+            graphics.fill(barX, barY, barX + innerWidth, barY + barHeight, LOADING_BAR_BG);
+            graphics.renderOutline(barX, barY, innerWidth, barHeight, LOADING_BAR_BORDER);
+            float clamped = Mth.clamp(displayedProgress, 0.0F, 1.0F);
+            int fillWidth = Math.round(barInnerWidth * clamped);
+            if (fillWidth == 0 && clamped > 0.0F) {
+               fillWidth = 1;
+            }
+
+            if (fillWidth > 0) {
+               graphics.fill(barX + 1, barY + 1, barX + 1 + fillWidth, barY + barHeight - 1, LOADING_BAR_FILL);
+            }
+         }
+      }
+   }
+
+   private static float displayedProgress(TerrainPreview.PreviewStatus status) {
+      float stageProgress = Mth.clamp(status.progress(), 0.0F, 1.0F);
+
+      return switch (status.stage()) {
+         case DOWNLOADING -> stageProgress * 0.4F;
+         case PROCESSING_OSM -> 0.4F + stageProgress * 0.6F;
+         case LOADING -> 0.4F + stageProgress * 0.6F;
+         case COMPLETE -> 1.0F;
+      };
+   }
+
+   private void toggleRenderMode() {
+      this.renderMode = this.renderMode.toggle();
+      this.updateModeButtonLabel();
+      this.lastInteractionTime = System.currentTimeMillis();
+      this.dragging = false;
+   }
+
+   private void toggleInfoPanel() {
+      this.infoPanelVisible = !this.infoPanelVisible;
+      this.lastInteractionTime = System.currentTimeMillis();
+      this.dragging = false;
+   }
+
+   private void runAutoAdjust() {
+      if (this.autoAdjustAction != null) {
+         TerrainPreview.PreviewInfo info = this.preview.getInfo();
+         if (info != null) {
+            EarthGeneratorSettings settings = this.autoAdjustAction.apply(info);
+            if (settings != null) {
+               this.preview.requestRebuild(settings);
+            }
+         }
+      }
+   }
+
+   private void updateModeButtonLabel() {
+      this.modeButton.setMessage(this.renderMode.buttonLabel());
+   }
+
+   private void renderModeButton(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      int buttonX = this.getX() + MODE_BUTTON_PADDING;
+      int buttonY = this.getY() + MODE_BUTTON_PADDING;
+      this.modeButton.setX(buttonX);
+      this.modeButton.setY(buttonY);
+      this.modeButton.setWidth(MODE_BUTTON_WIDTH);
+      this.modeButton.setHeight(MODE_BUTTON_HEIGHT);
+      this.modeButton.render(graphics, mouseX, mouseY, delta);
+   }
+
+   private void renderInfoButton(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      int buttonX = this.getX() + MODE_BUTTON_PADDING;
+      int buttonY = this.getY() + MODE_BUTTON_PADDING + MODE_BUTTON_HEIGHT + INFO_BUTTON_PADDING;
+      this.infoButton.setX(buttonX);
+      this.infoButton.setY(buttonY);
+      this.infoButton.setWidth(INFO_BUTTON_SIZE);
+      this.infoButton.setHeight(INFO_BUTTON_SIZE);
+      this.infoButton.render(graphics, mouseX, mouseY, delta);
+   }
+
+   private void renderInfoPanel(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      if (!this.infoPanelVisible) {
+         return;
+      }
+
+      Font font = Minecraft.getInstance().font;
+      TerrainPreviewWidget.InfoPanelLayout layout = this.infoPanelLayout(font);
+      graphics.fill(layout.x(), layout.y(), layout.right(), layout.bottom(), INFO_PANEL_BG);
+      graphics.renderOutline(layout.x(), layout.y(), layout.width(), layout.height(), INFO_PANEL_BORDER);
+      int textX = layout.x() + INFO_PANEL_PADDING;
+      int textY = layout.y() + INFO_PANEL_PADDING;
+      TerrainPreview.PreviewInfo info = this.preview.getInfo();
+      if (info == null) {
+         graphics.drawString(font, Component.translatable("tellus.preview.info.title"), textX, textY, INFO_TEXT, false);
+         graphics.drawString(font, Component.translatable("tellus.preview.info.loading"), textX, textY + INFO_TITLE_SPACING, INFO_SUBTLE, false);
+         this.autoAdjustButton.active = false;
+      } else {
+         graphics.drawString(font, Component.translatable("tellus.preview.info.title"), textX, textY, INFO_TEXT, false);
+         textY += INFO_TITLE_SPACING;
+         String demSummary = this.demSummary(info);
+         graphics.drawString(font, this.truncate(font, demSummary, layout.contentWidth()), textX, textY, INFO_TEXT, false);
+         textY += INFO_LINE_SPACING;
+         String resolutionSummary = this.resolutionSummary(info);
+         graphics.drawString(font, this.truncate(font, resolutionSummary, layout.contentWidth()), textX, textY, INFO_SUBTLE, false);
+         textY += INFO_LINE_SPACING;
+         if (info.hasBlendedProviders()) {
+            String blended = Component.translatable("tellus.preview.info.blended").getString() + ": " + this.providerNames(info.blendedProviders());
+            graphics.drawString(font, this.truncate(font, blended, layout.contentWidth()), textX, textY, INFO_SUBTLE, false);
+            textY += INFO_LINE_SPACING;
+         }
+
+         String altitude = Component.translatable("tellus.preview.info.highest").getString() + ": " + String.format(Locale.ROOT, "%.0f m", info.maxElevationMeters());
+         graphics.drawString(font, this.truncate(font, altitude, layout.contentWidth()), textX, textY, INFO_TEXT, false);
+         textY += INFO_TITLE_SPACING;
+         this.drawValueLine(
+            graphics,
+            font,
+            textX,
+            textY,
+            Component.translatable("tellus.preview.info.min_y").getString(),
+            Integer.toString(info.minSurfaceY()),
+            info.minWithinLimits() ? INFO_GOOD : INFO_BAD,
+            layout.contentWidth()
+         );
+         textY += INFO_LINE_SPACING;
+         this.drawValueLine(
+            graphics,
+            font,
+            textX,
+            textY,
+            Component.translatable("tellus.preview.info.max_y").getString(),
+            Integer.toString(info.maxSurfaceY()),
+            info.maxWithinLimits() ? INFO_GOOD : INFO_BAD,
+            layout.contentWidth()
+         );
+         textY += INFO_SECTION_SPACING;
+         this.autoAdjustButton.active = this.autoAdjustAction != null;
+      }
+
+      this.autoAdjustButton.setX(layout.buttonX());
+      this.autoAdjustButton.setY(layout.buttonY());
+      this.autoAdjustButton.setWidth(layout.buttonWidth());
+      this.autoAdjustButton.setHeight(20);
+      this.autoAdjustButton.render(graphics, mouseX, mouseY, delta);
+   }
+
+   private void renderFullscreenButton(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      if (this.fullscreenAction != null) {
+         int buttonX = this.getX() + this.width - FULLSCREEN_BUTTON_SIZE - FULLSCREEN_BUTTON_PADDING;
+         int buttonY = this.getY() + FULLSCREEN_BUTTON_PADDING;
+         this.fullscreenButton.setX(buttonX);
+         this.fullscreenButton.setY(buttonY);
+         this.fullscreenButton.setWidth(FULLSCREEN_BUTTON_SIZE);
+         this.fullscreenButton.setHeight(FULLSCREEN_BUTTON_SIZE);
+         this.fullscreenButton.render(graphics, mouseX, mouseY, delta);
+      }
+   }
+
+   private TerrainPreviewWidget.InfoPanelLayout infoPanelLayout(Font font) {
+      int infoButtonX = this.getX() + MODE_BUTTON_PADDING;
+      int infoButtonY = this.getY() + MODE_BUTTON_PADDING + MODE_BUTTON_HEIGHT + INFO_BUTTON_PADDING;
+      int x = infoButtonX + INFO_BUTTON_SIZE + 8;
+      int width = Math.min(INFO_PANEL_WIDTH, Math.max(190, this.getX() + this.width - x - 8));
+      TerrainPreview.PreviewInfo info = this.preview.getInfo();
+      int textLines = info == null ? 2 : 6 + (info.hasBlendedProviders() ? 1 : 0);
+      int textHeight = INFO_TITLE_SPACING + (textLines - 1) * INFO_LINE_SPACING;
+      int height = INFO_PANEL_PADDING + textHeight + INFO_SECTION_SPACING + 20 + INFO_PANEL_PADDING;
+      int buttonWidth = 110;
+      int y = infoButtonY;
+      int buttonY = y + height - 20 - INFO_PANEL_PADDING;
+      return new TerrainPreviewWidget.InfoPanelLayout(x, y, width, height, x + width - INFO_PANEL_PADDING - buttonWidth, buttonY, buttonWidth);
+   }
+
+   private boolean isMouseOverInfoPanel(double mouseX, double mouseY) {
+      if (!this.infoPanelVisible) {
+         return false;
+      } else {
+         TerrainPreviewWidget.InfoPanelLayout layout = this.infoPanelLayout(Minecraft.getInstance().font);
+         return mouseX >= layout.x() && mouseX < layout.right() && mouseY >= layout.y() && mouseY < layout.bottom();
+      }
+   }
+
+   private String demSummary(TerrainPreview.PreviewInfo info) {
+      if (info.primaryProviders().isEmpty()) {
+         return Component.translatable("tellus.preview.info.dem_unknown").getString();
+      } else if (!info.hasMixedPrimaryProviders()) {
+         return Component.translatable("tellus.preview.info.dem_main").getString() + ": " + info.mainProvider().provider().label().getString();
+      } else {
+         StringBuilder builder = new StringBuilder(Component.translatable("tellus.preview.info.dem_mix").getString()).append(": ");
+
+         for (int i = 0; i < info.primaryProviders().size(); i++) {
+            TerrainPreview.PreviewProviderShare share = info.primaryProviders().get(i);
+            if (i > 0) {
+               builder.append(", ");
+            }
+
+            builder.append(share.provider().label().getString())
+               .append(" (")
+               .append(String.format(Locale.ROOT, "%.0f%%", share.share() * 100.0))
+               .append(")");
+         }
+
+         return builder.toString();
+      }
+   }
+
+   private String providerNames(Iterable<TellusElevationSource.DemUsage> providers) {
+      StringBuilder builder = new StringBuilder();
+
+      for (TellusElevationSource.DemUsage provider : providers) {
+         if (!builder.isEmpty()) {
+            builder.append(", ");
+         }
+
+         builder.append(provider.label().getString());
+      }
+
+      return builder.toString();
+   }
+
+   private String resolutionSummary(TerrainPreview.PreviewInfo info) {
+      String label = Component.translatable("tellus.preview.info.resolution").getString();
+      if (info.primaryResolutions().isEmpty()) {
+         return label + ": " + Component.translatable("tellus.preview.info.dem_unknown").getString();
+      } else if (!info.hasMixedPrimaryResolutions()) {
+         return label + ": " + this.formatResolution(info.mainResolution().resolutionMeters());
+      } else {
+         StringBuilder builder = new StringBuilder(label).append(": ");
+
+         for (int i = 0; i < info.primaryResolutions().size(); i++) {
+            TerrainPreview.PreviewResolutionShare share = info.primaryResolutions().get(i);
+            if (i > 0) {
+               builder.append(", ");
+            }
+
+            builder.append(this.formatResolution(share.resolutionMeters()))
+               .append(" (")
+               .append(String.format(Locale.ROOT, "%.0f%%", share.share() * 100.0))
+               .append(")");
+         }
+
+         return builder.toString();
+      }
+   }
+
+   private String formatResolution(double resolutionMeters) {
+      if (!Double.isFinite(resolutionMeters) || resolutionMeters <= 0.0) {
+         return Component.translatable("tellus.preview.info.dem_unknown").getString();
+      } else if (Math.abs(resolutionMeters - Math.rint(resolutionMeters)) < 0.05) {
+         return String.format(Locale.ROOT, "%.0f m", resolutionMeters);
+      } else {
+         return String.format(Locale.ROOT, "%.1f m", resolutionMeters);
+      }
+   }
+
+   private String truncate(Font font, String text, int width) {
+      if (font.width(text) <= width) {
+         return text;
+      } else {
+         String truncated = font.plainSubstrByWidth(text, Math.max(0, width - font.width("...")));
+         return truncated + "...";
+      }
+   }
+
+   private void drawValueLine(GuiGraphics graphics, Font font, int x, int y, String label, String value, int valueColor, int width) {
+      graphics.drawString(font, label, x, y, INFO_TEXT, false);
+      int valueWidth = font.width(value);
+      int valueX = Math.min(x + font.width(label) + 16, x + Math.max(0, width - valueWidth));
+      graphics.drawString(font, value, valueX, y, valueColor, false);
+   }
+
+   @Override
+   public void close() {
+      if (this.ownsPreview) {
+         this.preview.close();
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record InfoPanelLayout(int x, int y, int width, int height, int buttonX, int buttonY, int buttonWidth) {
+      private int right() {
+         return this.x + this.width;
+      }
+
+      private int bottom() {
+         return this.y + this.height;
+      }
+
+      private int contentWidth() {
+         return this.width - INFO_PANEL_PADDING * 2;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public record ViewState(float rotationX, float rotationY, float zoom, TerrainPreviewWidget.RenderMode renderMode) {
+      public ViewState(float rotationX, float rotationY, float zoom, TerrainPreviewWidget.RenderMode renderMode) {
+         this.rotationX = rotationX;
+         this.rotationY = rotationY;
+         this.zoom = zoom;
+         this.renderMode = Objects.requireNonNull(renderMode, "renderMode");
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public static enum RenderMode {
+      FULL_DETAIL("3D+"),
+      TERRAIN_ONLY("3D");
+
+      private final Component buttonLabel;
+
+      private RenderMode(String buttonLabel) {
+         this.buttonLabel = Component.literal(buttonLabel);
+      }
+
+      private Component buttonLabel() {
+         return this.buttonLabel;
+      }
+
+      private TerrainPreviewWidget.RenderMode toggle() {
+         return this == FULL_DETAIL ? TERRAIN_ONLY : FULL_DETAIL;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/screen/EarthCustomizeScreen.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/screen/EarthCustomizeScreen.java
@@ -1,0 +1,3187 @@
+package com.yucareux.tellus.client.screen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.serialization.Lifecycle;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.config.HmaAccessConfig;
+import com.yucareux.tellus.client.preview.TerrainPreview;
+import com.yucareux.tellus.client.preview.TerrainPreviewWidget;
+import com.yucareux.tellus.client.widget.CustomizationList;
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleFunction;
+import java.util.stream.Stream;
+import net.neoforged.fml.ModList;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.components.Button.OnPress;
+import net.minecraft.client.gui.components.CycleButton.Builder;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
+import net.minecraft.core.Holder;
+import net.minecraft.core.LayeredRegistryAccess;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.Registry;
+import net.minecraft.core.HolderLookup.RegistryLookup;
+import net.minecraft.core.RegistryAccess.Frozen;
+import net.minecraft.core.RegistryAccess.ImmutableRegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.RegistryLayer;
+import net.minecraft.server.packs.repository.KnownPack;
+import net.minecraft.util.Mth;
+import net.minecraft.Util;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.levelgen.WorldDimensions;
+
+@OnlyIn(Dist.CLIENT)
+public class EarthCustomizeScreen extends Screen {
+   
+   private static final Component TITLE = Objects.requireNonNull(Component.translatable("options.tellus.customize_world_title.name"), "customizeTitle");
+   
+   private static final Component YES = Objects.requireNonNull(Component.translatable("gui.yes").withStyle(ChatFormatting.GREEN), "yesLabel");
+   
+   private static final Component NO = Objects.requireNonNull(Component.translatable("gui.no").withStyle(ChatFormatting.RED), "noLabel");
+   
+   private static final Component WORK_IN_PROGRESS = Objects.requireNonNull(
+      Component.translatable("tellus.customize.work_in_progress").withStyle(ChatFormatting.GRAY), "workInProgressLabel"
+   );
+   
+   private static final ResourceLocation DYNAMIC_DIMENSION_TYPE_ID = Objects.requireNonNull(
+      ResourceLocation.fromNamespaceAndPath("tellus", "earth_dynamic"), "dynamicDimensionTypeId"
+   );
+   
+   private static final ResourceKey<DimensionType> DYNAMIC_DIMENSION_TYPE_KEY = Objects.requireNonNull(
+      ResourceKey.create(Registries.DIMENSION_TYPE, DYNAMIC_DIMENSION_TYPE_ID), "dynamicDimensionTypeKey"
+   );
+   private static final double OSM_ROADS_AND_BUILDINGS_MAX_WORLD_SCALE = 15.0;
+   private final CreateWorldScreen parent;
+   private final List<EarthCustomizeScreen.CategoryDefinition> categories;
+   private CustomizationList list;
+   
+   private final TerrainPreview preview = new TerrainPreview();
+   private TerrainPreviewWidget previewWidget;
+   
+   private TerrainPreviewWidget.ViewState pendingPreviewViewState;
+   private String currentCategoryId;
+   private long previewDirtyAt = -1L;
+   private double spawnLatitude = 27.9881;
+   private double spawnLongitude = 86.925;
+
+   public EarthCustomizeScreen(CreateWorldScreen parent, WorldCreationContext worldCreationContext) {
+      super(TITLE);
+      this.parent = parent;
+      this.categories = this.createCategories();
+      this.applySettingsToCategories(resolveInitialSettings(worldCreationContext));
+   }
+
+   protected void init() {
+      int listTop = 40;
+      int listHeight = Math.max(0, this.height - 36 - listTop);
+      int listWidth = Math.max(140, this.width / 2 - 20);
+      int previewWidth = Math.max(140, this.width - listWidth - 40);
+      int previewHeight = Math.max(80, this.height - 80);
+      EarthGeneratorSettings settings = this.buildSettings();
+      this.list = new CustomizationList(this.minecraft, listWidth, listHeight, listTop, 20);
+      this.list.setX(10);
+      this.addRenderableWidget(this.list);
+      if (this.previewWidget != null) {
+         this.previewWidget.close();
+      }
+
+      int previewX = this.width - previewWidth - 10;
+      this.previewWidget = new TerrainPreviewWidget(previewX, listTop, previewWidth, previewHeight, this.preview);
+      this.previewWidget.setFullscreenAction(this::openPreviewFullScreen);
+      this.previewWidget.setAutoAdjustAction(this::applyPreviewAutoAdjust);
+      if (this.pendingPreviewViewState != null) {
+         this.previewWidget.setViewState(this.pendingPreviewViewState);
+         this.pendingPreviewViewState = null;
+      }
+
+      this.addRenderableWidget(this.previewWidget);
+      this.showCategories();
+      if (!settings.equals(this.preview.getLastSettings()) || !this.preview.isLoading() && this.preview.getInfo() == null) {
+         this.previewWidget.requestRebuild(settings);
+      }
+
+      int buttonY = this.height - 28;
+      Component spawnpointLabel = Objects.requireNonNull(Component.translatable("gui.earth.spawnpoint"), "spawnpointLabel");
+      this.addRenderableWidget(Button.builder(spawnpointLabel, button -> {
+         if (this.minecraft != null) {
+            this.minecraft.setScreen(new EarthSpawnpointScreen(this));
+         }
+      }).bounds(this.width / 2 - 155, buttonY, 150, 20).build());
+      Component doneLabel = Objects.requireNonNull(Component.translatable("gui.done"), "doneLabel");
+      this.addRenderableWidget(Button.builder(doneLabel, button -> this.onClose()).bounds(this.width / 2 + 5, buttonY, 150, 20).build());
+   }
+
+   private void onSettingsChanged() {
+      this.previewDirtyAt = System.currentTimeMillis();
+   }
+
+   public void applySpawnpoint(double latitude, double longitude) {
+      this.spawnLatitude = latitude;
+      this.spawnLongitude = longitude;
+      this.previewDirtyAt = System.currentTimeMillis();
+   }
+
+   public double getSpawnLatitude() {
+      return this.spawnLatitude;
+   }
+
+   public double getSpawnLongitude() {
+      return this.spawnLongitude;
+   }
+
+   private void openPreviewFullScreen() {
+      if (this.minecraft != null && this.previewWidget != null) {
+         TerrainPreviewWidget.ViewState viewState = Objects.requireNonNull(this.previewWidget.getViewState(), "viewState");
+         this.minecraft.setScreen(new TerrainPreviewScreen(this, this.preview, viewState));
+      }
+   }
+
+   public void applyPreviewViewState( TerrainPreviewWidget.ViewState state) {
+      this.pendingPreviewViewState = state;
+      if (this.previewWidget != null && this.minecraft != null && this.minecraft.screen == this) {
+         this.previewWidget.setViewState(state);
+         this.pendingPreviewViewState = null;
+      }
+   }
+
+   public EarthGeneratorSettings applyPreviewAutoAdjust(TerrainPreview.PreviewInfo info) {
+      EarthGeneratorSettings current = this.buildSettings();
+      double targetWorldScale = findBestWorldScale(current, info);
+      int targetHeightOffset = findBestHeightOffset(current, info, targetWorldScale);
+      int delta = targetHeightOffset - current.heightOffset();
+      this.setSliderValue("world_scale", targetWorldScale);
+      this.setSliderValue("height_offset", targetHeightOffset);
+      if (!current.isSeaLevelAutomatic()) {
+         this.setSliderValue("sea_level", current.seaLevel() + delta);
+      }
+
+      if (current.minAltitude() != Integer.MIN_VALUE) {
+         this.setSliderValue("min_altitude", current.minAltitude() + delta);
+      }
+
+      if (current.maxAltitude() != Integer.MIN_VALUE) {
+         this.setSliderValue("max_altitude", current.maxAltitude() + delta);
+      }
+
+      if (this.minecraft != null && this.minecraft.screen == this) {
+         this.refreshCurrentCategory();
+      }
+
+      return this.buildSettings();
+   }
+
+   public void onClose() {
+      if (this.minecraft != null) {
+         EarthGeneratorSettings settings = Objects.requireNonNull(this.buildSettings(), "generatorSettings");
+         WorldCreationContext current = Objects.requireNonNull(this.parent.getUiState().getSettings(), "worldCreationContext");
+         EarthGeneratorSettings.HeightLimits limits = Objects.requireNonNull(EarthGeneratorSettings.resolveHeightLimits(settings), "heightLimits");
+         WorldCreationContext updated = Objects.requireNonNull(updateWorldCreationContext(current, settings, limits), "updatedWorldContext");
+         this.parent.getUiState().setSettings(updated);
+         this.preview.close();
+         this.minecraft.setScreen(this.parent);
+      }
+   }
+
+   private static WorldCreationContext updateWorldCreationContext(
+      WorldCreationContext current, EarthGeneratorSettings settings, EarthGeneratorSettings.HeightLimits limits
+   ) {
+      WorldDimensions selectedDimensions = current.selectedDimensions();
+      LevelStem overworldStem = (LevelStem)selectedDimensions.get(LevelStem.OVERWORLD)
+         .orElseThrow(() -> new IllegalStateException("Overworld settings missing"));
+      Holder<DimensionType> baseType = Objects.requireNonNull(overworldStem.type(), "overworldDimensionType");
+      DimensionType updatedType = Objects.requireNonNull(
+         EarthGeneratorSettings.applyHeightLimits((DimensionType)baseType.value(), limits), "updatedDimensionType"
+      );
+      ResourceKey<DimensionType> overworldKey = Objects.requireNonNull(
+         overworldStem.type().unwrapKey().orElse(DYNAMIC_DIMENSION_TYPE_KEY), "overworldDimensionTypeKey"
+      );
+      EarthCustomizeScreen.RegistryUpdate registryUpdate = updateDimensionTypeRegistry(current.worldgenRegistries(), updatedType, overworldKey);
+      LayeredRegistryAccess<RegistryLayer> registriesWithTypes = registryUpdate.registries();
+      RegistryLookup<DimensionType> dimensionTypes = registriesWithTypes.compositeAccess().lookupOrThrow(Registries.DIMENSION_TYPE);
+      Holder<DimensionType> overworldHolder = Objects.requireNonNull(registryUpdate.holder(), "overworldDimensionTypeHolder");
+      if (Tellus.LOGGER.isInfoEnabled()) {
+         DimensionType registryType = (DimensionType)dimensionTypes.getOrThrow(overworldKey).value();
+         Tellus.LOGGER
+            .info(
+               "Tellus world settings: scale={}, minAltitude={}, maxAltitude={}, heightOffset={}, limits=[minY={}, height={}, logicalHeight={}], overworldKey={}, updatedType=[{}], registryType=[{}]",
+               new Object[]{
+                  settings.worldScale(),
+                  settings.minAltitude(),
+                  settings.maxAltitude(),
+                  settings.heightOffset(),
+                  limits.minY(),
+                  limits.height(),
+                  limits.logicalHeight(),
+                  overworldKey.location(),
+                  describeDimensionType(updatedType),
+                  describeDimensionType(registryType)
+               }
+            );
+      }
+
+      ChunkGenerator generator = Objects.requireNonNull(EarthChunkGenerator.create(registriesWithTypes.compositeAccess(), settings), "overworldGenerator");
+      WorldDimensions updatedDimensions = Objects.requireNonNull(
+         updateDimensions(selectedDimensions, overworldHolder, generator, dimensionTypes), "updatedDimensions"
+      );
+      Registry<LevelStem> updatedDatapackDimensions = Objects.requireNonNull(
+         updateDatapackDimensions(current.datapackDimensions(), overworldHolder, generator, dimensionTypes), "updatedDatapackDimensions"
+      );
+      LayeredRegistryAccess<RegistryLayer> updatedRegistries = Objects.requireNonNull(
+         updateWorldgenLevelStems(registriesWithTypes, updatedDatapackDimensions), "updatedRegistries"
+      );
+      return new WorldCreationContext(
+         current.options(),
+         updatedDatapackDimensions,
+         updatedDimensions,
+         updatedRegistries,
+         current.dataPackResources(),
+         current.dataConfiguration()
+      );
+   }
+
+   
+   private static Registry<LevelStem> updateDatapackDimensions(
+       Registry<LevelStem> source,
+       Holder<DimensionType> overworldHolder,
+       ChunkGenerator overworldGenerator,
+      RegistryLookup<DimensionType> dimensionTypes
+   ) {
+      Holder<DimensionType> safeOverworldHolder = Objects.requireNonNull(overworldHolder, "overworldHolder");
+      ChunkGenerator safeOverworldGenerator = Objects.requireNonNull(overworldGenerator, "overworldGenerator");
+      RegistryLookup<DimensionType> dimensionTypesChecked = Objects.requireNonNull(dimensionTypes, "dimensionTypes");
+      Lifecycle lifecycle = Objects.requireNonNull(
+         source instanceof MappedRegistry<LevelStem> mapped ? mapped.registryLifecycle() : Lifecycle.experimental(), "datapackDimensionsLifecycle"
+      );
+      MappedRegistry<LevelStem> copy = new MappedRegistry<>(Registries.LEVEL_STEM, lifecycle);
+      List<Entry<ResourceKey<LevelStem>, LevelStem>> entries = new ArrayList<>(source.entrySet());
+      entries.sort(Comparator.comparingInt(entryx -> source.getId((LevelStem)entryx.getValue())));
+
+      for (Entry<ResourceKey<LevelStem>, LevelStem> entry : entries) {
+         ResourceKey<LevelStem> key = Objects.requireNonNull(entry.getKey(), "dimensionStemKey");
+         LevelStem stem = Objects.requireNonNull(entry.getValue(), "dimensionStem");
+         LevelStem updatedStem;
+         if (key.equals(LevelStem.OVERWORLD)) {
+            updatedStem = new LevelStem(safeOverworldHolder, safeOverworldGenerator);
+         } else {
+            ResourceKey<DimensionType> typeKey = (ResourceKey<DimensionType>)stem.type().unwrapKey().orElse(null);
+            Holder<DimensionType> typeHolder = typeKey != null
+               ? Objects.requireNonNull(dimensionTypesChecked.getOrThrow(typeKey), "dimensionType")
+               : Objects.requireNonNull(stem.type(), "stemDimensionType");
+            updatedStem = new LevelStem(typeHolder, stem.generator());
+         }
+
+         RegistrationInfo info = Objects.requireNonNull(source.registrationInfo(key).orElse(RegistrationInfo.BUILT_IN), "dimensionStemRegistrationInfo");
+         copy.register(key, updatedStem, info);
+      }
+
+      return copy.freeze();
+   }
+
+   private static LayeredRegistryAccess<RegistryLayer> updateWorldgenLevelStems(
+      LayeredRegistryAccess<RegistryLayer> registries, Registry<LevelStem> updatedLevelStems
+   ) {
+      LayeredRegistryAccess<RegistryLayer> updated = registries;
+      boolean updatedAny = false;
+
+      for (RegistryLayer layer : RegistryLayer.values()) {
+         Frozen layerAccess = updated.getLayer(layer);
+         if (!layerAccess.lookup(Registries.LEVEL_STEM).isEmpty()) {
+            Frozen updatedLayer = replaceRegistry(layerAccess, Registries.LEVEL_STEM, updatedLevelStems);
+            updated = replaceLayer(updated, layer, updatedLayer);
+            updatedAny = true;
+         }
+      }
+
+      LayeredRegistryAccess<RegistryLayer> result = updatedAny ? updated : registries;
+      return Objects.requireNonNull(result, "updatedRegistries");
+   }
+
+   
+   private static WorldDimensions updateDimensions(
+      WorldDimensions dimensions,
+      Holder<DimensionType> overworldHolder,
+      ChunkGenerator overworldGenerator,
+      RegistryLookup<DimensionType> dimensionTypes
+   ) {
+      Holder<DimensionType> safeOverworldHolder = Objects.requireNonNull(overworldHolder, "overworldHolder");
+      ChunkGenerator safeOverworldGenerator = Objects.requireNonNull(overworldGenerator, "overworldGenerator");
+      RegistryLookup<DimensionType> dimensionTypesChecked = Objects.requireNonNull(dimensionTypes, "dimensionTypes");
+      Map<ResourceKey<LevelStem>, LevelStem> updatedStems = new LinkedHashMap<>();
+      dimensions.dimensions()
+         .forEach(
+            (key, stem) -> {
+               Holder<DimensionType> typeHolder;
+               if (key.equals(LevelStem.OVERWORLD)) {
+                  typeHolder = safeOverworldHolder;
+               } else {
+                  ResourceKey<DimensionType> typeKey = (ResourceKey<DimensionType>)stem.type().unwrapKey().orElse(null);
+                  typeHolder = typeKey != null
+                     ? Objects.requireNonNull(dimensionTypesChecked.getOrThrow(typeKey), "dimensionType")
+                     : Objects.requireNonNull(stem.type(), "stemDimensionType");
+               }
+
+               updatedStems.put((ResourceKey<LevelStem>)key, new LevelStem(typeHolder, stem.generator()));
+            }
+         );
+      return new WorldDimensions(WorldDimensions.withOverworld(updatedStems, safeOverworldHolder, safeOverworldGenerator));
+   }
+
+   public void tick() {
+      super.tick();
+      if (this.previewWidget != null) {
+         this.previewWidget.tick();
+      }
+
+      if (this.previewDirtyAt > 0L && System.currentTimeMillis() - this.previewDirtyAt >= 350L) {
+         this.previewDirtyAt = -1L;
+         if (this.previewWidget != null) {
+            this.previewWidget.requestRebuild(this.buildSettings());
+         }
+      }
+   }
+
+   public void removed() {
+      if (this.previewWidget != null) {
+         this.previewWidget.close();
+      }
+
+      super.removed();
+   }
+
+   
+   private EarthGeneratorSettings buildSettings() {
+      double worldScale = this.findSliderValue("world_scale", EarthGeneratorSettings.DEFAULT.worldScale());
+      EarthGeneratorSettings.DemSelection demSelection = this.buildDemSelection();
+      double terrestrialScale = this.findSliderValue("terrestrial_height_scale", EarthGeneratorSettings.DEFAULT.terrestrialHeightScale());
+      double oceanicScale = this.findSliderValue("oceanic_height_scale", EarthGeneratorSettings.DEFAULT.oceanicHeightScale());
+      int heightOffset = (int)Math.round(this.findSliderValue("height_offset", EarthGeneratorSettings.DEFAULT.heightOffset()));
+      int seaLevel = this.resolveSeaLevelSetting("sea_level", -64.0);
+      int maxAltitude = this.resolveAltitudeSetting("max_altitude", -1.0);
+      int minAltitude = this.resolveAltitudeSetting("min_altitude", -2048.0);
+      int riverLakeShorelineBlend = (int)Math.round(
+         this.findSliderValue("river_lake_shoreline_blend", EarthGeneratorSettings.DEFAULT.riverLakeShorelineBlend())
+      );
+      int oceanShorelineBlend = (int)Math.round(this.findSliderValue("ocean_shoreline_blend", EarthGeneratorSettings.DEFAULT.oceanShorelineBlend()));
+      boolean shorelineBlendCliffLimit = this.findToggleValue("shoreline_blend_cliff_limit", EarthGeneratorSettings.DEFAULT.shorelineBlendCliffLimit());
+      boolean caveGeneration = this.findToggleValue("cave_generation", EarthGeneratorSettings.DEFAULT.caveGeneration());
+      boolean oreDistribution = this.findToggleValue("ore_distribution", EarthGeneratorSettings.DEFAULT.oreDistribution());
+      boolean lavaPools = this.findToggleValue("lava_pools", EarthGeneratorSettings.DEFAULT.lavaPools());
+      boolean enableRoads = this.findToggleValue("enable_roads", EarthGeneratorSettings.DEFAULT.enableRoads());
+      boolean enableBuildings = this.findToggleValue("enable_buildings", EarthGeneratorSettings.DEFAULT.enableBuildings());
+      boolean enableWater = this.findToggleValue("enable_water", EarthGeneratorSettings.DEFAULT.enableWater());
+      boolean deepDark = this.findToggleValue("deep_dark", EarthGeneratorSettings.DEFAULT.deepDark());
+      boolean geodes = this.findToggleValue("geodes", EarthGeneratorSettings.DEFAULT.geodes());
+      boolean addStrongholds = this.findToggleValue("add_strongholds", EarthGeneratorSettings.DEFAULT.addStrongholds());
+      boolean addVillages = this.findToggleValue("add_villages", EarthGeneratorSettings.DEFAULT.addVillages());
+      boolean addMineshafts = this.findToggleValue("add_mineshafts", EarthGeneratorSettings.DEFAULT.addMineshafts());
+      boolean addOceanMonuments = this.findToggleValue("add_ocean_monuments", EarthGeneratorSettings.DEFAULT.addOceanMonuments());
+      boolean addWoodlandMansions = this.findToggleValue("add_woodland_mansions", EarthGeneratorSettings.DEFAULT.addWoodlandMansions());
+      boolean addDesertTemples = this.findToggleValue("add_desert_temples", EarthGeneratorSettings.DEFAULT.addDesertTemples());
+      boolean addJungleTemples = this.findToggleValue("add_jungle_temples", EarthGeneratorSettings.DEFAULT.addJungleTemples());
+      boolean addPillagerOutposts = this.findToggleValue("add_pillager_outposts", EarthGeneratorSettings.DEFAULT.addPillagerOutposts());
+      boolean addRuinedPortals = this.findToggleValue("add_ruined_portals", EarthGeneratorSettings.DEFAULT.addRuinedPortals());
+      boolean addShipwrecks = this.findToggleValue("add_shipwrecks", EarthGeneratorSettings.DEFAULT.addShipwrecks());
+      boolean addOceanRuins = this.findToggleValue("add_ocean_ruins", EarthGeneratorSettings.DEFAULT.addOceanRuins());
+      boolean addBuriedTreasure = this.findToggleValue("add_buried_treasure", EarthGeneratorSettings.DEFAULT.addBuriedTreasure());
+      boolean addIgloos = this.findToggleValue("add_igloos", EarthGeneratorSettings.DEFAULT.addIgloos());
+      boolean addWitchHuts = this.findToggleValue("add_witch_huts", EarthGeneratorSettings.DEFAULT.addWitchHuts());
+      boolean addAncientCities = this.findToggleValue("add_ancient_cities", EarthGeneratorSettings.DEFAULT.addAncientCities());
+      boolean addTrialChambers = this.findToggleValue("add_trial_chambers", EarthGeneratorSettings.DEFAULT.addTrialChambers());
+      boolean addTrailRuins = this.findToggleValue("add_trail_ruins", EarthGeneratorSettings.DEFAULT.addTrailRuins());
+      boolean distantHorizonsWaterResolver = this.findToggleValue(
+         "distant_horizons_water_resolver", EarthGeneratorSettings.DEFAULT.distantHorizonsWaterResolver()
+      );
+      boolean distantHorizonsOsmFeatures = EarthGeneratorSettings.DEFAULT.distantHorizonsOsmFeatures();
+      int distantHorizonsOsmRoadMaxDetail = EarthGeneratorSettings.DEFAULT.distantHorizonsOsmRoadMaxDetail();
+      int distantHorizonsOsmBuildingMaxDetail = EarthGeneratorSettings.DEFAULT.distantHorizonsOsmBuildingMaxDetail();
+      boolean distantHorizonsOsmNonBlockingFetch = EarthGeneratorSettings.DEFAULT.distantHorizonsOsmNonBlockingFetch();
+      boolean realtimeTime = this.findToggleValue("realtime_time", EarthGeneratorSettings.DEFAULT.realtimeTime());
+      boolean realtimeWeather = this.findToggleValue("realtime_weather", EarthGeneratorSettings.DEFAULT.realtimeWeather());
+      boolean historicalSnow = false;
+      boolean voxyChunkPregenEnabled = this.findToggleValue("voxy_chunk_pregen_enabled", EarthGeneratorSettings.DEFAULT.voxyChunkPregenEnabled());
+      int voxyChunkPregenMaxRadius = (int)Math.round(
+         this.findSliderValue("voxy_chunk_pregen_max_radius", EarthGeneratorSettings.DEFAULT.voxyChunkPregenMaxRadius())
+      );
+      int voxyChunkPregenChunksPerTick = (int)Math.round(
+         this.findSliderValue("voxy_chunk_pregen_chunks_per_tick", EarthGeneratorSettings.DEFAULT.voxyChunkPregenChunksPerTick())
+      );
+      EarthGeneratorSettings.DistantHorizonsRenderMode renderMode = this.findRenderMode(
+         "distant_horizons_render_mode", EarthGeneratorSettings.DEFAULT.distantHorizonsRenderMode()
+      );
+      if (!roadsAndBuildingsSupportedForWorldScale(worldScale)) {
+         enableRoads = false;
+         enableBuildings = false;
+      }
+
+      if (renderMode == EarthGeneratorSettings.DistantHorizonsRenderMode.ULTRA_FAST) {
+         distantHorizonsWaterResolver = false;
+      }
+
+      return new EarthGeneratorSettings(
+         worldScale,
+         terrestrialScale,
+         oceanicScale,
+         heightOffset,
+         seaLevel,
+         this.spawnLatitude,
+         this.spawnLongitude,
+         minAltitude,
+         maxAltitude,
+         riverLakeShorelineBlend,
+         oceanShorelineBlend,
+         shorelineBlendCliffLimit,
+         caveGeneration,
+         oreDistribution,
+         lavaPools,
+         addStrongholds,
+         addVillages,
+         addMineshafts,
+         addOceanMonuments,
+         addWoodlandMansions,
+         addDesertTemples,
+         addJungleTemples,
+         addPillagerOutposts,
+         addRuinedPortals,
+         addShipwrecks,
+         addOceanRuins,
+         addBuriedTreasure,
+         addIgloos,
+         addWitchHuts,
+         addAncientCities,
+         addTrialChambers,
+         addTrailRuins,
+         deepDark,
+         geodes,
+         distantHorizonsWaterResolver,
+         distantHorizonsOsmFeatures,
+         distantHorizonsOsmRoadMaxDetail,
+         distantHorizonsOsmBuildingMaxDetail,
+         distantHorizonsOsmNonBlockingFetch,
+         realtimeTime,
+         realtimeWeather,
+         historicalSnow,
+         voxyChunkPregenEnabled,
+         voxyChunkPregenMaxRadius,
+         voxyChunkPregenChunksPerTick,
+         renderMode,
+         demSelection,
+         enableRoads,
+         enableBuildings,
+         enableWater
+      );
+   }
+
+   private static EarthGeneratorSettings resolveInitialSettings(WorldCreationContext worldCreationContext) {
+      EarthGeneratorSettings defaultSettings = Objects.requireNonNull(EarthGeneratorSettings.DEFAULT, "defaultSettings");
+      if (worldCreationContext == null) {
+         return defaultSettings;
+      } else {
+         LevelStem overworld = (LevelStem)worldCreationContext.selectedDimensions().get(LevelStem.OVERWORLD).orElse(null);
+         if (overworld == null) {
+            return defaultSettings;
+         } else {
+            return overworld.generator() instanceof EarthChunkGenerator earthGenerator
+               ? Objects.requireNonNull(earthGenerator.settings(), "generatorSettings")
+               : defaultSettings;
+         }
+      }
+   }
+
+   private void applySettingsToCategories(EarthGeneratorSettings settings) {
+      this.applySettingsToCategories(settings, false);
+   }
+
+   private void applySettingsToCategories(EarthGeneratorSettings settings, boolean preserveSpawnpoint) {
+      EarthGeneratorSettings initialSettings = Objects.requireNonNull(settings, "initialSettings");
+      if (!preserveSpawnpoint) {
+         this.spawnLatitude = initialSettings.spawnLatitude();
+         this.spawnLongitude = initialSettings.spawnLongitude();
+      }
+
+      this.setSliderValue("world_scale", initialSettings.worldScale());
+      this.setDemSelectionValue(initialSettings.demSelection());
+      this.setSliderValue("terrestrial_height_scale", initialSettings.terrestrialHeightScale());
+      this.setSliderValue("oceanic_height_scale", initialSettings.oceanicHeightScale());
+      this.setSliderValue("height_offset", initialSettings.heightOffset());
+      this.setSliderValue("sea_level", initialSettings.seaLevel() == -2147483647 ? -64.0 : initialSettings.seaLevel());
+      this.setSliderValue("max_altitude", initialSettings.maxAltitude() == Integer.MIN_VALUE ? -1.0 : initialSettings.maxAltitude());
+      this.setSliderValue("min_altitude", initialSettings.minAltitude() == Integer.MIN_VALUE ? -2048.0 : initialSettings.minAltitude());
+      this.setSliderValue("river_lake_shoreline_blend", initialSettings.riverLakeShorelineBlend());
+      this.setSliderValue("ocean_shoreline_blend", initialSettings.oceanShorelineBlend());
+      this.setToggleValue("shoreline_blend_cliff_limit", initialSettings.shorelineBlendCliffLimit());
+      this.setToggleValue("cave_generation", initialSettings.caveGeneration());
+      this.setToggleValue("ore_distribution", initialSettings.oreDistribution());
+      this.setToggleValue("lava_pools", initialSettings.lavaPools());
+      this.setToggleValue("enable_roads", initialSettings.enableRoads());
+      this.setToggleValue("enable_buildings", initialSettings.enableBuildings());
+      this.setToggleValue("enable_water", initialSettings.enableWater());
+      this.setToggleValue("deep_dark", initialSettings.deepDark());
+      this.setToggleValue("geodes", initialSettings.geodes());
+      this.setToggleValue("add_strongholds", initialSettings.addStrongholds());
+      this.setToggleValue("add_villages", initialSettings.addVillages());
+      this.setToggleValue("add_mineshafts", initialSettings.addMineshafts());
+      this.setToggleValue("add_ocean_monuments", initialSettings.addOceanMonuments());
+      this.setToggleValue("add_woodland_mansions", initialSettings.addWoodlandMansions());
+      this.setToggleValue("add_desert_temples", initialSettings.addDesertTemples());
+      this.setToggleValue("add_jungle_temples", initialSettings.addJungleTemples());
+      this.setToggleValue("add_pillager_outposts", initialSettings.addPillagerOutposts());
+      this.setToggleValue("add_ruined_portals", initialSettings.addRuinedPortals());
+      this.setToggleValue("add_shipwrecks", initialSettings.addShipwrecks());
+      this.setToggleValue("add_ocean_ruins", initialSettings.addOceanRuins());
+      this.setToggleValue("add_buried_treasure", initialSettings.addBuriedTreasure());
+      this.setToggleValue("add_igloos", initialSettings.addIgloos());
+      this.setToggleValue("add_witch_huts", initialSettings.addWitchHuts());
+      this.setToggleValue("add_ancient_cities", initialSettings.addAncientCities());
+      this.setToggleValue("add_trial_chambers", initialSettings.addTrialChambers());
+      this.setToggleValue("add_trail_ruins", initialSettings.addTrailRuins());
+      this.setToggleValue("distant_horizons_water_resolver", initialSettings.distantHorizonsWaterResolver());
+      this.setToggleValue("realtime_time", initialSettings.realtimeTime());
+      this.setToggleValue("realtime_weather", initialSettings.realtimeWeather());
+      this.setToggleValue("historical_snow", false);
+      this.setToggleValue("voxy_chunk_pregen_enabled", initialSettings.voxyChunkPregenEnabled());
+      this.setSliderValue("voxy_chunk_pregen_max_radius", initialSettings.voxyChunkPregenMaxRadius());
+      this.setSliderValue("voxy_chunk_pregen_chunks_per_tick", initialSettings.voxyChunkPregenChunksPerTick());
+      this.setRenderModeValue("distant_horizons_render_mode", initialSettings.distantHorizonsRenderMode());
+   }
+
+   private void setSliderValue(String key, double value) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.SliderDefinition slider && slider.key.equals(key)) {
+               slider.value = Mth.clamp(value, slider.min, slider.max);
+               return;
+            }
+         }
+      }
+   }
+
+   private void setToggleValue(String key, boolean value) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals(key)) {
+               toggle.value = value;
+               return;
+            }
+         }
+      }
+   }
+
+   private void setRenderModeValue(String key, EarthGeneratorSettings.DistantHorizonsRenderMode value) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ModeDefinition mode && mode.key.equals(key)) {
+               mode.value = value;
+               return;
+            }
+         }
+      }
+   }
+
+   private void setDemSelectionValue(EarthGeneratorSettings.DemSelection demSelection) {
+      EarthGeneratorSettings.DemSelection normalized = Objects.requireNonNull(demSelection, "demSelection");
+      this.setToggleValue("dem_automatic", normalized.automatic());
+      for (EarthGeneratorSettings.DemProvider provider : EarthGeneratorSettings.DemSelection.userSelectableProviders()) {
+         this.setDemProviderToggleValue(provider, normalized.isEnabled(provider));
+      }
+   }
+
+   private void setDemProviderToggleValue(EarthGeneratorSettings.DemProvider provider, boolean value) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.DemProviderToggleDefinition providerToggle && providerToggle.provider == provider) {
+               providerToggle.value = value;
+               return;
+            }
+         }
+      }
+   }
+
+   private double findSliderValue(String key, double fallback) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.SliderDefinition slider && slider.key.equals(key)) {
+               return slider.value;
+            }
+         }
+      }
+
+      return fallback;
+   }
+
+   private boolean findToggleValue(String key, boolean fallback) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals(key)) {
+               return toggle.value;
+            }
+         }
+      }
+
+      return fallback;
+   }
+
+   private EarthGeneratorSettings.DistantHorizonsRenderMode findRenderMode(String key, EarthGeneratorSettings.DistantHorizonsRenderMode fallback) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ModeDefinition mode && mode.key.equals(key)) {
+               return mode.value;
+            }
+         }
+      }
+
+      return fallback;
+   }
+
+   private boolean findDemProviderToggleValue(EarthGeneratorSettings.DemProvider provider, boolean fallback) {
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.DemProviderToggleDefinition providerToggle && providerToggle.provider == provider) {
+               return providerToggle.value;
+            }
+         }
+      }
+
+      return fallback;
+   }
+
+   private EarthGeneratorSettings.DemSelection buildDemSelection() {
+      boolean automatic = this.findToggleValue("dem_automatic", EarthGeneratorSettings.DEFAULT.demSelection().automatic());
+      int enabledProviderMask = 0;
+
+      for (EarthGeneratorSettings.DemProvider provider : EarthGeneratorSettings.DemSelection.userSelectableProviders()) {
+         boolean enabled = this.findDemProviderToggleValue(
+            provider, EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(provider)
+         );
+         if (enabled) {
+            enabledProviderMask |= provider.selectionBit();
+         }
+      }
+
+      return automatic ? EarthGeneratorSettings.DemSelection.automaticSelection() : EarthGeneratorSettings.DemSelection.manual(enabledProviderMask);
+   }
+
+   public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      super.render(graphics, mouseX, mouseY, delta);
+      graphics.drawCenteredString(this.font, this.title, this.width / 2, 20, 16777215);
+   }
+
+   private List<EarthCustomizeScreen.CategoryDefinition> createCategories() {
+      List<EarthCustomizeScreen.CategoryDefinition> categories = new ArrayList<>();
+      boolean distantHorizonsInstalled = ModList.get().isLoaded("distanthorizons");
+      boolean voxyInstalled = ModList.get().isLoaded("voxy");
+      EarthCustomizeScreen.HmaTokenDefinition hmaToken = new EarthCustomizeScreen.HmaTokenDefinition(HmaAccessManager.savedToken());
+      EarthCustomizeScreen.CategoryDefinition hmaAccessCategory = new EarthCustomizeScreen.CategoryDefinition(
+         "hma_access", hmaAccessEntries(hmaToken)
+      ).hideFromRoot().parent("world");
+      EarthCustomizeScreen.CategoryDefinition demProvidersCategory = new EarthCustomizeScreen.CategoryDefinition(
+         "dem_providers",
+         List.of(
+            toggle("dem_automatic", EarthGeneratorSettings.DEFAULT.demSelection().automatic()),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.TERRARIUM, EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.TERRARIUM)
+            ),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.SWISSALTI3D,
+               EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.SWISSALTI3D)
+            ),
+            demProviderToggle(EarthGeneratorSettings.DemProvider.AHN, EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.AHN)),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.CANELEVATION,
+               EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.CANELEVATION)
+            ),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.NORWAYDTM1,
+               EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.NORWAYDTM1)
+            ),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.JAPANGSI,
+               EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.JAPANGSI)
+            ),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.USGS, EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.USGS)
+            ),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.COPERNICUS,
+               EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.COPERNICUS)
+            ),
+            demProviderToggle(
+               EarthGeneratorSettings.DemProvider.ARCTICDEM,
+               EarthGeneratorSettings.DEFAULT.demSelection().isEnabled(EarthGeneratorSettings.DemProvider.ARCTICDEM)
+            )
+         )
+      ).hideFromRoot().parent("world");
+      List<EarthCustomizeScreen.SettingDefinition> worldSettings = new ArrayList<>(
+         List.of(
+            slider("world_scale", 30.0, 1.0, 500.0, 5.0)
+               .withDisplay(EarthCustomizeScreen::formatWorldScale)
+               .withScale(EarthCustomizeScreen.SliderScale.power(3.0)),
+            this.categoryLink(demProvidersCategory)
+               .withLabel(Component.translatable("property.tellus.dem_provider.name"))
+               .withTooltip(Component.translatable("property.tellus.dem_provider.tooltip").withStyle(ChatFormatting.GRAY))
+         )
+      );
+      worldSettings.add(
+         this.categoryLink(hmaAccessCategory)
+            .active(false)
+            .withTooltip(Component.translatable("tellus.hma_access.button.tooltip").withStyle(ChatFormatting.GRAY))
+      );
+      worldSettings.addAll(
+         List.of(
+            slider("terrestrial_height_scale", 1.0, 0.0, 50.0, 0.5)
+               .withDisplay(EarthCustomizeScreen::formatMultiplier)
+               .withScale(EarthCustomizeScreen.SliderScale.power(3.0)),
+            slider("oceanic_height_scale", 1.0, 0.0, 50.0, 0.5)
+               .withDisplay(EarthCustomizeScreen::formatMultiplier)
+               .withScale(EarthCustomizeScreen.SliderScale.power(3.0)),
+            slider("height_offset", EarthGeneratorSettings.DEFAULT.heightOffset(), -2000.0, 128.0, 1.0)
+               .withDisplay(EarthCustomizeScreen::formatHeightOffset),
+            slider("sea_level", -64.0, -64.0, 256.0, 1.0).withDisplay(EarthCustomizeScreen::formatSeaLevel),
+            slider("max_altitude", -1.0, -1.0, 2031.0, 16.0).withDisplay(EarthCustomizeScreen::formatMaxAltitude),
+            slider("min_altitude", EarthGeneratorSettings.DEFAULT.minAltitude(), -2048.0, 2031.0, 16.0).withDisplay(EarthCustomizeScreen::formatMinAltitude),
+            slider("river_lake_shoreline_blend", EarthGeneratorSettings.DEFAULT.riverLakeShorelineBlend(), 0.0, 10.0, 1.0)
+               .withDisplay(EarthCustomizeScreen::formatHeightOffset),
+            slider("ocean_shoreline_blend", EarthGeneratorSettings.DEFAULT.oceanShorelineBlend(), 0.0, 10.0, 1.0)
+               .withDisplay(EarthCustomizeScreen::formatHeightOffset),
+            toggle("shoreline_blend_cliff_limit", EarthGeneratorSettings.DEFAULT.shorelineBlendCliffLimit())
+         )
+      );
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition("world", worldSettings)
+      );
+      categories.add(demProvidersCategory);
+      categories.add(hmaAccessCategory);
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "openstreetmaps_features",
+            List.of(
+               toggle("enable_roads", EarthGeneratorSettings.DEFAULT.enableRoads()),
+               toggle("enable_buildings", EarthGeneratorSettings.DEFAULT.enableBuildings()),
+               toggle("enable_water", EarthGeneratorSettings.DEFAULT.enableWater())
+            )
+         )
+      );
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "ecological",
+            List.of(
+               toggle("land_vegetation", true).locked(true),
+               slider("land_vegetation_density", 100.0, 0.0, 200.0, 5.0).withDisplay(EarthCustomizeScreen::formatPercent).locked(true),
+               slider("trees_density", 100.0, 0.0, 200.0, 5.0).withDisplay(EarthCustomizeScreen::formatPercent).locked(true),
+               toggle("aquatic_vegetation", true).locked(true),
+               toggle("crops_in_villages", true).locked(true)
+            )
+         )
+      );
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "geological",
+            List.of(
+               toggle("cave_generation", EarthGeneratorSettings.DEFAULT.caveGeneration()),
+               toggle("ore_distribution", EarthGeneratorSettings.DEFAULT.oreDistribution()),
+               toggle("lava_pools", EarthGeneratorSettings.DEFAULT.lavaPools())
+            )
+         )
+      );
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "structure",
+            List.of(
+               toggle("add_strongholds", EarthGeneratorSettings.DEFAULT.addStrongholds()),
+               toggle("add_villages", EarthGeneratorSettings.DEFAULT.addVillages()),
+               toggle("add_mineshafts", EarthGeneratorSettings.DEFAULT.addMineshafts()),
+               toggle("add_ocean_monuments", EarthGeneratorSettings.DEFAULT.addOceanMonuments()),
+               toggle("add_woodland_mansions", EarthGeneratorSettings.DEFAULT.addWoodlandMansions()),
+               toggle("add_desert_temples", EarthGeneratorSettings.DEFAULT.addDesertTemples()),
+               toggle("add_jungle_temples", EarthGeneratorSettings.DEFAULT.addJungleTemples()),
+               toggle("add_pillager_outposts", EarthGeneratorSettings.DEFAULT.addPillagerOutposts()),
+               toggle("add_ruined_portals", EarthGeneratorSettings.DEFAULT.addRuinedPortals()),
+               toggle("add_shipwrecks", EarthGeneratorSettings.DEFAULT.addShipwrecks()),
+               toggle("add_ocean_ruins", EarthGeneratorSettings.DEFAULT.addOceanRuins()),
+               toggle("add_buried_treasure", EarthGeneratorSettings.DEFAULT.addBuriedTreasure()),
+               toggle("add_igloos", EarthGeneratorSettings.DEFAULT.addIgloos()),
+               toggle("add_witch_huts", EarthGeneratorSettings.DEFAULT.addWitchHuts()),
+               toggle("add_ancient_cities", EarthGeneratorSettings.DEFAULT.addAncientCities()),
+               toggle("add_trial_chambers", EarthGeneratorSettings.DEFAULT.addTrialChambers()),
+               toggle("add_trail_ruins", EarthGeneratorSettings.DEFAULT.addTrailRuins()),
+               toggle("deep_dark", EarthGeneratorSettings.DEFAULT.deepDark()),
+               toggle("geodes", EarthGeneratorSettings.DEFAULT.geodes())
+            )
+         )
+      );
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "realtime",
+            List.of(
+               toggle("realtime_time", EarthGeneratorSettings.DEFAULT.realtimeTime()),
+               toggle("realtime_weather", EarthGeneratorSettings.DEFAULT.realtimeWeather()),
+               toggle("historical_snow", false).forceDisabled(true, historicalSnowReworkTooltip())
+            )
+         )
+      );
+      EarthCustomizeScreen.CategoryDefinition distantHorizonsCategory = Objects.requireNonNull(
+         new EarthCustomizeScreen.CategoryDefinition(
+               "distant_horizons",
+               List.of(
+                  mode("distant_horizons_render_mode", EarthGeneratorSettings.DEFAULT.distantHorizonsRenderMode()),
+                  toggle("distant_horizons_water_resolver", EarthGeneratorSettings.DEFAULT.distantHorizonsWaterResolver())
+               )
+            )
+            .hideFromRoot()
+            .parent("compatibility"),
+         "distantHorizonsCategory"
+      );
+      EarthCustomizeScreen.CategoryDefinition voxyCategory = Objects.requireNonNull(
+         new EarthCustomizeScreen.CategoryDefinition(
+               "voxy",
+               List.of(
+                  toggle("voxy_chunk_pregen_enabled", EarthGeneratorSettings.DEFAULT.voxyChunkPregenEnabled()),
+                  slider("voxy_chunk_pregen_max_radius", EarthGeneratorSettings.DEFAULT.voxyChunkPregenMaxRadius(), 0.0, 512.0, 1.0)
+                     .withDisplay(EarthCustomizeScreen::formatChunkRadius),
+                  slider("voxy_chunk_pregen_chunks_per_tick", EarthGeneratorSettings.DEFAULT.voxyChunkPregenChunksPerTick(), 1.0, 200.0, 1.0)
+                     .withDisplay(EarthCustomizeScreen::formatChunksPerTick)
+               )
+            )
+            .hideFromRoot()
+            .parent("compatibility"),
+         "voxyCategory"
+      );
+      if (!distantHorizonsInstalled) {
+         disableCategoryForMissingMod(distantHorizonsCategory, "distanthorizons");
+      }
+
+      if (!voxyInstalled) {
+         disableCategoryForMissingMod(voxyCategory, "voxy");
+      }
+
+      List<EarthCustomizeScreen.SettingDefinition> compatibilitySettings = new ArrayList<>();
+      compatibilitySettings.add(
+         this.categoryLink(distantHorizonsCategory)
+            .active(distantHorizonsInstalled)
+            .withTooltip(distantHorizonsInstalled ? null : requiresModTooltip("distanthorizons"))
+      );
+      compatibilitySettings.add(this.categoryLink(voxyCategory).active(voxyInstalled).withTooltip(voxyInstalled ? null : requiresModTooltip("voxy")));
+      if (distantHorizonsInstalled && voxyInstalled) {
+         compatibilitySettings.add(infoSubtle(Component.translatable("tellus.compatibility.both_mods_warning")));
+         compatibilitySettings.add(infoSubtle(Component.translatable("tellus.compatibility.priority_warning")));
+         compatibilitySettings.add(infoSubtle(Component.translatable("tellus.compatibility.exclusive_warning")));
+      }
+
+      compatibilitySettings.add(comingSoonButton());
+      categories.add(new EarthCustomizeScreen.CategoryDefinition("compatibility", compatibilitySettings));
+      categories.add(distantHorizonsCategory);
+      categories.add(voxyCategory);
+      categories.add(
+         new EarthCustomizeScreen.CategoryDefinition(
+            "cache",
+            List.of(
+               cacheEntry(EarthCustomizeScreen.CacheMetric.OSM, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.ESA, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.KOPPEN, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.TERRAIN, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.SWISSALTI3D, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.AHN, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.CANELEVATION, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.NORWAYDTM1, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.JAPANGSI, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.ARCTICDEM, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.USGS, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.COPERNICUS, true),
+               cacheEntry(EarthCustomizeScreen.CacheMetric.TOTAL, false),
+               cacheActionButton(Component.translatable("tellus.cache.delete_all"), EarthCustomizeScreen.CacheManager::deleteAll)
+            )
+         )
+      );
+      categories.add(new EarthCustomizeScreen.CategoryDefinition("data_sources", dataSourcesEntries()));
+      return categories;
+   }
+
+   private static EarthCustomizeScreen.SliderDefinition slider(String key, double defaultValue, double min, double max, double step) {
+      return new EarthCustomizeScreen.SliderDefinition(key, defaultValue, min, max, step);
+   }
+
+   private static EarthCustomizeScreen.ToggleDefinition toggle(String key, boolean defaultValue) {
+      return new EarthCustomizeScreen.ToggleDefinition(key, defaultValue);
+   }
+
+   private static EarthCustomizeScreen.DemProviderToggleDefinition demProviderToggle(
+      EarthGeneratorSettings.DemProvider provider, boolean defaultValue
+   ) {
+      return new EarthCustomizeScreen.DemProviderToggleDefinition(provider, defaultValue);
+   }
+
+   private static EarthCustomizeScreen.ModeDefinition mode(String key, EarthGeneratorSettings.DistantHorizonsRenderMode defaultValue) {
+      return new EarthCustomizeScreen.ModeDefinition(key, defaultValue);
+   }
+
+   private static List<EarthCustomizeScreen.SettingDefinition> hmaAccessEntries(EarthCustomizeScreen.HmaTokenDefinition tokenDefinition) {
+      List<EarthCustomizeScreen.SettingDefinition> entries = new ArrayList<>();
+      entries.add(infoHeader("High Mountain Asia 8 m Access"));
+      entries.add(infoLine("Tellus can use NSIDC High Mountain Asia 8 m DEM tiles, but Earthdata access is required."));
+      entries.add(infoSubtle("1. Create an Earthdata account."));
+      entries.add(infoLink("https://urs.earthdata.nasa.gov/users/new"));
+      entries.add(infoSubtle("2. Follow the Earthdata token guide and generate a bearer token."));
+      entries.add(infoLink("https://urs.earthdata.nasa.gov/documentation/for_users/user_token"));
+      entries.add(infoSubtle("3. Paste the bearer token below and test it."));
+      entries.add(infoSubtle(Component.translatable("tellus.hma_access.instruction.test_before_save")));
+      entries.add(infoSubtle("Stored locally in config/tellus-hma-access.properties on this computer."));
+      entries.add(infoSpacer());
+      entries.add(infoSubtle("Earthdata bearer token"));
+      entries.add(tokenDefinition);
+      entries.add(new EarthCustomizeScreen.HmaAccessButtonsDefinition(tokenDefinition));
+      entries.add(new EarthCustomizeScreen.HmaAccessStatusDefinition());
+      entries.add(infoSpacer());
+      return entries;
+   }
+
+   private EarthCustomizeScreen.CategoryLinkDefinition categoryLink( EarthCustomizeScreen.CategoryDefinition targetCategory) {
+      return new EarthCustomizeScreen.CategoryLinkDefinition(targetCategory);
+   }
+
+   private static void disableCategoryForMissingMod( EarthCustomizeScreen.CategoryDefinition category,  String modId) {
+      Component tooltip = requiresModTooltip(modId);
+
+      for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+         if (setting instanceof EarthCustomizeScreen.ModeDefinition mode) {
+            mode.unavailable(tooltip);
+         } else if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle) {
+            toggle.unavailable(tooltip);
+         } else if (setting instanceof EarthCustomizeScreen.SliderDefinition slider) {
+            slider.unavailable(tooltip);
+         }
+      }
+   }
+
+   private static EarthCustomizeScreen.ButtonDefinition comingSoonButton() {
+      Component label = Objects.requireNonNull(Component.translatable("gui.tellus.coming_soon"), "comingSoonLabel");
+      Component tooltip = Objects.requireNonNull(
+         Component.translatable("tellus.customize.coming_soon").withStyle(ChatFormatting.GRAY).copy().append(" ").append(WORK_IN_PROGRESS),
+         "comingSoonTooltip"
+      );
+      return new EarthCustomizeScreen.ButtonDefinition(label, tooltip, false);
+   }
+
+   private static EarthCustomizeScreen.CacheEntryDefinition cacheEntry(EarthCustomizeScreen.CacheMetric metric, boolean allowDelete) {
+      return new EarthCustomizeScreen.CacheEntryDefinition(metric, allowDelete);
+   }
+
+   private static EarthCustomizeScreen.CacheActionDefinition cacheActionButton( Component label,  Runnable action) {
+      return new EarthCustomizeScreen.CacheActionDefinition(label, action);
+   }
+
+   private static List<EarthCustomizeScreen.SettingDefinition> dataSourcesEntries() {
+      List<EarthCustomizeScreen.SettingDefinition> entries = new ArrayList<>();
+      entries.add(infoHeader("ESA WorldCover 2021 (land cover)"));
+      entries.add(infoLine("ESA WorldCover 2021 (10 m land cover, v200)"));
+      entries.add(infoLine("© ESA WorldCover project / Contains modified Copernicus Sentinel data (2021)"));
+      entries.add(infoLine("processed by ESA WorldCover consortium."));
+      entries.add(infoSubtle("License: CC BY 4.0"));
+      entries.add(infoLink("https://creativecommons.org/licenses/by/4.0/"));
+      entries.add(infoLink("https://doi.org/10.5281/zenodo.7254221"));
+      entries.add(infoLine("In-game processing: reprojected to the world grid, resampled to blocks,"));
+      entries.add(infoLine("and cached as tiles for fast lookup."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Köppen–Geiger climate classification (1 km, Beck et al. 2018)"));
+      entries.add(infoLine("Source: Beck, H.E., Zimmermann, N.E., McVicar, T.R., et al. (2018)."));
+      entries.add(infoLine("Present and future Köppen–Geiger climate classification maps at 1-km resolution"));
+      entries.add(infoLine("(Scientific Data)."));
+      entries.add(infoSubtle("License: CC BY 4.0"));
+      entries.add(infoLink("https://creativecommons.org/licenses/by/4.0/"));
+      entries.add(infoSubtle("Publication DOI:"));
+      entries.add(infoLink("https://doi.org/10.1038/sdata.2018.214"));
+      entries.add(infoLine("In-game processing: reprojected and resampled to match the world grid."));
+      entries.add(infoLine("Cached for fast lookup."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Terrain Tiles (global DEM tiles)"));
+      entries.add(infoLine("Terrain Tiles (AWS Open Data Registry / Mapzen Jörð)"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://registry.opendata.aws/terrain-tiles"));
+      entries.add(infoLine("Source attributions for Terrain Tiles:"));
+      entries.add(infoSubtle("ArcticDEM terrain data: DEM(s) were created from DigitalGlobe, Inc. imagery"));
+      entries.add(infoSubtle("and funded under National Science Foundation awards 1043681, 1559691, and 1542736;"));
+      entries.add(infoSubtle("Australia terrain data © Commonwealth of Australia (Geoscience Australia) 2017;"));
+      entries.add(infoSubtle("Austria terrain data © offene Daten Österreichs – Digitales Geländemodell (DGM) Österreich;"));
+      entries.add(infoSubtle("Canada terrain data contains information licensed under the Open Government Licence – Canada;"));
+      entries.add(infoSubtle("Europe terrain data produced using Copernicus data and information funded by the"));
+      entries.add(infoSubtle("European Union – EU-DEM layers;"));
+      entries.add(infoSubtle("Global ETOPO1 terrain data U.S. National Oceanic and Atmospheric Administration;"));
+      entries.add(infoSubtle("New Zealand terrain data Copyright 2011 Crown copyright (c) Land Information"));
+      entries.add(infoSubtle("New Zealand and the New Zealand Government (All rights reserved);"));
+      entries.add(infoSubtle("Norway terrain data © Kartverket;"));
+      entries.add(infoSubtle("United Kingdom terrain data © Environment Agency copyright and/or database right 2015."));
+      entries.add(infoSubtle("All rights reserved;"));
+      entries.add(infoSubtle("United States 3DEP (formerly NED) and global GMTED2010 and SRTM terrain data"));
+      entries.add(infoSubtle("courtesy of the U.S. Geological Survey."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("swissALTI3D 0.5 m / 2 m"));
+      entries.add(infoLine("swisstopo swissALTI3D digital terrain model"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://www.swisstopo.admin.ch/en/height-model-swissalti3d"));
+      entries.add(infoLink("https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.swissalti3d"));
+      entries.add(infoLink("https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.swissalti3d/items"));
+      entries.add(infoLink("https://www.swisstopo.admin.ch/en/free-geodata-ogd"));
+      entries.add(infoLink("https://www.swisstopo.admin.ch/en/conditions-geodata"));
+      entries.add(infoLine("In-game processing: sampled from official swisstopo swissALTI3D COG tiles"));
+      entries.add(infoLine("with byte-range reads and cached locally. Automatic prefers"));
+      entries.add(infoLine("0.5 m at fine scales and 2 m at broader scales inside swissALTI3D coverage."));
+      entries.add(infoSubtle("Terrain data source: Federal Office of Topography swisstopo."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("AHN DTM 0.5 m"));
+      entries.add(infoLine("Actueel Hoogtebestand Nederland (AHN) DTM 0,5m"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://service.pdok.nl/rws/actueel-hoogtebestand-nederland/atom/dtm_05m.xml"));
+      entries.add(infoLink("https://service.pdok.nl/rws/actueel-hoogtebestand-nederland/atom/downloads/dtm_05m/kaartbladindex.json"));
+      entries.add(infoLine("In-game processing: sampled from official PDOK/RWS AHN DTM COG tiles"));
+      entries.add(infoLine("with byte-range reads and cached locally for reuse."));
+      entries.add(infoSubtle("AHN terrain data provided by Rijkswaterstaat through PDOK."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("CANElevation 2 m / 30 m DTM"));
+      entries.add(infoLine("Natural Resources Canada CANElevation DEMs"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://registry.opendata.aws/canelevation-dem/"));
+      entries.add(infoLine("In-game processing: sampled from public CANElevation GeoTIFF tiles"));
+      entries.add(infoLine("with byte-range reads and cached locally. Automatic prefers"));
+      entries.add(infoLine("HRDEM 2 m in Canada where available and falls back to MRDEM 30 m elsewhere."));
+      entries.add(infoSubtle("High Resolution Digital Elevation Model (HRDEM) 2 m DTM and"));
+      entries.add(infoSubtle("Multi-Resolution Digital Elevation Model (MRDEM) 30 m DTM"));
+      entries.add(infoSubtle("provided by Natural Resources Canada under the Open Government Licence - Canada."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Norway DTM1 1 m"));
+      entries.add(infoLine("Kartverket / Geonorge DTM 1 Høydedata"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://nedlasting.geonorge.no/geonorge/ATOM/hoydedata/Hoydedata_ServiceFeed.atom"));
+      entries.add(infoLink("https://nedlasting.geonorge.no/geonorge/ATOM/hoydedata/datasett/DTM1.atom"));
+      entries.add(infoLink("https://data.norge.no/nlod/en/2.0"));
+      entries.add(infoLine("In-game processing: sampled from official Geonorge DTM1 GeoTIFF tiles"));
+      entries.add(infoLine("with byte-range reads and cached locally. Automatic prefers"));
+      entries.add(infoLine("Norway DTM1 across published mainland Norway coverage."));
+      entries.add(infoSubtle("Terrain data provided by Kartverket under the Norwegian Licence for Open Government Data (NLOD) 2.0."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Japan GSI elevation tiles"));
+      entries.add(infoLine("Geospatial Information Authority of Japan (GSI) elevation tiles"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://maps.gsi.go.jp/development/ichiran.html#dem"));
+      entries.add(infoLink("https://maps.gsi.go.jp/development/demtile.html"));
+      entries.add(infoLink("https://maps.gsi.go.jp/development/hyokochi.html"));
+      entries.add(infoLink("https://maps.gsi.go.jp/help/termsofuse.html"));
+      entries.add(infoLine("In-game processing: sampled from official GSI PNG elevation tiles"));
+      entries.add(infoLine("with internal DEM1A/5A/5B/5C/10B fallback and cached locally."));
+      entries.add(infoLine("Automatic prefers Japan GSI in Japan and falls through to the next"));
+      entries.add(infoLine("best DEM when higher-resolution GSI tiles are missing or nodata."));
+      entries.add(infoSubtle("Terrain data provided by the Geospatial Information Authority of Japan under GSI tile terms of use."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Polar Geospatial Center DEMs"));
+      entries.add(infoLine("ArcticDEM and REMA mosaic DEMs"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://registry.opendata.aws/pgc-arcticdem/"));
+      entries.add(infoLink("https://registry.opendata.aws/pgc-rema/"));
+      entries.add(infoLine("In-game processing: sampled from public PGC mosaic GeoTIFF tiles"));
+      entries.add(infoLine("with byte-range reads and cached locally for reuse."));
+      entries.add(infoSubtle("ArcticDEM terrain data: DEM(s) were created from DigitalGlobe, Inc. imagery"));
+      entries.add(infoSubtle("and funded under National Science Foundation awards 1043681, 1559691, and 1542736."));
+      entries.add(infoSubtle("REMA terrain data: Reference Elevation Model of Antarctica provided by"));
+      entries.add(infoSubtle("the Polar Geospatial Center and collaborators."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("USGS 3DEP Bare-Earth DEM"));
+      entries.add(infoLine("USGS 3DEP Bare-Earth DEM Dynamic Service"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer?f=pjson"));
+      entries.add(infoLine("In-game processing: sampled from public USGS 3DEP dynamic GeoTIFF tiles"));
+      entries.add(infoLine("and cached locally. Automatic uses USGS across the U.S."));
+      entries.add(infoSubtle("USGS 3DEP products and services:"));
+      entries.add(infoLink("https://www.usgs.gov/3d-elevation-program/about-3dep-products-services"));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Copernicus DEM GLO-30 / GLO-90"));
+      entries.add(infoLine("Copernicus Digital Elevation Model (GLO-30 / GLO-90)"));
+      entries.add(infoLine("Accessed on " + formatLocalDate() + " from"));
+      entries.add(infoLink("https://registry.opendata.aws/copernicus-dem/"));
+      entries.add(infoLine("In-game processing: sampled from public Copernicus COG tiles"));
+      entries.add(infoLine("with Terrain Tiles retained automatically where its footprint metadata"));
+      entries.add(infoLine("indicates higher native resolution outside regional DEM coverage."));
+      entries.add(infoSpacer());
+      entries.add(infoHeader("Open-Meteo (weather)"));
+      entries.add(infoLine("Weather data provided by Open-Meteo.com."));
+      entries.add(infoLink("https://open-meteo.com/"));
+      entries.add(infoSubtle("License: CC BY 4.0"));
+      entries.add(infoLink("https://creativecommons.org/licenses/by/4.0/"));
+      entries.add(infoLine("Credit: \"Weather data by Open-Meteo.com\"."));
+      entries.add(infoLink("https://doi.org/10.5281/ZENODO.7970649"));
+      return entries;
+   }
+
+   private static EarthCustomizeScreen.TextLineDefinition infoHeader(String text) {
+      return new EarthCustomizeScreen.TextLineDefinition(Component.literal(text), -604044, null);
+   }
+
+   private static EarthCustomizeScreen.TextLineDefinition infoLine(String text) {
+      return new EarthCustomizeScreen.TextLineDefinition(Component.literal(text), -1710619, null);
+   }
+
+   private static EarthCustomizeScreen.TextLineDefinition infoSubtle(String text) {
+      return new EarthCustomizeScreen.TextLineDefinition(Component.literal(text), -4605511, null);
+   }
+
+   private static EarthCustomizeScreen.TextLineDefinition infoSubtle( Component text) {
+      return new EarthCustomizeScreen.TextLineDefinition(text, -4605511, null);
+   }
+
+   private static EarthCustomizeScreen.TextLineDefinition infoLink(String url) {
+      return new EarthCustomizeScreen.TextLineDefinition(Component.literal(url), -11141121, url);
+   }
+
+   private static EarthCustomizeScreen.SpacerDefinition infoSpacer() {
+      return new EarthCustomizeScreen.SpacerDefinition();
+   }
+
+   private static String formatWorldScale(double value) {
+      if (value < 1000.0) {
+         double rounded = Math.round(value * 10.0) / 10.0;
+         return Math.abs(rounded - Math.rint(rounded)) < 1.0E-6
+            ? String.format(Locale.ROOT, "1:%.0fm", rounded)
+            : String.format(Locale.ROOT, "1:%.1fm", rounded);
+      } else {
+         return String.format(Locale.ROOT, "1:%.1fkm", value / 1000.0);
+      }
+   }
+
+   private static String formatLocalDate() {
+      DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(Locale.getDefault());
+      return formatter.format(LocalDate.now());
+   }
+
+   private static String formatMultiplier(double value) {
+      return String.format(Locale.ROOT, "%.1fx", value);
+   }
+
+   private static String formatHeightOffset(double value) {
+      return String.format(Locale.ROOT, "%.0f blocks", value);
+   }
+
+   private static String formatSeaLevel(double value) {
+      return value <= -63.5 ? "Automatic" : String.format(Locale.ROOT, "%.0f blocks", value);
+   }
+
+   private static String formatPercent(double value) {
+      return String.format(Locale.ROOT, "%.0f%%", value);
+   }
+
+   private static String formatChunkRadius(double value) {
+      return String.format(Locale.ROOT, "%.0f chunks", value);
+   }
+
+   private static String formatChunksPerTick(double value) {
+      return String.format(Locale.ROOT, "%.0f chunks/tick", value);
+   }
+
+   private static String formatMaxAltitude(double value) {
+      return formatAltitude(value, -1.0);
+   }
+
+   private static String formatMinAltitude(double value) {
+      return formatAltitude(value, -2048.0);
+   }
+
+   
+   private static Component formatRenderMode(EarthGeneratorSettings.DistantHorizonsRenderMode mode) {
+      return Objects.requireNonNull(Component.translatable("property.tellus.distant_horizons_render_mode.value." + mode.id()), "renderModeLabel");
+   }
+
+   
+   private static Component formatDemProvider(EarthGeneratorSettings.DemProvider provider) {
+      return Objects.requireNonNull(Component.translatable("property.tellus.dem_provider.value." + provider.id()), "demProviderLabel");
+   }
+
+   private static String formatAltitude(double value, double autoValue) {
+      return value <= autoValue + 0.5 ? "Automatic" : String.format(Locale.ROOT, "%.0f blocks", value);
+   }
+
+   private static double findBestWorldScale(EarthGeneratorSettings settings, TerrainPreview.PreviewInfo info) {
+      for (int step = 10; step <= 5000; step++) {
+         double worldScale = step / 10.0;
+         if (canFitPreviewAtWorldScale(settings, info, worldScale)) {
+            return worldScale;
+         }
+      }
+
+      return 500.0;
+   }
+
+   private static boolean canFitPreviewAtWorldScale(EarthGeneratorSettings settings, TerrainPreview.PreviewInfo info, double worldScale) {
+      int minBase = scaledSurfaceY(info.minElevationMeters(), worldScale, settings.terrestrialHeightScale(), settings.oceanicHeightScale(), 0);
+      int maxBase = scaledSurfaceY(info.maxElevationMeters(), worldScale, settings.terrestrialHeightScale(), settings.oceanicHeightScale(), 0);
+      int minOffset = Math.max(EarthGeneratorSettings.MIN_WORLD_Y - minBase, -2000);
+      int maxOffset = Math.min(EarthGeneratorSettings.MAX_WORLD_Y - maxBase, 128);
+      return minOffset <= maxOffset;
+   }
+
+   private static int findBestHeightOffset(EarthGeneratorSettings settings, TerrainPreview.PreviewInfo info, double worldScale) {
+      int minBase = scaledSurfaceY(info.minElevationMeters(), worldScale, settings.terrestrialHeightScale(), settings.oceanicHeightScale(), 0);
+      int maxBase = scaledSurfaceY(info.maxElevationMeters(), worldScale, settings.terrestrialHeightScale(), settings.oceanicHeightScale(), 0);
+      int minOffset = Math.max(EarthGeneratorSettings.MIN_WORLD_Y - minBase, -2000);
+      int maxOffset = Math.min(EarthGeneratorSettings.MAX_WORLD_Y - maxBase, 128);
+      if (minOffset > maxOffset) {
+         return Mth.clamp(settings.heightOffset(), -2000, 128);
+      } else {
+         return Mth.clamp((int)Math.round((minOffset + maxOffset) * 0.5), minOffset, maxOffset);
+      }
+   }
+
+   private static int scaledSurfaceY(double elevation, double worldScale, double terrestrialScale, double oceanicScale, int heightOffset) {
+      double scale = elevation >= 0.0 ? terrestrialScale : oceanicScale;
+      double scaled = elevation * scale / worldScale;
+      int base = elevation >= 0.0 ? Mth.ceil(scaled) : Mth.floor(scaled);
+      return base + heightOffset;
+   }
+
+   private static String formatBytes(long bytes) {
+      if (bytes <= 0L) {
+         return "0 B";
+      } else {
+         double value = bytes;
+         String[] units = new String[]{"B", "KB", "MB", "GB", "TB"};
+
+         int unit;
+         for (unit = 0; value >= 1024.0 && unit < units.length - 1; unit++) {
+            value /= 1024.0;
+         }
+
+         return unit == 0
+            ? Objects.requireNonNull(String.format(Locale.ROOT, "%d B", bytes), "formattedBytes")
+            : Objects.requireNonNull(String.format(Locale.ROOT, "%.1f %s", value, units[unit]), "formattedBytes");
+      }
+   }
+
+   
+   private static Component settingName(String key) {
+      return Objects.requireNonNull(Component.translatable("property.tellus." + key + ".name"), "settingName");
+   }
+
+   
+   private static Component settingTooltip(String key) {
+      return Objects.requireNonNull(Component.translatable("property.tellus." + key + ".tooltip").withStyle(ChatFormatting.GRAY), "settingTooltip");
+   }
+
+   
+   private static Component requiresModTooltip( String modId) {
+      return Objects.requireNonNull(
+         Component.translatable("tellus.compatibility.requires_mod", new Object[]{compatibilityModName(modId)}).withStyle(ChatFormatting.GRAY),
+         "requiresModTooltip"
+      );
+   }
+
+   
+   private static Component compatibilityModName( String modId) {
+      return switch (modId) {
+         case "distanthorizons" -> (MutableComponent)Objects.requireNonNull(Component.translatable("tellus.compatibility.mod.distant_horizons"), "modName");
+         case "voxy" -> (MutableComponent)Objects.requireNonNull(Component.translatable("tellus.compatibility.mod.voxy"), "modName");
+         default -> (MutableComponent)Objects.requireNonNull(Component.literal(modId), "modName");
+      };
+   }
+
+   
+   private static Component workInProgressTooltip(String key) {
+      return Objects.requireNonNull(settingTooltip(key), "settingTooltip").copy().append(Component.literal(" ")).append(WORK_IN_PROGRESS);
+   }
+
+   private static Component historicalSnowReworkTooltip() {
+      return Objects.requireNonNull(
+         Component.translatable("property.tellus.historical_snow.rework.tooltip").withStyle(ChatFormatting.GRAY),
+         "historicalSnowReworkTooltip"
+      );
+   }
+
+   private static String describeDimensionType(DimensionType type) {
+      return "minY=" + type.minY() + ",height=" + type.height() + ",logicalHeight=" + type.logicalHeight();
+   }
+
+   private int resolveAltitudeSetting(String key, double autoValue) {
+      double value = this.findSliderValue(key, autoValue);
+      return value <= autoValue + 0.5 ? Integer.MIN_VALUE : (int)Math.round(value);
+   }
+
+   private int resolveSeaLevelSetting(String key, double autoValue) {
+      double value = this.findSliderValue(key, autoValue);
+      return value <= autoValue + 0.5 ? -2147483647 : (int)Math.round(value);
+   }
+
+   private static EarthCustomizeScreen.RegistryUpdate updateDimensionTypeRegistry(
+      LayeredRegistryAccess<RegistryLayer> registries, DimensionType updatedType, ResourceKey<DimensionType> targetKey
+   ) {
+      LayeredRegistryAccess<RegistryLayer> updatedRegistries = registries;
+      boolean updatedAny = false;
+      ResourceKey<DimensionType> nonNullTargetKey = Objects.requireNonNull(targetKey, "targetDimensionTypeKey");
+
+      for (RegistryLayer layer : RegistryLayer.values()) {
+         Frozen layerAccess = updatedRegistries.getLayer(layer);
+         if (!layerAccess.lookup(Registries.DIMENSION_TYPE).isEmpty()) {
+            Registry<DimensionType> source = layerAccess.registryOrThrow(Registries.DIMENSION_TYPE);
+            Lifecycle lifecycle = Objects.requireNonNull(
+               source instanceof MappedRegistry<DimensionType> mapped ? mapped.registryLifecycle() : Lifecycle.experimental(), "dimensionTypeLifecycle"
+            );
+            MappedRegistry<DimensionType> copy = new MappedRegistry<>(Registries.DIMENSION_TYPE, lifecycle);
+            List<Entry<ResourceKey<DimensionType>, DimensionType>> entries = new ArrayList<>(source.entrySet());
+            entries.sort(Comparator.comparingInt(entry -> source.getId(entry.getValue())));
+
+            for (Entry<ResourceKey<DimensionType>, DimensionType> entry : entries) {
+               ResourceKey<DimensionType> key = Objects.requireNonNull(entry.getKey(), "dimensionTypeKey");
+               if (!key.equals(nonNullTargetKey)) {
+                  DimensionType value = Objects.requireNonNull(entry.getValue(), "dimensionType");
+                  RegistrationInfo info = Objects.requireNonNull(source.registrationInfo(key).orElse(RegistrationInfo.BUILT_IN), "registrationInfo");
+                  copy.register(key, value, info);
+               }
+            }
+
+            Optional<KnownPack> emptyKnownPack = Objects.requireNonNull(Optional.empty(), "emptyKnownPack");
+            RegistrationInfo targetInfo = Objects.requireNonNull(
+               source.registrationInfo(nonNullTargetKey)
+                  .map(infox -> new RegistrationInfo(emptyKnownPack, Objects.requireNonNull(infox.lifecycle(), "dimensionTypeLifecycle")))
+                  .orElseGet(() -> new RegistrationInfo(emptyKnownPack, Objects.requireNonNull(Lifecycle.experimental(), "experimentalLifecycle"))),
+               "dimensionTypeRegistrationInfo"
+            );
+            copy.register(nonNullTargetKey, Objects.requireNonNull(updatedType, "updatedType"), targetInfo);
+            Registry<DimensionType> frozen = copy.freeze();
+            Frozen updatedLayer = replaceRegistry(layerAccess, Registries.DIMENSION_TYPE, frozen);
+            updatedRegistries = replaceLayer(updatedRegistries, layer, updatedLayer);
+            updatedAny = true;
+         }
+      }
+
+      if (!updatedAny) {
+         throw new IllegalStateException("Dimension type registry missing");
+      } else {
+         RegistryLookup<DimensionType> dimensionTypes = updatedRegistries.compositeAccess().lookupOrThrow(Registries.DIMENSION_TYPE);
+         Holder<DimensionType> holder = Objects.requireNonNull(dimensionTypes.getOrThrow(nonNullTargetKey), "dimensionTypeHolder");
+         return new EarthCustomizeScreen.RegistryUpdate(updatedRegistries, holder);
+      }
+   }
+
+   private static Frozen replaceRegistry(Frozen source, ResourceKey<? extends Registry<?>> registryKey, Registry<?> replacement) {
+      Map<ResourceKey<? extends Registry<?>>, Registry<?>> registryMap = new LinkedHashMap<>();
+      source.registries().forEach(entry -> registryMap.put(entry.key(), entry.value()));
+      registryMap.put(registryKey, replacement);
+      return new ImmutableRegistryAccess(registryMap).freeze();
+   }
+
+   
+   private static LayeredRegistryAccess<RegistryLayer> replaceLayer(
+       LayeredRegistryAccess<RegistryLayer> registries,  RegistryLayer target, Frozen replacement
+   ) {
+      Frozen replacementChecked = Objects.requireNonNull(replacement, "replacement");
+      RegistryLayer[] layers = RegistryLayer.values();
+      List<Frozen> replacements = new ArrayList<>();
+      boolean found = false;
+
+      for (RegistryLayer layer : layers) {
+         if (!found) {
+            if (layer == target) {
+               found = true;
+               replacements.add(replacementChecked);
+            }
+         } else {
+            replacements.add(registries.getLayer(layer));
+         }
+      }
+
+      if (!found) {
+         throw new IllegalStateException("Registry layer missing: " + target);
+      } else {
+         return registries.replaceFrom(target, replacements);
+      }
+   }
+
+   private void showCategories() {
+      this.currentCategoryId = null;
+      this.setPreviewVisible(true);
+      this.list.clear();
+
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         if (category.showInRootMenu()) {
+            Component label = Objects.requireNonNull(category.getLabel(), "categoryLabel");
+            Button button = Button.builder(label, btn -> this.showCategory(category)).bounds(0, 0, this.list.getRowWidth(), 20).build();
+            this.list.addWidget(button);
+         }
+      }
+
+      this.list.setScrollAmount(0.0);
+   }
+
+   private void showCategory(EarthCustomizeScreen.CategoryDefinition category) {
+      this.currentCategoryId = category.getId();
+      this.list.clear();
+      String parentCategoryId = category.parentCategoryId();
+      EarthCustomizeScreen.CategoryDefinition backTarget = parentCategoryId == null ? null : this.findCategoryById(parentCategoryId);
+      Component backLabel = Objects.requireNonNull(Component.translatable("gui.back"), "backLabel");
+      Button back = Button.builder(backLabel, btn -> {
+         if (backTarget != null) {
+            this.showCategory(backTarget);
+         } else {
+            this.showCategories();
+         }
+      }).bounds(0, 0, this.list.getRowWidth(), 20).build();
+      this.list.addWidget(back);
+      boolean hidePreview = isPreviewHiddenCategory(category.getId());
+      this.setPreviewVisible(!hidePreview);
+      this.applyCategoryConstraints(category);
+      if ("cache".equals(category.getId())) {
+         EarthCustomizeScreen.CacheManager.requestRefresh();
+      }
+
+      if ("world".equals(category.getId())) {
+         this.list.addWidget(this.createWorldHeaderActions(category));
+      }
+
+      if ("structure".equals(category.getId())) {
+         this.list.addWidget(this.createStructureHeaderActions(category));
+      }
+
+      Runnable onChange = this::onSettingsChanged;
+      if ("distant_horizons".equals(category.getId()) || "voxy".equals(category.getId()) || "dem_providers".equals(category.getId())) {
+         onChange = () -> {
+            this.onSettingsChanged();
+            this.showCategory(category);
+         };
+      }
+
+      if ("openstreetmaps_features".equals(category.getId()) && !this.roadsAndBuildingsSupportedForSelectedScale()) {
+         this.list.addWidget(
+            infoSubtle(Component.translatable("tellus.openstreetmaps_features.scale_limit_warning")).createWidget(onChange)
+         );
+      }
+
+      for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+         this.list.addWidget(setting.createWidget(onChange));
+      }
+
+      this.list.setScrollAmount(0.0);
+   }
+
+   
+   private EarthCustomizeScreen.CategoryDefinition findCategoryById( String id) {
+      String targetId = Objects.requireNonNull(id, "id");
+
+      for (EarthCustomizeScreen.CategoryDefinition category : this.categories) {
+         if (category.getId().equals(targetId)) {
+            return category;
+         }
+      }
+
+      return null;
+   }
+
+   private AbstractWidget createWorldHeaderActions(EarthCustomizeScreen.CategoryDefinition category) {
+      EarthGeneratorSettings defaultSettings = Objects.requireNonNull(EarthGeneratorSettings.DEFAULT, "defaultSettings");
+      Component restoreDefaultsLabel = Objects.requireNonNull(Component.translatable("gui.tellus.restore_defaults"), "restoreDefaultsLabel");
+      Component selectPresetLabel = Objects.requireNonNull(Component.translatable("gui.tellus.select_preset"), "selectPresetLabel");
+      Component comingSoonTooltip = Objects.requireNonNull(
+         Component.translatable("gui.tellus.coming_soon").withStyle(ChatFormatting.GRAY), "selectPresetTooltip"
+      );
+      return new EarthCustomizeScreen.DualButtonWidget(restoreDefaultsLabel, btn -> {
+         this.applySettingsToCategories(defaultSettings, true);
+         this.onSettingsChanged();
+         this.showCategory(category);
+      }, selectPresetLabel, btn -> {}, false, comingSoonTooltip);
+   }
+
+   
+   private AbstractWidget createStructureHeaderActions( EarthCustomizeScreen.CategoryDefinition category) {
+      Component enableAllLabel = Objects.requireNonNull(Component.translatable("gui.tellus.enable_all"), "enableAllLabel");
+      Component disableAllLabel = Objects.requireNonNull(Component.translatable("gui.tellus.disable_all"), "disableAllLabel");
+      return new EarthCustomizeScreen.DualButtonWidget(enableAllLabel, btn -> {
+         this.setCategoryToggleValues(category, true);
+         this.onSettingsChanged();
+         this.showCategory(category);
+      }, disableAllLabel, btn -> {
+         this.setCategoryToggleValues(category, false);
+         this.onSettingsChanged();
+         this.showCategory(category);
+      }, true, null);
+   }
+
+   private void setCategoryToggleValues( EarthCustomizeScreen.CategoryDefinition category, boolean value) {
+      for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+         if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && !toggle.locked && !toggle.unavailable) {
+            toggle.value = value;
+         }
+      }
+   }
+
+   private void applyCategoryConstraints(EarthCustomizeScreen.CategoryDefinition category) {
+      boolean bothCompatibilityModsInstalled = ModList.get().isLoaded("distanthorizons") && ModList.get().isLoaded("voxy");
+      boolean voxyEnabled = bothCompatibilityModsInstalled
+         && this.findToggleValue("voxy_chunk_pregen_enabled", EarthGeneratorSettings.DEFAULT.voxyChunkPregenEnabled());
+      if ("openstreetmaps_features".equals(category.getId())) {
+         EarthCustomizeScreen.ToggleDefinition roads = null;
+         EarthCustomizeScreen.ToggleDefinition buildings = null;
+
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals("enable_roads")) {
+               roads = toggle;
+            }
+
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals("enable_buildings")) {
+               buildings = toggle;
+            }
+         }
+
+         boolean scaleSupported = this.roadsAndBuildingsSupportedForSelectedScale();
+         if (roads != null) {
+            roads.forceDisabled(
+               !scaleSupported,
+               Component.translatable("property.tellus.enable_roads.scale_limit.tooltip").withStyle(ChatFormatting.GRAY)
+            );
+         }
+
+         if (buildings != null) {
+            buildings.forceDisabled(
+               !scaleSupported,
+               Component.translatable("property.tellus.enable_buildings.scale_limit.tooltip").withStyle(ChatFormatting.GRAY)
+            );
+         }
+      } else if ("dem_providers".equals(category.getId())) {
+         EarthCustomizeScreen.ToggleDefinition automatic = null;
+         Map<EarthGeneratorSettings.DemProvider, EarthCustomizeScreen.DemProviderToggleDefinition> providerToggles = new LinkedHashMap<>();
+
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals("dem_automatic")) {
+               automatic = toggle;
+            }
+
+            if (setting instanceof EarthCustomizeScreen.DemProviderToggleDefinition providerToggle) {
+               providerToggles.put(providerToggle.provider, providerToggle);
+            }
+         }
+
+         Component automaticTooltip = Component.translatable("tellus.dem_provider.force_disabled.automatic").withStyle(ChatFormatting.GRAY);
+         if (automatic != null && automatic.value) {
+            for (EarthCustomizeScreen.DemProviderToggleDefinition providerToggle : providerToggles.values()) {
+               providerToggle.value = true;
+               providerToggle.forceDisabled(true, automaticTooltip);
+            }
+            return;
+         }
+
+         for (EarthCustomizeScreen.DemProviderToggleDefinition providerToggle : providerToggles.values()) {
+            providerToggle.forceDisabled(false);
+         }
+
+         EarthCustomizeScreen.DemProviderToggleDefinition terrainTiles = providerToggles.get(EarthGeneratorSettings.DemProvider.TERRARIUM);
+         EarthCustomizeScreen.DemProviderToggleDefinition copernicus = providerToggles.get(EarthGeneratorSettings.DemProvider.COPERNICUS);
+         if (terrainTiles != null && copernicus != null) {
+            if (!terrainTiles.value) {
+               copernicus.value = true;
+               copernicus.forceDisabled(
+                  true, Component.translatable("tellus.dem_provider.force_disabled.copernicus_required").withStyle(ChatFormatting.GRAY)
+               );
+            } else if (!copernicus.value) {
+               terrainTiles.value = true;
+               terrainTiles.forceDisabled(
+                  true, Component.translatable("tellus.dem_provider.force_disabled.terrain_tiles_required").withStyle(ChatFormatting.GRAY)
+               );
+            }
+         }
+      } else if ("voxy".equals(category.getId())) {
+         EarthCustomizeScreen.ToggleDefinition enabled = null;
+         EarthCustomizeScreen.SliderDefinition maxRadius = null;
+         EarthCustomizeScreen.SliderDefinition chunksPerTick = null;
+
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals("voxy_chunk_pregen_enabled")) {
+               enabled = toggle;
+            }
+
+            if (setting instanceof EarthCustomizeScreen.SliderDefinition slider && slider.key.equals("voxy_chunk_pregen_max_radius")) {
+               maxRadius = slider;
+            }
+
+            if (setting instanceof EarthCustomizeScreen.SliderDefinition slider && slider.key.equals("voxy_chunk_pregen_chunks_per_tick")) {
+               chunksPerTick = slider;
+            }
+         }
+
+         if (enabled != null && maxRadius != null && chunksPerTick != null) {
+            boolean disable = !enabled.value;
+            maxRadius.forceDisabled(disable);
+            chunksPerTick.forceDisabled(disable);
+         }
+      } else if ("distant_horizons".equals(category.getId())) {
+         EarthCustomizeScreen.ModeDefinition renderMode = null;
+         EarthCustomizeScreen.ToggleDefinition waterResolver = null;
+
+         for (EarthCustomizeScreen.SettingDefinition setting : category.getSettings()) {
+            if (setting instanceof EarthCustomizeScreen.ModeDefinition mode && mode.key.equals("distant_horizons_render_mode")) {
+               renderMode = mode;
+            }
+
+            if (setting instanceof EarthCustomizeScreen.ToggleDefinition toggle && toggle.key.equals("distant_horizons_water_resolver")) {
+               waterResolver = toggle;
+            }
+         }
+
+         if (renderMode != null && waterResolver != null) {
+            boolean blockedByVoxy = bothCompatibilityModsInstalled && voxyEnabled;
+            boolean ultraFast = renderMode.value == EarthGeneratorSettings.DistantHorizonsRenderMode.ULTRA_FAST;
+            renderMode.forceDisabled(blockedByVoxy);
+            waterResolver.forceDisabled(ultraFast || blockedByVoxy);
+            if (ultraFast) {
+               waterResolver.value = false;
+            }
+         }
+      }
+   }
+
+   private boolean roadsAndBuildingsSupportedForSelectedScale() {
+      return roadsAndBuildingsSupportedForWorldScale(this.findSliderValue("world_scale", EarthGeneratorSettings.DEFAULT.worldScale()));
+   }
+
+   private static boolean roadsAndBuildingsSupportedForWorldScale(double worldScale) {
+      return worldScale > 0.0 && worldScale <= OSM_ROADS_AND_BUILDINGS_MAX_WORLD_SCALE;
+   }
+
+   private static boolean isPreviewHiddenCategory(String id) {
+      return "cache".equals(id) || "data_sources".equals(id) || "hma_access".equals(id);
+   }
+
+   private void setPreviewVisible(boolean visible) {
+      this.updateLayout(visible);
+   }
+
+   private void refreshCurrentCategory() {
+      if (this.currentCategoryId == null) {
+         this.showCategories();
+      } else {
+         EarthCustomizeScreen.CategoryDefinition category = this.findCategoryById(this.currentCategoryId);
+         if (category != null) {
+            this.showCategory(category);
+         } else {
+            this.showCategories();
+         }
+      }
+   }
+
+   private void updateLayout(boolean previewVisible) {
+      if (this.list != null) {
+         int listTop = 40;
+         int listHeight = Math.max(0, this.height - 36 - listTop);
+         int listWidth = previewVisible ? Math.max(140, this.width / 2 - 20) : Math.max(140, this.width - 20);
+         this.list.setX(10);
+         this.list.setY(listTop);
+         this.list.setWidth(listWidth);
+         this.list.setHeight(listHeight);
+         if (this.previewWidget != null) {
+            this.previewWidget.visible = previewVisible;
+            this.previewWidget.active = previewVisible;
+            if (previewVisible) {
+               int previewWidth = Math.max(140, this.width - listWidth - 40);
+               int previewHeight = Math.max(80, this.height - 80);
+               int previewX = this.width - previewWidth - 10;
+               this.previewWidget.setX(previewX);
+               this.previewWidget.setY(listTop);
+               this.previewWidget.setWidth(previewWidth);
+               this.previewWidget.setHeight(previewHeight);
+            }
+         }
+      }
+   }
+
+   private static boolean isShiftDown() {
+      long window = Minecraft.getInstance().getWindow().getWindow();
+      return InputConstants.isKeyDown(window, 340) || InputConstants.isKeyDown(window, 344);
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class ButtonDefinition implements EarthCustomizeScreen.SettingDefinition {
+      
+      private final Component label;
+      
+      private final Component tooltip;
+      private final boolean active;
+
+      private ButtonDefinition(Component label, Component tooltip, boolean active) {
+         this.label = Objects.requireNonNull(label, "buttonLabel");
+         this.tooltip = tooltip;
+         this.active = active;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         Button button = Button.builder(this.label, btn -> {}).bounds(0, 0, 0, 20).build();
+         button.active = this.active;
+         if (this.tooltip != null) {
+            button.setTooltip(Tooltip.create(this.tooltip));
+         }
+
+         return button;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CacheActionDefinition implements EarthCustomizeScreen.SettingDefinition {
+      
+      private final Component label;
+      
+      private final Runnable action;
+
+      private CacheActionDefinition( Component label,  Runnable action) {
+         this.label = Objects.requireNonNull(label, "label");
+         this.action = Objects.requireNonNull(action, "action");
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         return new EarthCustomizeScreen.CacheActionWidget(this.label, this.action);
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CacheActionWidget extends AbstractWidget {
+      private final Button button;
+
+      private CacheActionWidget( Component label,  Runnable action) {
+         super(0, 0, 0, 20, Component.empty());
+         Component safeLabel = Objects.requireNonNull(label, "label");
+         Runnable safeAction = Objects.requireNonNull(action, "action");
+         this.button = Button.builder(safeLabel, btn -> safeAction.run()).bounds(0, 0, 0, 20).build();
+      }
+
+      protected void renderWidget( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         EarthCustomizeScreen.CacheSnapshot snapshot = EarthCustomizeScreen.CacheManager.snapshot();
+         this.button.active = snapshot.ready() && snapshot.totalBytes() > 0L;
+         this.button.setX(this.getX());
+         this.button.setY(this.getY());
+         this.button.setWidth(this.width);
+         this.button.setHeight(this.height);
+         this.button.render(graphics, mouseX, mouseY, delta);
+      }
+
+      public void onClick(double mouseX, double mouseY) {
+         this.button.mouseClicked(mouseX, mouseY, 0);
+      }
+
+      protected void onDrag(double mouseX, double mouseY, double deltaX, double deltaY) {
+         this.button.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+      }
+
+      public void onRelease(double mouseX, double mouseY) {
+         this.button.mouseReleased(mouseX, mouseY, 0);
+      }
+
+      protected void updateWidgetNarration( NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CacheEntryDefinition implements EarthCustomizeScreen.SettingDefinition {
+      private final EarthCustomizeScreen.CacheMetric metric;
+      private final boolean allowDelete;
+
+      private CacheEntryDefinition(EarthCustomizeScreen.CacheMetric metric, boolean allowDelete) {
+         this.metric = Objects.requireNonNull(metric, "metric");
+         this.allowDelete = allowDelete;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         return new EarthCustomizeScreen.CacheEntryWidget(this.metric, this.allowDelete);
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CacheEntryWidget extends AbstractWidget {
+      
+      private static final Component DELETE_LABEL = Objects.requireNonNull(Component.translatable("tellus.cache.delete"), "deleteLabel");
+      private final EarthCustomizeScreen.CacheMetric metric;
+      private final Button deleteButton;
+      private final boolean allowDelete;
+
+      private CacheEntryWidget(EarthCustomizeScreen.CacheMetric metric, boolean allowDelete) {
+         super(0, 0, 0, 20, Component.empty());
+         this.metric = Objects.requireNonNull(metric, "metric");
+         this.allowDelete = allowDelete;
+         this.deleteButton = Button.builder(DELETE_LABEL, btn -> EarthCustomizeScreen.CacheManager.delete(metric)).bounds(0, 0, 0, 20).build();
+      }
+
+      protected void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         Font font = Minecraft.getInstance().font;
+         EarthCustomizeScreen.CacheSnapshot snapshot = EarthCustomizeScreen.CacheManager.snapshot();
+         boolean ready = snapshot.ready();
+         long bytes = snapshot.bytesFor(this.metric);
+         String sizeText = ready ? EarthCustomizeScreen.formatBytes(bytes) : "...";
+         int buttonWidth = Math.max(96, font.width(DELETE_LABEL) + 12);
+         int buttonX = this.getX() + this.width - buttonWidth;
+         int buttonY = this.getY();
+         int sizeWidth = font.width(sizeText);
+         int sizeX = buttonX - 4 - sizeWidth;
+         int labelX = this.getX() + 4;
+         int textY = this.getY() + (this.height - 9) / 2;
+         Component label = this.metric.label();
+         graphics.drawString(font, label, labelX, textY, -1, false);
+         graphics.drawString(font, sizeText, sizeX, textY, -6250336, false);
+         if (this.allowDelete) {
+            this.deleteButton.setX(buttonX);
+            this.deleteButton.setY(buttonY);
+            this.deleteButton.setWidth(buttonWidth);
+            this.deleteButton.setHeight(this.height);
+            this.deleteButton.active = ready && bytes > 0L;
+            this.deleteButton.render(graphics, mouseX, mouseY, delta);
+         }
+      }
+
+      public void onClick(double mouseX, double mouseY) {
+         if (this.allowDelete) {
+            this.deleteButton.mouseClicked(mouseX, mouseY, 0);
+         }
+      }
+
+      protected void onDrag(double mouseX, double mouseY, double deltaX, double deltaY) {
+         if (this.allowDelete) {
+            this.deleteButton.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+         }
+      }
+
+      public void onRelease(double mouseX, double mouseY) {
+         if (this.allowDelete) {
+            this.deleteButton.mouseReleased(mouseX, mouseY, 0);
+         }
+      }
+
+      protected void updateWidgetNarration( NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class HmaAccessManager {
+      private static final String TEST_URL
+         = "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-protected/HMA/HMA_DEM8m_MOS/1/2002/01/28/HMA_DEM8m_MOS_20170716_tile-677.tif";
+      private static final int TEST_SUCCESS_COLOR = 5635925;
+      private static final int CONNECT_TIMEOUT_MS = 8000;
+      private static final int READ_TIMEOUT_MS = 12000;
+      private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor(runnable -> {
+         Thread thread = new Thread(runnable, "tellus-hma-access");
+         thread.setDaemon(true);
+         return thread;
+      });
+      private static final AtomicReference<EarthCustomizeScreen.HmaAccessState> STATE = new AtomicReference<>(initialState());
+      private static final AtomicBoolean TEST_IN_FLIGHT = new AtomicBoolean(false);
+      private static final AtomicReference<String> VERIFIED_TOKEN = new AtomicReference<>("");
+
+      private static EarthCustomizeScreen.HmaAccessState state() {
+         return STATE.get();
+      }
+
+      private static String savedToken() {
+         return HmaAccessConfig.bearerToken();
+      }
+
+      private static boolean isTesting() {
+         return state().testing();
+      }
+
+      private static boolean canSaveToken(String token) {
+         String normalized = normalizeToken(token);
+         return !normalized.isBlank() && !Objects.equals(normalized, savedToken()) && Objects.equals(normalized, VERIFIED_TOKEN.get());
+      }
+
+      private static void onTokenEdited(String token) {
+         String normalized = normalizeToken(token);
+         if (state().testing() || Objects.equals(normalized, VERIFIED_TOKEN.get())) {
+            return;
+         }
+
+         if (Objects.equals(normalized, savedToken())) {
+            STATE.set(initialState());
+         } else if (!normalized.isBlank()) {
+            STATE.set(testBeforeSaveState());
+         } else if (HmaAccessConfig.hasBearerToken()) {
+            STATE.set(savedState());
+         } else {
+            STATE.set(notConfiguredState());
+         }
+      }
+
+      private static void saveToken(String token) {
+         String normalized = normalizeToken(token);
+
+         try {
+            if (normalized.isBlank()) {
+               VERIFIED_TOKEN.set("");
+               HmaAccessConfig.clearBearerToken();
+               STATE.set(notConfiguredState());
+            } else if (Objects.equals(normalized, savedToken())) {
+               STATE.set(savedState());
+            } else if (!canSaveToken(normalized)) {
+               STATE.set(testBeforeSaveState());
+            } else {
+               HmaAccessConfig.setBearerToken(normalized);
+               VERIFIED_TOKEN.set(normalized);
+               STATE.set(savedState());
+            }
+         } catch (RuntimeException error) {
+            Tellus.LOGGER.warn("Failed to save HMA access token", error);
+            STATE.set(new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.save_failed"), -65536));
+         }
+      }
+
+      private static void clearToken() {
+         try {
+            VERIFIED_TOKEN.set("");
+            HmaAccessConfig.clearBearerToken();
+            STATE.set(notConfiguredState());
+         } catch (RuntimeException error) {
+            Tellus.LOGGER.warn("Failed to clear HMA access token", error);
+            STATE.set(new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.save_failed"), -65536));
+         }
+      }
+
+      private static void testToken(String token) {
+         String normalized = normalizeToken(token);
+         if (normalized.isBlank()) {
+            STATE.set(new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.token_missing"), -6250336));
+         } else if (TEST_IN_FLIGHT.compareAndSet(false, true)) {
+            STATE.set(new EarthCustomizeScreen.HmaAccessState(true, Component.translatable("tellus.hma_access.status.testing"), -11167233));
+            CompletableFuture.<EarthCustomizeScreen.HmaAccessState>supplyAsync(() -> performAccessTest(normalized), EXECUTOR).whenComplete((state, error) -> {
+               if (error != null || state == null) {
+                  Tellus.LOGGER.warn("Failed to test HMA access token", error);
+                  STATE.set(new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.network_failed"), -65536));
+               } else {
+                  STATE.set(state);
+               }
+
+               TEST_IN_FLIGHT.set(false);
+            });
+         }
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState performAccessTest(String token) {
+         HttpURLConnection connection = null;
+
+         try {
+            connection = openProbeConnection(TEST_URL);
+            connection.setRequestProperty("Authorization", "Bearer " + token);
+            int status = connection.getResponseCode();
+            if (isSuccessStatus(status)) {
+               VERIFIED_TOKEN.set(token);
+               return successState();
+            } else if (status == 401 || status == 403) {
+               VERIFIED_TOKEN.compareAndSet(token, "");
+               return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.test_failed_auth"), -65536);
+            } else if (isRedirectStatus(status)) {
+               return probeRedirectTarget(connection.getHeaderField("Location"), token);
+            } else {
+               VERIFIED_TOKEN.compareAndSet(token, "");
+               return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.http_error", status), -65536);
+            }
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("HMA token test failed", error);
+            VERIFIED_TOKEN.compareAndSet(token, "");
+            return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.network_failed"), -65536);
+         } finally {
+            if (connection != null) {
+               connection.disconnect();
+            }
+         }
+      }
+
+      private static HttpURLConnection openProbeConnection(String targetUrl) throws IOException {
+         HttpURLConnection connection = (HttpURLConnection)URI.create(targetUrl).toURL().openConnection();
+         connection.setInstanceFollowRedirects(false);
+         connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+         connection.setReadTimeout(READ_TIMEOUT_MS);
+         connection.setRequestMethod("GET");
+         connection.setRequestProperty("User-Agent", "Tellus/1.0 (Minecraft Mod)");
+         connection.setRequestProperty("Range", "bytes=0-0");
+         return connection;
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState probeRedirectTarget(String location, String token) {
+         if (location == null || location.isBlank()) {
+            VERIFIED_TOKEN.compareAndSet(token, "");
+            return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.network_failed"), -65536);
+         } else if (isEarthdataLoginRedirect(location)) {
+            VERIFIED_TOKEN.compareAndSet(token, "");
+            return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.test_failed_auth"), -65536);
+         } else {
+            HttpURLConnection redirectConnection = null;
+
+            try {
+               redirectConnection = openProbeConnection(location);
+               int status = redirectConnection.getResponseCode();
+               if (isSuccessStatus(status)) {
+                  VERIFIED_TOKEN.set(token);
+                  return successState();
+               } else if (status == 401 || status == 403) {
+                  VERIFIED_TOKEN.compareAndSet(token, "");
+                  return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.test_failed_auth"), -65536);
+               } else {
+                  VERIFIED_TOKEN.compareAndSet(token, "");
+                  return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.http_error", status), -65536);
+               }
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("HMA token redirect probe failed", error);
+               VERIFIED_TOKEN.compareAndSet(token, "");
+               return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.network_failed"), -65536);
+            } finally {
+               if (redirectConnection != null) {
+                  redirectConnection.disconnect();
+               }
+            }
+         }
+      }
+
+      private static boolean isEarthdataLoginRedirect(String location) {
+         try {
+            String host = URI.create(location).getHost();
+            return host != null && host.equals("urs.earthdata.nasa.gov");
+         } catch (IllegalArgumentException error) {
+            return false;
+         }
+      }
+
+      private static boolean isRedirectStatus(int status) {
+         return status >= 300 && status < 400;
+      }
+
+      private static boolean isSuccessStatus(int status) {
+         return status == 200 || status == 206;
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState successState() {
+         return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.test_success"), TEST_SUCCESS_COLOR);
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState savedState() {
+         return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.saved"), -10461088);
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState notConfiguredState() {
+         return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.not_configured"), -6250336);
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState testBeforeSaveState() {
+         return new EarthCustomizeScreen.HmaAccessState(false, Component.translatable("tellus.hma_access.status.test_before_save"), -6250336);
+      }
+
+      private static EarthCustomizeScreen.HmaAccessState initialState() {
+         return HmaAccessConfig.hasBearerToken()
+            ? savedState()
+            : notConfiguredState();
+      }
+
+      private static String normalizeToken(String token) {
+         return token == null ? "" : token.trim();
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record HmaAccessState(boolean testing, Component message, int color) {
+      private HmaAccessState {
+         Objects.requireNonNull(message, "message");
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CacheManager {
+      private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor(new EarthCustomizeScreen.CacheThreadFactory());
+      private static final AtomicReference<EarthCustomizeScreen.CacheSnapshot> SNAPSHOT = new AtomicReference<>(EarthCustomizeScreen.CacheSnapshot.empty());
+      private static final AtomicBoolean IN_FLIGHT = new AtomicBoolean(false);
+
+      private static EarthCustomizeScreen.CacheSnapshot snapshot() {
+         return SNAPSHOT.get();
+      }
+
+      private static void requestRefresh() {
+         refreshAsync(null);
+      }
+
+      private static void delete(EarthCustomizeScreen.CacheMetric metric) {
+         List<Path> paths = metric.resolvePaths();
+         if (!paths.isEmpty()) {
+            refreshAsync(() -> {
+               metric.clearRuntimeCache();
+               for (Path path : paths) {
+                  deleteDirectory(path);
+               }
+            });
+         }
+      }
+
+      private static void deleteAll() {
+         refreshAsync(() -> {
+            TellusCacheRegistry.clearAll();
+            for (EarthCustomizeScreen.CacheMetric metric : EarthCustomizeScreen.CacheMetric.values()) {
+               for (Path path : metric.resolvePaths()) {
+                  deleteDirectory(path);
+               }
+            }
+         });
+      }
+
+      private static void refreshAsync( Runnable task) {
+         if (IN_FLIGHT.compareAndSet(false, true)) {
+            SNAPSHOT.set(EarthCustomizeScreen.CacheSnapshot.empty());
+            CompletableFuture.<EarthCustomizeScreen.CacheSnapshot>supplyAsync(() -> {
+               if (task != null) {
+                  task.run();
+               }
+
+               return computeSnapshot();
+            }, EXECUTOR).whenComplete((snapshot, error) -> {
+               if (snapshot != null && error == null) {
+                  SNAPSHOT.set(snapshot);
+               } else {
+                  SNAPSHOT.set(EarthCustomizeScreen.CacheSnapshot.empty());
+               }
+
+               IN_FLIGHT.set(false);
+            });
+         }
+      }
+
+      private static EarthCustomizeScreen.CacheSnapshot computeSnapshot() {
+         long osmBytes = sizeFor(EarthCustomizeScreen.CacheMetric.OSM);
+         long esaBytes = sizeFor(EarthCustomizeScreen.CacheMetric.ESA);
+         long koppenBytes = sizeFor(EarthCustomizeScreen.CacheMetric.KOPPEN);
+         long terrainBytes = sizeFor(EarthCustomizeScreen.CacheMetric.TERRAIN);
+         long swissAlti3dBytes = sizeFor(EarthCustomizeScreen.CacheMetric.SWISSALTI3D);
+         long ahnBytes = sizeFor(EarthCustomizeScreen.CacheMetric.AHN);
+         long canElevationBytes = sizeFor(EarthCustomizeScreen.CacheMetric.CANELEVATION);
+         long norwayDtm1Bytes = sizeFor(EarthCustomizeScreen.CacheMetric.NORWAYDTM1);
+         long japanGsiBytes = sizeFor(EarthCustomizeScreen.CacheMetric.JAPANGSI);
+         long arcticDemBytes = sizeFor(EarthCustomizeScreen.CacheMetric.ARCTICDEM);
+         long usgsBytes = sizeFor(EarthCustomizeScreen.CacheMetric.USGS);
+         long copernicusBytes = sizeFor(EarthCustomizeScreen.CacheMetric.COPERNICUS);
+         return new EarthCustomizeScreen.CacheSnapshot(
+            true,
+            osmBytes,
+            esaBytes,
+            koppenBytes,
+            terrainBytes,
+            swissAlti3dBytes,
+            ahnBytes,
+            canElevationBytes,
+            norwayDtm1Bytes,
+            japanGsiBytes,
+            arcticDemBytes,
+            usgsBytes,
+            copernicusBytes
+         );
+      }
+
+      private static long sizeFor(EarthCustomizeScreen.CacheMetric metric) {
+         long total = 0L;
+
+         for (Path path : metric.resolvePaths()) {
+            if (Files.exists(path)) {
+               try {
+                  try (Stream<Path> stream = Files.walk(path)) {
+                     total += stream.filter(x$0 -> Files.isRegularFile(x$0)).mapToLong(file -> {
+                        try {
+                           return Files.size(file);
+                        } catch (IOException var2x) {
+                           return 0L;
+                        }
+                     }).sum();
+                  }
+               } catch (IOException var8) {
+                  Tellus.LOGGER.warn("Failed to scan cache at {}", path, var8);
+               }
+            }
+         }
+
+         return total;
+      }
+
+      private static void deleteDirectory(Path root) {
+         if (Files.exists(root)) {
+            Path deleteRoot = moveAsideForDeletion(root);
+            if (deleteRoot != null) {
+               try {
+                  deleteTree(deleteRoot);
+               } catch (IOException var3) {
+                  Tellus.LOGGER.warn("Failed to delete cache folder {}", deleteRoot, var3);
+               }
+            }
+         }
+      }
+
+      private static Path moveAsideForDeletion(Path root) {
+         Path deleteRoot = root.resolveSibling(root.getFileName() + ".deleting-" + System.nanoTime());
+
+         try {
+            Files.move(root, deleteRoot, StandardCopyOption.ATOMIC_MOVE);
+            return deleteRoot;
+         } catch (AtomicMoveNotSupportedException var4) {
+            try {
+               Files.move(root, deleteRoot);
+               return deleteRoot;
+            } catch (IOException var3) {
+               Tellus.LOGGER.warn("Failed to prepare cache folder {} for deletion", root, var3);
+               return null;
+            }
+         } catch (IOException var5) {
+            Tellus.LOGGER.warn("Failed to prepare cache folder {} for deletion", root, var5);
+            return null;
+         }
+      }
+
+      private static void deleteTree(Path root) throws IOException {
+         Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+               Files.deleteIfExists(file);
+               return FileVisitResult.CONTINUE;
+            }
+
+            public FileVisitResult postVisitDirectory(Path dir, IOException error) throws IOException {
+               if (error != null) {
+                  throw error;
+               }
+
+               Files.deleteIfExists(dir);
+               return FileVisitResult.CONTINUE;
+            }
+         });
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static enum CacheMetric {
+      OSM("tellus.cache.section.osm", "tellus/cache/map", TellusCacheDomain.OSM),
+      ESA("tellus.cache.section.esa", "tellus/cache/worldcover2021", TellusCacheDomain.LAND_COVER),
+      KOPPEN("tellus.cache.section.koppen", "tellus/cache/koppen", TellusCacheDomain.KOPPEN),
+      TERRAIN(
+         "tellus.cache.section.terrain",
+         new String[]{"tellus/cache/elevation-tellus", "tellus/cache/elevation-normalized"},
+         new TellusCacheDomain[]{TellusCacheDomain.TERRAIN, TellusCacheDomain.NORMALIZED_TERRAIN}
+      ),
+      SWISSALTI3D("tellus.cache.section.swissalti3d", "tellus/cache/elevation-swissalti3d", TellusCacheDomain.SWISSALTI3D),
+      AHN("tellus.cache.section.ahn", "tellus/cache/elevation-ahn", TellusCacheDomain.AHN),
+      CANELEVATION("tellus.cache.section.canelevation", "tellus/cache/elevation-canelevation", TellusCacheDomain.CANELEVATION),
+      NORWAYDTM1("tellus.cache.section.norwaydtm1", "tellus/cache/elevation-norway-dtm1", TellusCacheDomain.NORWAYDTM1),
+      JAPANGSI("tellus.cache.section.japangsi", "tellus/cache/elevation-japangsi", TellusCacheDomain.JAPANGSI),
+      ARCTICDEM(
+         "tellus.cache.section.arcticdem",
+         new String[]{"tellus/cache/elevation-arcticdem", "tellus/cache/elevation-rema"},
+         new TellusCacheDomain[]{TellusCacheDomain.ARCTICDEM, TellusCacheDomain.REMA}
+      ),
+      USGS("tellus.cache.section.usgs", "tellus/cache/elevation-usgs3dep", TellusCacheDomain.USGS),
+      COPERNICUS("tellus.cache.section.copernicus", "tellus/cache/elevation-copernicus", TellusCacheDomain.COPERNICUS),
+      TOTAL("tellus.cache.section.total", new String[0], new TellusCacheDomain[0]);
+
+      
+      private final String labelKey;
+      private final String[] relativePaths;
+      private final TellusCacheDomain[] domains;
+
+      private CacheMetric( String labelKey,  String relativePath,  TellusCacheDomain domain) {
+         this(
+            labelKey,
+            relativePath == null ? null : new String[]{relativePath},
+            domain == null ? null : new TellusCacheDomain[]{domain}
+         );
+      }
+
+      private CacheMetric( String labelKey,  String[] relativePaths,  TellusCacheDomain[] domains) {
+         this.labelKey = Objects.requireNonNull(labelKey, "labelKey");
+         this.relativePaths = relativePaths;
+         this.domains = domains;
+      }
+
+      
+      private Component label() {
+         return Objects.requireNonNull(Component.translatable(this.labelKey), "cacheLabel");
+      }
+
+      
+      private List<Path> resolvePaths() {
+         if (this.relativePaths == null || this.relativePaths.length == 0) {
+            return List.of();
+         } else {
+            List<Path> paths = new ArrayList<>(this.relativePaths.length);
+
+            for (String relativePath : this.relativePaths) {
+               if (relativePath != null) {
+                  paths.add(Minecraft.getInstance().gameDirectory.toPath().resolve(relativePath));
+               }
+            }
+
+            return paths;
+         }
+      }
+
+      private void clearRuntimeCache() {
+         if (this.domains != null) {
+            for (TellusCacheDomain domain : this.domains) {
+               if (domain != null) {
+                  TellusCacheRegistry.clear(domain);
+               }
+            }
+         }
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record CacheSnapshot(
+      boolean ready,
+      long osmBytes,
+      long esaBytes,
+      long koppenBytes,
+      long terrainBytes,
+      long swissAlti3dBytes,
+      long ahnBytes,
+      long canElevationBytes,
+      long norwayDtm1Bytes,
+      long japanGsiBytes,
+      long arcticDemBytes,
+      long usgsBytes,
+      long copernicusBytes
+   ) {
+      private static EarthCustomizeScreen.CacheSnapshot empty() {
+         return new EarthCustomizeScreen.CacheSnapshot(false, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
+      }
+
+      private long bytesFor(EarthCustomizeScreen.CacheMetric metric) {
+         return switch (metric) {
+            case OSM -> this.osmBytes;
+            case ESA -> this.esaBytes;
+            case KOPPEN -> this.koppenBytes;
+            case TERRAIN -> this.terrainBytes;
+            case SWISSALTI3D -> this.swissAlti3dBytes;
+            case AHN -> this.ahnBytes;
+            case CANELEVATION -> this.canElevationBytes;
+            case NORWAYDTM1 -> this.norwayDtm1Bytes;
+            case JAPANGSI -> this.japanGsiBytes;
+            case ARCTICDEM -> this.arcticDemBytes;
+            case USGS -> this.usgsBytes;
+            case COPERNICUS -> this.copernicusBytes;
+            case TOTAL -> this.totalBytes();
+         };
+      }
+
+      private long totalBytes() {
+         return this.osmBytes
+            + this.esaBytes
+            + this.koppenBytes
+            + this.terrainBytes
+            + this.swissAlti3dBytes
+            + this.ahnBytes
+            + this.canElevationBytes
+            + this.norwayDtm1Bytes
+            + this.japanGsiBytes
+            + this.arcticDemBytes
+            + this.usgsBytes
+            + this.copernicusBytes;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CacheThreadFactory implements ThreadFactory {
+      private int index;
+
+      @Override
+      public Thread newThread(Runnable runnable) {
+         Thread thread = new Thread(runnable, "tellus-cache-" + ++this.index);
+         thread.setDaemon(true);
+         return thread;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class CategoryDefinition {
+      private final String id;
+      private final List<EarthCustomizeScreen.SettingDefinition> settings;
+      private boolean showInRootMenu = true;
+      
+      private String parentCategoryId;
+
+      private CategoryDefinition(String id, List<EarthCustomizeScreen.SettingDefinition> settings) {
+         this.id = id;
+         this.settings = settings;
+      }
+
+      private EarthCustomizeScreen.CategoryDefinition hideFromRoot() {
+         this.showInRootMenu = false;
+         return this;
+      }
+
+      private EarthCustomizeScreen.CategoryDefinition parent( String parentCategoryId) {
+         this.parentCategoryId = Objects.requireNonNull(parentCategoryId, "parentCategoryId");
+         return this;
+      }
+
+      private String getId() {
+         return this.id;
+      }
+
+      
+      private Component getLabel() {
+         return this.getLabel(false);
+      }
+
+      
+      private Component getLabel(boolean selected) {
+         Component base = Objects.requireNonNull(Component.translatable("category.tellus." + this.id + ".name"), "categoryLabel");
+         return !selected ? base : Objects.requireNonNull(base.copy().withStyle(ChatFormatting.YELLOW), "selectedCategoryLabel");
+      }
+
+      private List<EarthCustomizeScreen.SettingDefinition> getSettings() {
+         return this.settings;
+      }
+
+      private boolean showInRootMenu() {
+         return this.showInRootMenu;
+      }
+
+      
+      private String parentCategoryId() {
+         return this.parentCategoryId;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private final class CategoryLinkDefinition implements EarthCustomizeScreen.SettingDefinition {
+      
+      private final EarthCustomizeScreen.CategoryDefinition targetCategory;
+      private boolean active = true;
+      
+      private Component label;
+      private Component tooltip;
+
+      private CategoryLinkDefinition( EarthCustomizeScreen.CategoryDefinition targetCategory) {
+         this.targetCategory = Objects.requireNonNull(targetCategory, "targetCategory");
+      }
+
+      private EarthCustomizeScreen.CategoryLinkDefinition active(boolean active) {
+         this.active = active;
+         return this;
+      }
+
+      private EarthCustomizeScreen.CategoryLinkDefinition withLabel(Component label) {
+         this.label = Objects.requireNonNull(label, "label");
+         return this;
+      }
+
+      private EarthCustomizeScreen.CategoryLinkDefinition withTooltip( Component tooltip) {
+         this.tooltip = tooltip;
+         return this;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         Component label = this.label != null ? this.label : this.targetCategory.getLabel();
+         Button button = Button.builder(label, btn -> EarthCustomizeScreen.this.showCategory(this.targetCategory)).bounds(0, 0, 0, 20).build();
+         button.active = this.active;
+         if (this.tooltip != null) {
+            button.setTooltip(Tooltip.create(this.tooltip));
+         }
+
+         return button;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class DemProviderToggleDefinition implements EarthCustomizeScreen.SettingDefinition {
+      private final EarthGeneratorSettings.DemProvider provider;
+      private boolean value;
+      private boolean forceDisabled;
+      private Component forceDisabledTooltip;
+
+      private DemProviderToggleDefinition(EarthGeneratorSettings.DemProvider provider, boolean defaultValue) {
+         this.provider = Objects.requireNonNull(provider, "provider");
+         this.value = defaultValue;
+      }
+
+      private EarthCustomizeScreen.DemProviderToggleDefinition forceDisabled(boolean forceDisabled) {
+         this.forceDisabled = forceDisabled;
+         if (!forceDisabled) {
+            this.forceDisabledTooltip = null;
+         }
+
+         return this;
+      }
+
+      private EarthCustomizeScreen.DemProviderToggleDefinition forceDisabled(boolean forceDisabled, Component tooltip) {
+         this.forceDisabled = forceDisabled;
+         this.forceDisabledTooltip = forceDisabled ? Objects.requireNonNull(tooltip, "forceDisabledTooltip") : null;
+         return this;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         Component name = EarthCustomizeScreen.formatDemProvider(this.provider);
+         Component tooltip = this.forceDisabled && this.forceDisabledTooltip != null
+            ? this.forceDisabledTooltip
+            : EarthCustomizeScreen.settingTooltip("dem_provider");
+         Builder<Boolean> builder = CycleButton.booleanBuilder(EarthCustomizeScreen.YES, EarthCustomizeScreen.NO)
+            .withInitialValue(this.value)
+            .withTooltip(value -> Tooltip.create(tooltip));
+         CycleButton<Boolean> button = builder.create(0, 0, 0, 20, name, (btn, value) -> {
+            this.value = value;
+            onChange.run();
+         });
+         button.active = !this.forceDisabled;
+         return button;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class DualButtonWidget extends AbstractWidget {
+      private final Button leftButton;
+      private final Button rightButton;
+
+      private DualButtonWidget(
+          Component leftLabel,
+          OnPress leftAction,
+          Component rightLabel,
+          OnPress rightAction,
+         boolean rightActive,
+          Component rightTooltip
+      ) {
+         super(0, 0, 0, 20, Component.empty());
+         this.leftButton = Button.builder(Objects.requireNonNull(leftLabel, "leftLabel"), Objects.requireNonNull(leftAction, "leftAction"))
+            .bounds(0, 0, 0, 20)
+            .build();
+         this.rightButton = Button.builder(Objects.requireNonNull(rightLabel, "rightLabel"), Objects.requireNonNull(rightAction, "rightAction"))
+            .bounds(0, 0, 0, 20)
+            .build();
+         this.rightButton.active = rightActive;
+         if (rightTooltip != null) {
+            this.rightButton.setTooltip(Tooltip.create(rightTooltip));
+         }
+      }
+
+      protected void renderWidget( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         int leftWidth = Math.max(0, (this.width - 4) / 2);
+         int rightWidth = Math.max(0, this.width - leftWidth - 4);
+         int x = this.getX();
+         int y = this.getY();
+         this.leftButton.setX(x);
+         this.leftButton.setY(y);
+         this.leftButton.setWidth(leftWidth);
+         this.leftButton.setHeight(this.height);
+         this.rightButton.setX(x + leftWidth + 4);
+         this.rightButton.setY(y);
+         this.rightButton.setWidth(rightWidth);
+         this.rightButton.setHeight(this.height);
+         this.leftButton.render(graphics, mouseX, mouseY, delta);
+         this.rightButton.render(graphics, mouseX, mouseY, delta);
+      }
+
+      public boolean mouseClicked(double mouseX, double mouseY, int button) {
+         boolean leftClicked = this.leftButton.mouseClicked(mouseX, mouseY, button);
+         boolean rightClicked = this.rightButton.mouseClicked(mouseX, mouseY, button);
+         return leftClicked || rightClicked;
+      }
+
+      protected void onDrag(double mouseX, double mouseY, double deltaX, double deltaY) {
+         this.leftButton.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+         this.rightButton.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+      }
+
+      public void onRelease(double mouseX, double mouseY) {
+         this.leftButton.mouseReleased(mouseX, mouseY, 0);
+         this.rightButton.mouseReleased(mouseX, mouseY, 0);
+      }
+
+      protected void updateWidgetNarration( NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class HmaTokenDefinition implements EarthCustomizeScreen.SettingDefinition {
+      private String value;
+      private EditBox widget;
+
+      private HmaTokenDefinition(String initialValue) {
+         this.value = HmaAccessManager.savedToken();
+         this.setValue(initialValue);
+      }
+
+      private String value() {
+         return this.value;
+      }
+
+      private void setValue(String value) {
+         String normalized = HmaAccessManager.normalizeToken(value);
+         this.value = normalized;
+         EditBox widget = this.widget;
+         if (widget != null && !Objects.equals(widget.getValue(), normalized)) {
+            widget.setValue(normalized);
+         }
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         EditBox widget = new EditBox(Minecraft.getInstance().font, 0, 0, 0, 20, Component.literal("Earthdata bearer token"));
+         widget.setMaxLength(4096);
+         widget.setHint(Component.translatable("tellus.hma_access.token.hint"));
+         widget.setTooltip(Tooltip.create(Component.translatable("tellus.hma_access.token.tooltip")));
+         widget.setValue(this.value);
+         widget.setResponder(value -> {
+            String normalized = HmaAccessManager.normalizeToken(value);
+            this.value = normalized;
+            HmaAccessManager.onTokenEdited(normalized);
+         });
+         this.widget = widget;
+         return widget;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class HmaAccessButtonsDefinition implements EarthCustomizeScreen.SettingDefinition {
+      private final EarthCustomizeScreen.HmaTokenDefinition tokenDefinition;
+
+      private HmaAccessButtonsDefinition(EarthCustomizeScreen.HmaTokenDefinition tokenDefinition) {
+         this.tokenDefinition = Objects.requireNonNull(tokenDefinition, "tokenDefinition");
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         return new EarthCustomizeScreen.HmaAccessButtonsWidget(this.tokenDefinition);
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class HmaAccessButtonsWidget extends AbstractWidget {
+      private final EarthCustomizeScreen.HmaTokenDefinition tokenDefinition;
+      private final Button saveButton;
+      private final Button testButton;
+      private final Button clearButton;
+
+      private HmaAccessButtonsWidget(EarthCustomizeScreen.HmaTokenDefinition tokenDefinition) {
+         super(0, 0, 0, 20, Component.empty());
+         this.tokenDefinition = Objects.requireNonNull(tokenDefinition, "tokenDefinition");
+         this.saveButton = Button.builder(Component.translatable("tellus.hma_access.action.save"), btn -> {
+            HmaAccessManager.saveToken(this.tokenDefinition.value());
+         }).bounds(0, 0, 0, 20).build();
+         this.testButton = Button.builder(Component.translatable("tellus.hma_access.action.test"), btn -> {
+            HmaAccessManager.testToken(this.tokenDefinition.value());
+         }).bounds(0, 0, 0, 20).build();
+         this.clearButton = Button.builder(Component.translatable("tellus.hma_access.action.clear"), btn -> {
+            this.tokenDefinition.setValue("");
+            HmaAccessManager.clearToken();
+         }).bounds(0, 0, 0, 20).build();
+      }
+
+      protected void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         String currentToken = HmaAccessManager.normalizeToken(this.tokenDefinition.value());
+         String savedToken = HmaAccessManager.savedToken();
+         this.saveButton.active = HmaAccessManager.canSaveToken(currentToken);
+         this.testButton.active = !currentToken.isBlank() && !HmaAccessManager.isTesting();
+         this.clearButton.active = !currentToken.isBlank() || !savedToken.isBlank();
+         int gap = 4;
+         int buttonWidth = Math.max(0, (this.width - gap * 2) / 3);
+         int remaining = Math.max(0, this.width - buttonWidth * 3 - gap * 2);
+         int x = this.getX();
+         int y = this.getY();
+         this.saveButton.setX(x);
+         this.saveButton.setY(y);
+         this.saveButton.setWidth(buttonWidth);
+         this.saveButton.setHeight(this.height);
+         this.testButton.setX(x + buttonWidth + gap);
+         this.testButton.setY(y);
+         this.testButton.setWidth(buttonWidth);
+         this.testButton.setHeight(this.height);
+         this.clearButton.setX(x + (buttonWidth + gap) * 2);
+         this.clearButton.setY(y);
+         this.clearButton.setWidth(buttonWidth + remaining);
+         this.clearButton.setHeight(this.height);
+         this.saveButton.render(graphics, mouseX, mouseY, delta);
+         this.testButton.render(graphics, mouseX, mouseY, delta);
+         this.clearButton.render(graphics, mouseX, mouseY, delta);
+      }
+
+      public boolean mouseClicked(double mouseX, double mouseY, int button) {
+         boolean saveClicked = this.saveButton.mouseClicked(mouseX, mouseY, button);
+         boolean testClicked = this.testButton.mouseClicked(mouseX, mouseY, button);
+         boolean clearClicked = this.clearButton.mouseClicked(mouseX, mouseY, button);
+         return saveClicked || testClicked || clearClicked;
+      }
+
+      protected void onDrag(double mouseX, double mouseY, double deltaX, double deltaY) {
+         this.saveButton.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+         this.testButton.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+         this.clearButton.mouseDragged(mouseX, mouseY, 0, deltaX, deltaY);
+      }
+
+      public void onRelease(double mouseX, double mouseY) {
+         this.saveButton.mouseReleased(mouseX, mouseY, 0);
+         this.testButton.mouseReleased(mouseX, mouseY, 0);
+         this.clearButton.mouseReleased(mouseX, mouseY, 0);
+      }
+
+      protected void updateWidgetNarration(NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class HmaAccessStatusDefinition implements EarthCustomizeScreen.SettingDefinition {
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         return new EarthCustomizeScreen.HmaAccessStatusWidget();
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class HmaAccessStatusWidget extends AbstractWidget {
+      private HmaAccessStatusWidget() {
+         super(0, 0, 0, 20, Component.empty());
+      }
+
+      protected void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         EarthCustomizeScreen.HmaAccessState state = HmaAccessManager.state();
+         Font font = Minecraft.getInstance().font;
+         int textWidth = font.width(state.message());
+         int textX = this.getX() + Math.max(0, (this.width - textWidth) / 2);
+         int textY = this.getY() + (this.height - 9) / 2;
+         graphics.drawString(font, state.message(), textX, textY, state.color(), false);
+      }
+
+      protected void updateWidgetNarration(NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class EarthSlider extends AbstractSliderButton {
+      private final EarthCustomizeScreen.SliderDefinition definition;
+      private final Runnable onChange;
+
+      private EarthSlider(int x, int y, int width, int height, EarthCustomizeScreen.SliderDefinition definition, Runnable onChange) {
+         super(x, y, width, height, Component.empty(), 0.0);
+         this.definition = definition;
+         this.onChange = onChange;
+         this.value = this.toPosition(definition.value);
+         this.updateMessage();
+      }
+
+      protected void updateMessage() {
+         double value = this.toValue(this.value);
+         String fallback = Objects.requireNonNull(String.format(Locale.ROOT, "%.2f", value), "formattedValue");
+         String valueText = this.definition.display != null ? Objects.requireNonNullElse(this.definition.display.apply(value), fallback) : fallback;
+         MutableComponent message = EarthCustomizeScreen.settingName(this.definition.key)
+            .copy()
+            .append(": ")
+            .append(Component.literal(Objects.requireNonNull(valueText, "valueText")));
+         this.setMessage(message);
+      }
+
+      protected void applyValue() {
+         double rawValue = this.toValue(this.value);
+         double snappedValue = this.snap(rawValue, this.definition.step);
+         if (Math.abs(snappedValue - rawValue) > 1.0E-6) {
+            this.value = this.toPosition(snappedValue);
+         }
+
+         if (Math.abs(this.definition.value - snappedValue) > 1.0E-6) {
+            this.definition.value = snappedValue;
+            this.onChange.run();
+         }
+      }
+
+      private double snap(double value, double step) {
+         double effectiveStep = step;
+         if ("world_scale".equals(this.definition.key) && EarthCustomizeScreen.isShiftDown()) {
+            effectiveStep = Math.max(0.1, step / 50.0);
+         }
+
+         if (effectiveStep <= 0.0) {
+            return Mth.clamp(value, this.definition.min, this.definition.max);
+         } else if ("world_scale".equals(this.definition.key)) {
+            double firstStep = this.definition.min;
+            double cutoff = (firstStep + effectiveStep) * 0.5;
+            if (value <= cutoff) {
+               return firstStep;
+            } else {
+               double snapped = Math.round(value / effectiveStep) * effectiveStep;
+               if (effectiveStep < 1.0) {
+                  snapped = Math.round(snapped * 10.0) / 10.0;
+               }
+
+               double adjusted = Math.max(effectiveStep, snapped);
+               return Mth.clamp(adjusted, this.definition.min, this.definition.max);
+            }
+         } else {
+            double snapped = this.definition.min + Math.round((value - this.definition.min) / effectiveStep) * effectiveStep;
+            return Mth.clamp(snapped, this.definition.min, this.definition.max);
+         }
+      }
+
+      private double toPosition(double value) {
+         double position = (Mth.clamp(value, this.definition.min, this.definition.max) - this.definition.min) / (this.definition.max - this.definition.min);
+         return this.definition.scale.reverse(position);
+      }
+
+      private double toValue(double position) {
+         double scaled = this.definition.scale.apply(position);
+         return this.definition.min + (this.definition.max - this.definition.min) * Mth.clamp(scaled, 0.0, 1.0);
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class ModeDefinition implements EarthCustomizeScreen.SettingDefinition {
+      
+      private static final List<EarthGeneratorSettings.DistantHorizonsRenderMode> MODES = createModes();
+      private final String key;
+      private EarthGeneratorSettings.DistantHorizonsRenderMode value;
+      private boolean locked;
+      private boolean forceDisabled;
+      private boolean unavailable;
+      
+      private Component unavailableTooltip;
+
+      
+      private static List<EarthGeneratorSettings.DistantHorizonsRenderMode> createModes() {
+         List<EarthGeneratorSettings.DistantHorizonsRenderMode> modes = new ArrayList<>(3);
+         modes.add(EarthGeneratorSettings.DistantHorizonsRenderMode.DETAILED);
+         modes.add(EarthGeneratorSettings.DistantHorizonsRenderMode.FAST);
+         modes.add(EarthGeneratorSettings.DistantHorizonsRenderMode.ULTRA_FAST);
+         return modes;
+      }
+
+      private ModeDefinition(String key, EarthGeneratorSettings.DistantHorizonsRenderMode defaultValue) {
+         this.key = key;
+         this.value = defaultValue;
+      }
+
+      private EarthCustomizeScreen.ModeDefinition unavailable( Component tooltip) {
+         this.unavailable = true;
+         this.unavailableTooltip = Objects.requireNonNull(tooltip, "unavailableTooltip");
+         return this;
+      }
+
+      private EarthCustomizeScreen.ModeDefinition forceDisabled(boolean forceDisabled) {
+         this.forceDisabled = forceDisabled;
+         return this;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         Component name = EarthCustomizeScreen.settingName(this.key);
+         Component tooltip = this.unavailableTooltip != null
+            ? this.unavailableTooltip
+            : (this.locked ? EarthCustomizeScreen.workInProgressTooltip(this.key) : EarthCustomizeScreen.settingTooltip(this.key));
+         Builder<EarthGeneratorSettings.DistantHorizonsRenderMode> builder = CycleButton.builder(EarthCustomizeScreen::formatRenderMode)
+            .withInitialValue(this.value)
+            .withValues(MODES)
+            .withTooltip(value -> Tooltip.create(tooltip));
+         CycleButton<EarthGeneratorSettings.DistantHorizonsRenderMode> button = builder.create(0, 0, 0, 20, name, (btn, value) -> {
+            this.value = value;
+            onChange.run();
+         });
+         button.active = !this.locked && !this.forceDisabled && !this.unavailable;
+         return button;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private record RegistryUpdate(LayeredRegistryAccess<RegistryLayer> registries, Holder<DimensionType> holder) {
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private interface SettingDefinition {
+      AbstractWidget createWidget(Runnable var1);
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class SliderDefinition implements EarthCustomizeScreen.SettingDefinition {
+      private final String key;
+      private final double min;
+      private final double max;
+      private final double step;
+      private double value;
+      private DoubleFunction<String> display;
+      private EarthCustomizeScreen.SliderScale scale = EarthCustomizeScreen.SliderScale.linear();
+      private boolean locked;
+      private boolean forceDisabled;
+      private boolean unavailable;
+      
+      private Component unavailableTooltip;
+
+      private SliderDefinition(String key, double defaultValue, double min, double max, double step) {
+         this.key = key;
+         this.value = defaultValue;
+         this.min = min;
+         this.max = max;
+         this.step = step;
+      }
+
+      private EarthCustomizeScreen.SliderDefinition withDisplay(DoubleFunction<String> display) {
+         this.display = display;
+         return this;
+      }
+
+      private EarthCustomizeScreen.SliderDefinition withScale(EarthCustomizeScreen.SliderScale scale) {
+         this.scale = scale;
+         return this;
+      }
+
+      private EarthCustomizeScreen.SliderDefinition locked(boolean locked) {
+         this.locked = locked;
+         return this;
+      }
+
+      private EarthCustomizeScreen.SliderDefinition forceDisabled(boolean forceDisabled) {
+         this.forceDisabled = forceDisabled;
+         return this;
+      }
+
+      private EarthCustomizeScreen.SliderDefinition unavailable( Component tooltip) {
+         this.unavailable = true;
+         this.unavailableTooltip = Objects.requireNonNull(tooltip, "unavailableTooltip");
+         return this;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         EarthCustomizeScreen.EarthSlider slider = new EarthCustomizeScreen.EarthSlider(0, 0, 0, 20, this, onChange);
+         Component tooltip = this.unavailableTooltip != null
+            ? this.unavailableTooltip
+            : (this.locked ? EarthCustomizeScreen.workInProgressTooltip(this.key) : EarthCustomizeScreen.settingTooltip(this.key));
+         slider.setTooltip(Tooltip.create(tooltip));
+         slider.active = !this.locked && !this.forceDisabled && !this.unavailable;
+         return slider;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private interface SliderScale {
+      double apply(double var1);
+
+      double reverse(double var1);
+
+      static EarthCustomizeScreen.SliderScale linear() {
+         return new EarthCustomizeScreen.SliderScale() {
+            @Override
+            public double apply(double value) {
+               return value;
+            }
+
+            @Override
+            public double reverse(double value) {
+               return value;
+            }
+         };
+      }
+
+      static EarthCustomizeScreen.SliderScale power(double power) {
+         return new EarthCustomizeScreen.SliderScale() {
+            @Override
+            public double apply(double value) {
+               return Math.pow(value, power);
+            }
+
+            @Override
+            public double reverse(double value) {
+               return Math.pow(value, 1.0 / power);
+            }
+         };
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class SpacerDefinition implements EarthCustomizeScreen.SettingDefinition {
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         return new EarthCustomizeScreen.SpacerWidget();
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class SpacerWidget extends AbstractWidget {
+      private SpacerWidget() {
+         super(0, 0, 0, 20, Component.empty());
+      }
+
+      protected void renderWidget( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      }
+
+      protected void updateWidgetNarration( NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class TextLineDefinition implements EarthCustomizeScreen.SettingDefinition {
+      
+      private final Component text;
+      private final int color;
+      
+      private final String url;
+
+      private TextLineDefinition(Component text, int color,  String url) {
+         this.text = Objects.requireNonNull(text, "text");
+         this.color = color;
+         this.url = url;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         return new EarthCustomizeScreen.TextLineWidget(this.text, this.color, this.url);
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class TextLineWidget extends AbstractWidget {
+      
+      private final Component text;
+      private final int color;
+      
+      private final String url;
+
+      private TextLineWidget(Component text, int color,  String url) {
+         super(0, 0, 0, 20, Component.empty());
+         this.text = Objects.requireNonNull(text, "text");
+         this.color = color;
+         this.url = url;
+      }
+
+      protected void renderWidget( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         if (!this.text.getString().isEmpty()) {
+            Font font = Minecraft.getInstance().font;
+            int textWidth = font.width(this.text);
+            boolean hover = this.url != null && this.isMouseOver(mouseX, mouseY);
+            int drawColor = hover ? -5570561 : this.color;
+            int availableWidth = Math.max(1, this.width - 8);
+            float scale = textWidth > availableWidth ? (float)availableWidth / (float)textWidth : 1.0F;
+            float scaledWidth = textWidth * scale;
+            float scaledHeight = 9.0F * scale;
+            float textX = this.getX() + (this.width - scaledWidth) * 0.5F;
+            float textY = this.getY() + (this.height - scaledHeight) * 0.5F;
+            graphics.pose().pushPose();
+            graphics.pose().translate(textX, textY, 0.0F);
+            graphics.pose().scale(scale, scale, 1.0F);
+            graphics.drawString(font, this.text, 0, 0, drawColor, true);
+            if (this.url != null) {
+               int underlineY = 9;
+               graphics.fill(0, underlineY, textWidth, underlineY + 1, drawColor);
+            }
+
+            graphics.pose().popPose();
+         }
+      }
+
+      public boolean mouseClicked(double mouseX, double mouseY, int button) {
+         String url = this.url;
+         if (url != null && button == 0 && this.isMouseOver(mouseX, mouseY)) {
+            Util.getPlatform().openUri(url);
+            return true;
+         } else {
+            return false;
+         }
+      }
+
+      protected void updateWidgetNarration( NarrationElementOutput narration) {
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class ToggleDefinition implements EarthCustomizeScreen.SettingDefinition {
+      private final String key;
+      private boolean value;
+      private boolean locked;
+      private boolean forceDisabled;
+      private boolean unavailable;
+      
+      private Component unavailableTooltip;
+      
+      private Component forceDisabledTooltip;
+
+      private ToggleDefinition(String key, boolean defaultValue) {
+         this.key = key;
+         this.value = defaultValue;
+      }
+
+      private EarthCustomizeScreen.ToggleDefinition locked(boolean locked) {
+         this.locked = locked;
+         return this;
+      }
+
+      private EarthCustomizeScreen.ToggleDefinition forceDisabled(boolean forceDisabled) {
+         this.forceDisabled = forceDisabled;
+         if (!forceDisabled) {
+            this.forceDisabledTooltip = null;
+         }
+
+         return this;
+      }
+
+      private EarthCustomizeScreen.ToggleDefinition forceDisabled(boolean forceDisabled, Component tooltip) {
+         this.forceDisabled = forceDisabled;
+         this.forceDisabledTooltip = forceDisabled ? Objects.requireNonNull(tooltip, "forceDisabledTooltip") : null;
+         return this;
+      }
+
+      private EarthCustomizeScreen.ToggleDefinition unavailable( Component tooltip) {
+         this.unavailable = true;
+         this.unavailableTooltip = Objects.requireNonNull(tooltip, "unavailableTooltip");
+         return this;
+      }
+
+      @Override
+      public AbstractWidget createWidget(Runnable onChange) {
+         Component name = EarthCustomizeScreen.settingName(this.key);
+         Component tooltip = this.unavailableTooltip != null
+            ? this.unavailableTooltip
+            : (this.forceDisabled && this.forceDisabledTooltip != null
+               ? this.forceDisabledTooltip
+               : (this.locked ? EarthCustomizeScreen.workInProgressTooltip(this.key) : EarthCustomizeScreen.settingTooltip(this.key)));
+         Builder<Boolean> builder = CycleButton.booleanBuilder(EarthCustomizeScreen.YES, EarthCustomizeScreen.NO)
+            .withInitialValue(this.value)
+            .withTooltip(value -> Tooltip.create(tooltip));
+         CycleButton<Boolean> button = builder.create(0, 0, 0, 20, name, (btn, value) -> {
+            this.value = value;
+            onChange.run();
+         });
+         button.active = !this.locked && !this.forceDisabled && !this.unavailable;
+         return button;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/screen/EarthSpawnpointScreen.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/screen/EarthSpawnpointScreen.java
@@ -1,0 +1,141 @@
+package com.yucareux.tellus.client.screen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.client.widget.map.PlaceSearchWidget;
+import com.yucareux.tellus.client.widget.map.SlippyMapPoint;
+import com.yucareux.tellus.client.widget.map.SlippyMapWidget;
+import com.yucareux.tellus.client.widget.map.component.MarkerMapComponent;
+import com.yucareux.tellus.world.data.source.Geocoder;
+import com.yucareux.tellus.world.data.source.NominatimGeocoder;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+@OnlyIn(Dist.CLIENT)
+public class EarthSpawnpointScreen extends Screen {
+   private final EarthCustomizeScreen parent;
+   private SlippyMapWidget mapWidget;
+   private MarkerMapComponent markerComponent;
+   private PlaceSearchWidget searchWidget;
+   private boolean suppressMapRelease;
+
+   public EarthSpawnpointScreen(EarthCustomizeScreen parent) {
+      super(Component.translatable("gui.earth.spawnpoint"));
+      this.parent = parent;
+   }
+
+   protected void init() {
+      if (this.mapWidget != null) {
+         this.mapWidget.close();
+      }
+
+      int mapX = 0;
+      int mapY = 0;
+      int mapWidth = this.width;
+      int mapHeight = this.height;
+      this.mapWidget = new SlippyMapWidget(mapX, mapY, mapWidth, mapHeight);
+      this.mapWidget.setAttributionBottomPadding(28);
+      double latitude = this.parent.getSpawnLatitude();
+      double longitude = this.parent.getSpawnLongitude();
+      this.markerComponent = new MarkerMapComponent(new SlippyMapPoint(latitude, longitude)).allowMovement();
+      this.mapWidget.addComponent(this.markerComponent);
+      this.mapWidget.getMap().focus(latitude, longitude, 4);
+      Geocoder geocoder = new NominatimGeocoder();
+      this.searchWidget = new PlaceSearchWidget(mapX + 12, mapY + 12, 220, 20, geocoder, this::handleSearch);
+      this.addRenderableOnly(this.mapWidget);
+      this.addRenderableWidget(this.searchWidget);
+      int buttonY = this.height - 28;
+      this.addRenderableWidget(Button.builder(Component.translatable("gui.done"), button -> {
+         SlippyMapPoint marker = this.markerComponent.getMarker();
+         if (marker != null) {
+            this.parent.applySpawnpoint(marker.getLatitude(), marker.getLongitude());
+         }
+
+         this.minecraft.setScreen(this.parent);
+      }).bounds(this.width / 2 - 154, buttonY, 150, 20).build());
+      this.addRenderableWidget(
+         Button.builder(Component.translatable("gui.cancel"), button -> this.minecraft.setScreen(this.parent))
+            .bounds(this.width / 2 + 4, buttonY, 150, 20)
+            .build()
+      );
+      this.addWidget(this.mapWidget);
+   }
+
+   protected void setInitialFocus() {
+      if (this.searchWidget != null) {
+         this.setInitialFocus(this.searchWidget);
+      }
+   }
+
+   private void handleSearch(double latitude, double longitude) {
+      this.markerComponent.moveMarker(latitude, longitude);
+      this.mapWidget.getMap().focus(latitude, longitude, 12);
+   }
+
+   @Override
+   public boolean mouseClicked(double mouseX, double mouseY, int button) {
+      if (this.isSearchOverlayMouseOver(mouseX, mouseY)) {
+         this.suppressMapRelease = true;
+         this.cancelMapInteraction();
+         this.setFocused(this.searchWidget);
+         this.searchWidget.setFocused(true);
+         this.searchWidget.mouseClicked(mouseX, mouseY, button);
+         return true;
+      }
+
+      this.suppressMapRelease = false;
+      return super.mouseClicked(mouseX, mouseY, button);
+   }
+
+   @Override
+   public boolean mouseReleased(double mouseX, double mouseY, int button) {
+      if (this.suppressMapRelease || this.isSearchOverlayMouseOver(mouseX, mouseY)) {
+         this.suppressMapRelease = false;
+         this.cancelMapInteraction();
+         return true;
+      }
+
+      return super.mouseReleased(mouseX, mouseY, button);
+   }
+
+   public void render( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      graphics.fill(0, 0, this.width, this.height, -1072689136);
+      graphics.drawCenteredString(this.font, this.title, this.width / 2, 4, 16777215);
+      super.render(graphics, mouseX, mouseY, delta);
+   }
+
+   public void tick() {
+      super.tick();
+      if (this.searchWidget != null) {
+         this.searchWidget.tick();
+      }
+   }
+
+   public void onClose() {
+      if (this.minecraft != null) {
+         this.minecraft.setScreen(this.parent);
+      }
+   }
+
+   public void removed() {
+      if (this.mapWidget != null) {
+         this.mapWidget.close();
+      }
+
+      if (this.searchWidget != null) {
+         this.searchWidget.close();
+      }
+   }
+
+   private boolean isSearchOverlayMouseOver(double mouseX, double mouseY) {
+      return this.searchWidget != null && this.searchWidget.isMouseOver(mouseX, mouseY);
+   }
+
+   private void cancelMapInteraction() {
+      if (this.mapWidget != null) {
+         this.mapWidget.cancelInteraction();
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/screen/EarthTeleportScreen.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/screen/EarthTeleportScreen.java
@@ -1,0 +1,124 @@
+package com.yucareux.tellus.client.screen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.client.widget.map.PlaceSearchWidget;
+import com.yucareux.tellus.client.widget.map.SlippyMapPoint;
+import com.yucareux.tellus.client.widget.map.SlippyMapWidget;
+import com.yucareux.tellus.client.widget.map.component.MarkerMapComponent;
+import com.yucareux.tellus.network.GeoTpTeleportPayload;
+import com.yucareux.tellus.world.data.source.Geocoder;
+import com.yucareux.tellus.world.data.source.NominatimGeocoder;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+@OnlyIn(Dist.CLIENT)
+public class EarthTeleportScreen extends Screen {
+   private static final int DEFAULT_ZOOM = 6;
+   
+   private final Screen parent;
+   private final double initialLatitude;
+   private final double initialLongitude;
+   private SlippyMapWidget mapWidget;
+   private MarkerMapComponent markerComponent;
+   private PlaceSearchWidget searchWidget;
+
+   public EarthTeleportScreen( Screen parent, double latitude, double longitude) {
+      super(Component.translatable("gui.earth.teleport_map"));
+      this.parent = parent;
+      this.initialLatitude = latitude;
+      this.initialLongitude = longitude;
+   }
+
+   protected void init() {
+      if (this.mapWidget != null) {
+         this.mapWidget.close();
+      }
+
+      int mapX = 20;
+      int mapY = 20;
+      int mapWidth = this.width - 40;
+      int mapHeight = this.height - 60;
+      this.mapWidget = new SlippyMapWidget(mapX, mapY, mapWidth, mapHeight);
+      this.markerComponent = new MarkerMapComponent(new SlippyMapPoint(this.initialLatitude, this.initialLongitude)).allowMovement();
+      this.mapWidget.addComponent(this.markerComponent);
+      this.mapWidget.getMap().focus(this.initialLatitude, this.initialLongitude, DEFAULT_ZOOM);
+      Geocoder geocoder = new NominatimGeocoder();
+      this.searchWidget = new PlaceSearchWidget(mapX + 5, mapY + 5, 200, 20, geocoder, this::handleSearch);
+      this.addRenderableOnly(this.mapWidget);
+      this.addRenderableWidget(this.searchWidget);
+      int buttonY = this.height - 28;
+      this.addRenderableWidget(
+         Button.builder(Component.translatable("gui.earth.teleport"), button -> this.sendTeleport()).bounds(this.width / 2 - 154, buttonY, 150, 20).build()
+      );
+      this.addRenderableWidget(
+         Button.builder(Component.translatable("gui.cancel"), button -> this.closeScreen()).bounds(this.width / 2 + 4, buttonY, 150, 20).build()
+      );
+      this.addWidget(this.mapWidget);
+   }
+
+   protected void setInitialFocus() {
+      if (this.searchWidget != null) {
+         this.setInitialFocus(this.searchWidget);
+      }
+   }
+
+   private void handleSearch(double latitude, double longitude) {
+      this.markerComponent.moveMarker(latitude, longitude);
+      this.mapWidget.getMap().focus(latitude, longitude, 12);
+   }
+
+   private void sendTeleport() {
+      if (this.markerComponent != null) {
+         SlippyMapPoint marker = this.markerComponent.getMarker();
+         if (marker != null && this.minecraft != null) {
+            if (!true) {
+               if (this.minecraft.player != null) {
+                  this.minecraft.player.displayClientMessage(Component.literal("Tellus: Server does not accept GeoTP requests."), true);
+               }
+
+               this.closeScreen();
+            } else {
+               PacketDistributor.sendToServer(new GeoTpTeleportPayload(marker.getLatitude(), marker.getLongitude()));
+               this.closeScreen();
+            }
+         }
+      }
+   }
+
+   private void closeScreen() {
+      if (this.minecraft != null) {
+         this.minecraft.setScreen(this.parent);
+      }
+   }
+
+   public void render( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      graphics.fill(0, 0, this.width, this.height, -1072689136);
+      graphics.drawCenteredString(this.font, this.title, this.width / 2, 4, 16777215);
+      super.render(graphics, mouseX, mouseY, delta);
+   }
+
+   public void tick() {
+      super.tick();
+      if (this.searchWidget != null) {
+         this.searchWidget.tick();
+      }
+   }
+
+   public void onClose() {
+      this.closeScreen();
+   }
+
+   public void removed() {
+      if (this.mapWidget != null) {
+         this.mapWidget.close();
+      }
+
+      if (this.searchWidget != null) {
+         this.searchWidget.close();
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/screen/TerrainPreviewScreen.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/screen/TerrainPreviewScreen.java
@@ -1,0 +1,69 @@
+package com.yucareux.tellus.client.screen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.client.preview.TerrainPreview;
+import com.yucareux.tellus.client.preview.TerrainPreviewWidget;
+import java.util.Objects;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+@OnlyIn(Dist.CLIENT)
+public class TerrainPreviewScreen extends Screen {
+   
+   private final EarthCustomizeScreen parent;
+   
+   private final TerrainPreview preview;
+   
+   private final TerrainPreviewWidget.ViewState initialView;
+   private TerrainPreviewWidget previewWidget;
+
+   public TerrainPreviewScreen( EarthCustomizeScreen parent,  TerrainPreview preview,  TerrainPreviewWidget.ViewState initialView) {
+      super(Component.empty());
+      this.parent = Objects.requireNonNull(parent, "parent");
+      this.preview = Objects.requireNonNull(preview, "preview");
+      this.initialView = Objects.requireNonNull(initialView, "initialView");
+   }
+
+   protected void init() {
+      if (this.previewWidget != null) {
+         this.previewWidget.close();
+      }
+
+      this.previewWidget = new TerrainPreviewWidget(0, 0, this.width, this.height, this.preview);
+      this.previewWidget.setViewState(this.initialView);
+      this.previewWidget.setFullscreenAction(this::onClose);
+      this.previewWidget.setAutoAdjustAction(this.parent::applyPreviewAutoAdjust);
+      this.addRenderableOnly(this.previewWidget);
+      int buttonY = this.height - 28;
+      this.addRenderableWidget(
+         Button.builder(Component.translatable("gui.back"), button -> this.onClose()).bounds(this.width / 2 - 75, buttonY, 150, 20).build()
+      );
+      this.addWidget(this.previewWidget);
+   }
+
+   public void tick() {
+      super.tick();
+      if (this.previewWidget != null) {
+         this.previewWidget.tick();
+      }
+   }
+
+   public void onClose() {
+      if (this.minecraft != null) {
+         if (this.previewWidget != null) {
+            TerrainPreviewWidget.ViewState viewState = Objects.requireNonNull(this.previewWidget.getViewState(), "viewState");
+            this.parent.applyPreviewViewState(viewState);
+         }
+
+         this.minecraft.setScreen(this.parent);
+      }
+   }
+
+   public void removed() {
+      if (this.previewWidget != null) {
+         this.previewWidget.close();
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/CustomizationList.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/CustomizationList.java
@@ -1,0 +1,71 @@
+package com.yucareux.tellus.client.widget;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.List;
+import java.util.Objects;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.ContainerObjectSelectionList;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+
+@OnlyIn(Dist.CLIENT)
+public class CustomizationList extends ContainerObjectSelectionList<CustomizationList.Entry> {
+   public CustomizationList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
+      super(minecraft, width, height, y, itemHeight);
+      this.centerListVertically = false;
+   }
+
+   public void clear() {
+      this.clearEntries();
+   }
+
+   public void addWidget(AbstractWidget widget) {
+      this.addEntry(new CustomizationList.Entry(widget));
+   }
+
+   public int getRowWidth() {
+      return this.width - 20;
+   }
+
+   protected int scrollBarX() {
+      return this.getX() + this.width - 6;
+   }
+
+   protected void renderListBackground( GuiGraphics graphics) {
+   }
+
+   protected void renderListSeparators( GuiGraphics graphics) {
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public static class Entry extends net.minecraft.client.gui.components.ContainerObjectSelectionList.Entry<CustomizationList.Entry> {
+      private final AbstractWidget widget;
+
+      public Entry(AbstractWidget widget) {
+         this.widget = Objects.requireNonNull(widget, "widget");
+      }
+
+      
+      public List<? extends GuiEventListener> children() {
+         return Objects.requireNonNull(List.of(this.widget), "children");
+      }
+
+      
+      public List<? extends NarratableEntry> narratables() {
+         return Objects.requireNonNull(List.of(this.widget), "narratables");
+      }
+
+      public void render(
+         GuiGraphics graphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovered, float delta
+      ) {
+         this.widget.setX(left);
+         this.widget.setY(top);
+         this.widget.setWidth(width);
+         this.widget.setHeight(height);
+         this.widget.render(graphics, mouseX, mouseY, delta);
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/PlaceSearchWidget.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/PlaceSearchWidget.java
@@ -1,0 +1,342 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.world.data.source.Geocoder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.network.chat.Component;
+
+@OnlyIn(Dist.CLIENT)
+public class PlaceSearchWidget extends EditBox {
+   private static final int SUGGESTION_COUNT = 5;
+   private static final int SUGGESTION_HEIGHT = 20;
+   private static final int SUGGESTION_GAP = 2;
+   private static final long SUGGESTION_DEBOUNCE_MS = 250L;
+   private static final int SEARCH_TEXT_OFFSET_X = 4;
+   private static final int SUGGESTION_TEXT_PADDING = 6;
+   private static final int SUGGESTION_SCROLL_PADDING = 12;
+   private static final float SUGGESTION_SCROLL_SPEED = 28.0F;
+   private final Geocoder geocoder;
+   private final PlaceSearchWidget.SearchHandler searchHandler;
+   private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+      new ThreadFactoryBuilder().setNameFormat("tellus-geocoder-%d").setDaemon(true).build()
+   );
+   private final List<Geocoder.Suggestion> suggestions = new ArrayList<>(SUGGESTION_COUNT);
+   private final List<Button> suggestionButtons = new ArrayList<>(SUGGESTION_COUNT);
+   private ScheduledFuture<?> pendingSuggestTask;
+   private long suggestionRequestId;
+   private PlaceSearchWidget.State state = PlaceSearchWidget.State.OK;
+   private boolean pause;
+   private String lastInputText = "";
+
+   public PlaceSearchWidget(int x, int y, int width, int height, Geocoder geocoder, PlaceSearchWidget.SearchHandler searchHandler) {
+      super(Minecraft.getInstance().font, x, y, width, height, Component.translatable("gui.earth.search"));
+      this.geocoder = geocoder;
+      this.searchHandler = searchHandler;
+      this.setBordered(false);
+      this.setMaxLength(256);
+      this.setHint(Component.translatable("gui.earth.search"));
+   }
+
+   public void tick() {
+      String text = this.getValue().trim();
+      if (!text.equals(this.lastInputText)) {
+         this.lastInputText = text;
+         this.state = PlaceSearchWidget.State.OK;
+         this.pause = false;
+         if (!this.pause && !text.isEmpty()) {
+            this.scheduleSuggestions(text);
+         }
+      }
+
+      if (this.pause || text.isEmpty()) {
+         this.cancelPendingSuggest();
+         this.clearSuggestions();
+      }
+   }
+
+   public void renderWidget( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      int x = this.getX();
+      int y = this.getY();
+      int width = this.getWidth();
+      int height = this.getHeight();
+      graphics.fill(x - 1, y - 1, x + width + 1, y + height + 1, -6250336);
+      graphics.fill(x, y, x + width, y + height, this.state.getBackgroundColor());
+      graphics.pose().pushPose();
+      graphics.pose().translate((float)SEARCH_TEXT_OFFSET_X, (height - 8) / 2.0F - 1.0F, 0.0F);
+      super.renderWidget(graphics, mouseX, mouseY, delta);
+      graphics.pose().popPose();
+      if (this.shouldShowSuggestions()) {
+         this.layoutSuggestionButtons();
+
+         for (Button button : this.suggestionButtons) {
+            button.render(graphics, mouseX, mouseY, delta);
+         }
+      }
+   }
+
+   public boolean mouseClicked(double mouseX, double mouseY, int button) {
+      if (this.isVisible() && this.shouldShowSuggestions() && button == 0) {
+         for (Button suggestionButton : this.suggestionButtons) {
+            if (suggestionButton.mouseClicked(mouseX, mouseY, button)) {
+               return true;
+            }
+         }
+      }
+
+      return super.mouseClicked(mouseX, mouseY, button);
+   }
+
+   public boolean isMouseOver(double mouseX, double mouseY) {
+      if (super.isMouseOver(mouseX, mouseY)) {
+         return true;
+      } else {
+         if (this.shouldShowSuggestions()) {
+            for (Button button : this.suggestionButtons) {
+               if (button.isMouseOver(mouseX, mouseY)) {
+                  return true;
+               }
+            }
+         }
+
+         return false;
+      }
+   }
+
+   public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+      if (!this.isFocused()) {
+         return false;
+      } else {
+         this.pause = false;
+         if (keyCode == 257 || keyCode == 335) {
+            this.cancelPendingSuggest();
+            this.clearSuggestions();
+            this.handleAccept();
+            return true;
+         } else if (super.keyPressed(keyCode, scanCode, modifiers)) {
+            this.state = PlaceSearchWidget.State.OK;
+            return true;
+         } else {
+            return false;
+         }
+      }
+   }
+
+   public void close() {
+      this.cancelPendingSuggest();
+      this.executor.shutdownNow();
+   }
+
+   private void handleAccept() {
+      String text = this.getValue().trim();
+      if (!text.isEmpty()) {
+         this.pause = true;
+         this.cancelPendingSuggest();
+         this.clearSuggestions();
+         CompletableFuture.runAsync(() -> {
+            try {
+               double[] coordinate = this.geocoder.get(text);
+               if (coordinate != null) {
+                  Minecraft.getInstance().execute(() -> {
+                     this.searchHandler.handle(coordinate[0], coordinate[1]);
+                     this.state = PlaceSearchWidget.State.FOUND;
+                  });
+               } else {
+                  Minecraft.getInstance().execute(() -> this.state = PlaceSearchWidget.State.NOT_FOUND);
+               }
+            } catch (IOException var3) {
+               Tellus.LOGGER.error("Failed to find searched place {}", text, var3);
+            }
+         }, this.executor);
+      }
+   }
+
+   private void scheduleSuggestions(String text) {
+      this.cancelPendingSuggest();
+      this.clearSuggestions();
+      long requestId = ++this.suggestionRequestId;
+      this.pendingSuggestTask = this.executor.schedule(() -> {
+         Geocoder.Suggestion[] result = this.fetchSuggestions(text);
+         Minecraft.getInstance().execute(() -> this.applySuggestions(requestId, text, result));
+      }, SUGGESTION_DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+   }
+
+   private void applySuggestions(long requestId, String text, Geocoder.Suggestion[] result) {
+      if (requestId == this.suggestionRequestId) {
+         if (!this.pause && text.equals(this.getValue().trim())) {
+            this.suggestions.clear();
+            if (result != null) {
+               for (int i = 0; i < result.length && this.suggestions.size() < SUGGESTION_COUNT; i++) {
+                  this.suggestions.add(result[i]);
+               }
+            }
+
+            if (this.suggestions.isEmpty()) {
+               this.state = PlaceSearchWidget.State.NOT_FOUND;
+               this.suggestionButtons.clear();
+            } else {
+               this.state = PlaceSearchWidget.State.OK;
+               this.rebuildSuggestionButtons();
+            }
+         }
+      }
+   }
+
+   private Geocoder.Suggestion[] fetchSuggestions(String text) {
+      try {
+         return this.geocoder.suggest(text);
+      } catch (Exception var3) {
+         Tellus.LOGGER.error("Failed to get geocoder suggestions", var3);
+         return new Geocoder.Suggestion[0];
+      }
+   }
+
+   private void acceptSuggestion(Geocoder.Suggestion suggestion) {
+      this.pause = true;
+      this.cancelPendingSuggest();
+      this.clearSuggestions();
+      String displayName = Objects.requireNonNull(suggestion.displayName(), "suggestionDisplayName");
+      this.setValue(displayName);
+      this.state = PlaceSearchWidget.State.FOUND;
+      this.searchHandler.handle(suggestion.latitude(), suggestion.longitude());
+   }
+
+   private void rebuildSuggestionButtons() {
+      this.suggestionButtons.clear();
+      int x = this.getX();
+      int originY = this.getY() + this.getHeight() + SUGGESTION_GAP;
+      int width = this.getWidth();
+      int suggestionStride = SUGGESTION_HEIGHT + SUGGESTION_GAP;
+
+      for (int i = 0; i < this.suggestions.size(); i++) {
+         Geocoder.Suggestion suggestion = this.suggestions.get(i);
+         String displayName = Objects.requireNonNull(suggestion.displayName(), "suggestionDisplayName");
+         Component label = Component.literal(displayName);
+         Button button = new PlaceSearchWidget.SuggestionButton(
+            x,
+            originY + i * suggestionStride,
+            width,
+            SUGGESTION_HEIGHT,
+            label,
+            pressed -> this.acceptSuggestion(suggestion)
+         );
+         this.suggestionButtons.add(button);
+      }
+   }
+
+   private void layoutSuggestionButtons() {
+      int x = this.getX();
+      int originY = this.getY() + this.getHeight() + SUGGESTION_GAP;
+      int width = this.getWidth();
+      int suggestionStride = SUGGESTION_HEIGHT + SUGGESTION_GAP;
+
+      for (int i = 0; i < this.suggestionButtons.size(); i++) {
+         Button button = this.suggestionButtons.get(i);
+         button.setX(x);
+         button.setY(originY + i * suggestionStride);
+         button.setWidth(width);
+         button.setHeight(SUGGESTION_HEIGHT);
+      }
+   }
+
+   private void clearSuggestions() {
+      this.suggestions.clear();
+      this.suggestionButtons.clear();
+   }
+
+   private void cancelPendingSuggest() {
+      if (this.pendingSuggestTask != null) {
+         this.pendingSuggestTask.cancel(false);
+         this.pendingSuggestTask = null;
+      }
+   }
+
+   private boolean shouldShowSuggestions() {
+      return this.isFocused() && !this.suggestions.isEmpty();
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public interface SearchHandler {
+      void handle(double var1, double var3);
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   public static enum State {
+      OK(-16777216),
+      FOUND(-16759296),
+      NOT_FOUND(-12189696);
+
+      private final int backgroundColor;
+
+      private State(int backgroundColor) {
+         this.backgroundColor = backgroundColor;
+      }
+
+      public int getBackgroundColor() {
+         return this.backgroundColor;
+      }
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static final class SuggestionButton extends Button {
+      private long scrollStartMillis = System.currentTimeMillis();
+      private boolean wasHovering;
+
+      private SuggestionButton(int x, int y, int width, int height, Component message, OnPress onPress) {
+         super(x, y, width, height, message, onPress, DEFAULT_NARRATION);
+      }
+
+      protected void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+         int background = this.isHoveredOrFocused() ? -6710887 : -8355712;
+         graphics.fill(this.getX(), this.getY(), this.getX() + this.getWidth(), this.getY() + this.getHeight(), background);
+         graphics.renderOutline(this.getX(), this.getY(), this.getWidth(), this.getHeight(), -16777216);
+         Component message = this.getMessage();
+         int textWidth = Minecraft.getInstance().font.width(message);
+         int availableWidth = Math.max(0, this.getWidth() - SUGGESTION_SCROLL_PADDING);
+         int textX = this.getX() + SUGGESTION_TEXT_PADDING;
+         int textY = this.getY() + (this.getHeight() - 9) / 2;
+         int color = this.active ? -1 : -6250336;
+         float offset = 0.0F;
+         boolean hoveringText = mouseX >= textX && mouseX <= textX + availableWidth && mouseY >= this.getY() && mouseY <= this.getY() + this.getHeight();
+         if (hoveringText && !this.wasHovering) {
+            this.scrollStartMillis = System.currentTimeMillis();
+         }
+
+         this.wasHovering = hoveringText;
+         if (textWidth > availableWidth && hoveringText) {
+            float overflow = textWidth - availableWidth;
+            float span = overflow + (float)SUGGESTION_SCROLL_PADDING;
+            float cycle = span * 2.0F;
+            double elapsedSeconds = (System.currentTimeMillis() - this.scrollStartMillis) / 1000.0;
+            double position = elapsedSeconds * SUGGESTION_SCROLL_SPEED % cycle;
+            if (position > span) {
+               position = cycle - position;
+            }
+
+            offset = (float)position;
+         }
+
+         int scissorLeft = this.getX() + 2;
+         int scissorTop = this.getY() + 2;
+         int scissorRight = this.getX() + this.getWidth() - 2;
+         int scissorBottom = this.getY() + this.getHeight() - 2;
+         graphics.enableScissor(scissorLeft, scissorTop, scissorRight, scissorBottom);
+         graphics.drawString(Minecraft.getInstance().font, message, textX - Math.round(offset), textY, color, false);
+         graphics.disableScissor();
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMap.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMap.java
@@ -1,0 +1,160 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.Mth;
+
+@OnlyIn(Dist.CLIENT)
+public class SlippyMap {
+   public static final int TILE_SIZE = 256;
+   public static final int MIN_ZOOM = 3;
+   public static final int MAX_ZOOM = 19;
+   private final int width;
+   private final int height;
+   private final SlippyMap.Camera camera;
+   private final SlippyMapTileCache cache = new SlippyMapTileCache();
+
+   public SlippyMap(int width, int height) {
+      this.width = width;
+      this.height = height;
+      int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+      this.camera = new SlippyMap.Camera(new SlippyMapPoint(0.0, 0.0), width * scale, height * scale);
+   }
+
+   public SlippyMapTile getTile(SlippyMapTilePos pos) {
+      return this.cache.getTile(pos);
+   }
+
+   public void focus(double latitude, double longitude, int zoom) {
+      int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+      SlippyMapPoint point = new SlippyMapPoint(latitude, longitude);
+      this.camera.focus(point.getX(zoom), point.getY(zoom), zoom, this.width * scale, this.height * scale);
+   }
+
+   public void zoom(int step, int pivotX, int pivotY) {
+      int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+      this.camera.zoom(step, pivotX * scale, pivotY * scale);
+   }
+
+   public void drag(int deltaX, int deltaY) {
+      int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+      this.camera.pan(deltaX * scale, deltaY * scale);
+   }
+
+   public List<SlippyMapTilePos> getVisibleTiles() {
+      int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+      int cameraX = this.camera.getX();
+      int cameraY = this.camera.getY();
+      int cameraZoom = this.camera.getZoom();
+      int minX = Mth.floor(cameraX / 256.0);
+      int minY = Mth.floor(cameraY / 256.0);
+      int maxX = Mth.ceil((cameraX + this.width * scale) / 256.0);
+      int maxY = Mth.ceil((cameraY + this.height * scale) / 256.0);
+      List<SlippyMapTilePos> visibleTiles = new ArrayList<>();
+
+      for (int tileY = minY; tileY < maxY; tileY++) {
+         for (int tileX = minX; tileX < maxX; tileX++) {
+            visibleTiles.add(new SlippyMapTilePos(tileX, tileY, cameraZoom));
+         }
+      }
+
+      return visibleTiles;
+   }
+
+   public List<SlippyMapTilePos> cascadeTiles(List<SlippyMapTilePos> tiles) {
+      List<SlippyMapTilePos> cascaded = new ArrayList<>(tiles.size());
+
+      for (SlippyMapTilePos pos : tiles) {
+         this.cascadeTile(cascaded, pos);
+      }
+
+      return cascaded;
+   }
+
+   private void cascadeTile(List<SlippyMapTilePos> tiles, SlippyMapTilePos pos) {
+      int size = 1 << pos.getZoom();
+      if (pos.getX() >= 0 && pos.getY() >= 0 && pos.getX() < size && pos.getY() < size) {
+         SlippyMapTile image = this.cache.getTile(pos);
+         if (image != null && image.isReady()) {
+            tiles.add(pos);
+         }
+
+         if (pos.getZoom() >= 3 && (image == null || !image.isReady() || image.getTransition() < 1.0F)) {
+            this.cascadeTile(tiles, new SlippyMapTilePos(pos.getX() >> 1, pos.getY() >> 1, pos.getZoom() - 1));
+         }
+      }
+   }
+
+   public int getCameraX() {
+      return this.camera.getX();
+   }
+
+   public int getCameraY() {
+      return this.camera.getY();
+   }
+
+   public int getCameraZoom() {
+      return this.camera.getZoom();
+   }
+
+   public void shutdown() {
+      this.cache.shutdown();
+   }
+
+   @OnlyIn(Dist.CLIENT)
+   private static class Camera {
+      private SlippyMapPoint origin;
+      private int zoom = 3;
+
+      private Camera(SlippyMapPoint origin, int width, int height) {
+         this.origin = origin.translate(-width / 2, -height / 2, this.zoom);
+      }
+
+      public void focus(int x, int y, int zoom, int width, int height) {
+         int clampedZoom = Mth.clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+         this.origin = new SlippyMapPoint(x, y, clampedZoom).translate(-width / 2, -height / 2, clampedZoom);
+         this.zoom = clampedZoom;
+      }
+
+      public void pan(int deltaX, int deltaY) {
+         this.origin = this.origin.translate(deltaX, deltaY, this.zoom);
+      }
+
+      public void zoom(int steps, int pivotX, int pivotY) {
+         if (steps != 0) {
+            int originX = this.origin.getX(this.zoom);
+            int originY = this.origin.getY(this.zoom);
+            int nextZoom = Mth.clamp(this.zoom + steps, MIN_ZOOM, MAX_ZOOM);
+            if (nextZoom == this.zoom) {
+               return;
+            }
+
+            this.zoom = nextZoom;
+            if (steps > 0) {
+               int newX = originX * 2 + pivotX;
+               int newY = originY * 2 + pivotY;
+               this.origin = new SlippyMapPoint(newX, newY, this.zoom);
+            } else if (steps < 0) {
+               int newX = (originX - pivotX) / 2;
+               int newY = (originY - pivotY) / 2;
+               this.origin = new SlippyMapPoint(newX, newY, this.zoom);
+            }
+         }
+      }
+
+      public int getX() {
+         return this.origin.getX(this.zoom);
+      }
+
+      public int getY() {
+         return this.origin.getY(this.zoom);
+      }
+
+      public int getZoom() {
+         return this.zoom;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapPoint.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapPoint.java
@@ -1,0 +1,48 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import net.minecraft.util.Mth;
+
+@OnlyIn(Dist.CLIENT)
+public class SlippyMapPoint {
+   private final double latitude;
+   private final double longitude;
+
+   public SlippyMapPoint(double latitude, double longitude) {
+      this.latitude = latitude;
+      this.longitude = longitude;
+   }
+
+   public SlippyMapPoint(int x, int y, int zoom) {
+      double maximumX = 256 * (1 << zoom);
+      this.longitude = x / maximumX * 360.0 - 180.0;
+      double maximumY = 256 * (1 << zoom);
+      this.latitude = Math.toDegrees(Math.atan(Math.sinh(Math.PI - (Math.PI * 2) * y / maximumY)));
+   }
+
+   public double getLatitude() {
+      return this.latitude;
+   }
+
+   public double getLongitude() {
+      return this.longitude;
+   }
+
+   public int getX(int zoom) {
+      double maximumX = 256 * (1 << zoom);
+      return Mth.floor((this.longitude + 180.0) / 360.0 * maximumX);
+   }
+
+   public int getY(int zoom) {
+      double maximumY = 256 * (1 << zoom);
+      double angle = Math.toRadians(this.latitude);
+      return Mth.floor((1.0 - Math.log(Math.tan(angle) + 1.0 / Math.cos(angle)) / Math.PI) / 2.0 * maximumY);
+   }
+
+   public SlippyMapPoint translate(int x, int y, int zoom) {
+      int currentX = this.getX(zoom);
+      int currentY = this.getY(zoom);
+      return new SlippyMapPoint(currentX + x, currentY + y, zoom);
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapTile.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapTile.java
@@ -1,0 +1,89 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.mojang.blaze3d.platform.NativeImage;
+import com.yucareux.tellus.Tellus;
+import java.util.Objects;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+
+@OnlyIn(Dist.CLIENT)
+public class SlippyMapTile {
+   private final SlippyMapTilePos pos;
+   private final Object lock = new Object();
+   private float transition;
+   private volatile NativeImage image;
+   private ResourceLocation location;
+   private DynamicTexture texture;
+
+   public SlippyMapTile(SlippyMapTilePos pos) {
+      this.pos = pos;
+   }
+
+   public void update(float partialTicks) {
+      if (this.transition < 1.0F) {
+         this.transition = Mth.clamp(this.transition + partialTicks * 0.1F, 0.0F, 1.0F);
+      }
+   }
+
+   public void supplyImage(NativeImage image) {
+      synchronized (this.lock) {
+         if (this.image != null) {
+            this.image.close();
+         }
+
+         this.image = image;
+      }
+   }
+
+   public ResourceLocation getLocation() {
+      if (this.location == null && this.image != null) {
+         this.location = this.uploadImage();
+      }
+
+      return this.location;
+   }
+
+   public float getTransition() {
+      return this.transition;
+   }
+
+   public void delete() {
+      if (this.location != null) {
+         Minecraft.getInstance().getTextureManager().release(Objects.requireNonNull(this.location, "tileLocation"));
+         this.location = null;
+      }
+
+      if (this.texture != null) {
+         this.texture.close();
+         this.texture = null;
+      }
+
+      synchronized (this.lock) {
+         if (this.image != null) {
+            this.image.close();
+            this.image = null;
+         }
+      }
+   }
+
+   private ResourceLocation uploadImage() {
+      synchronized (this.lock) {
+         NativeImage image = Objects.requireNonNull(this.image, "tileImage");
+         this.image = null;
+         DynamicTexture texture = Objects.requireNonNull(new DynamicTexture(image), "tileTexture");
+         this.texture = texture;
+         texture.upload();
+         ResourceLocation id = Objects.requireNonNull(Tellus.id("map_" + this.pos), "tileId");
+         Minecraft.getInstance().getTextureManager().register(id, texture);
+         return id;
+      }
+   }
+
+   public boolean isReady() {
+      return this.getLocation() != null;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapTileCache.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapTileCache.java
@@ -1,0 +1,164 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.mojang.blaze3d.platform.NativeImage;
+import com.yucareux.tellus.Tellus;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import net.minecraft.client.Minecraft;
+
+@OnlyIn(Dist.CLIENT)
+public class SlippyMapTileCache {
+   private static final int CACHE_SIZE = 1024;
+   private final ExecutorService loadingService = Executors.newFixedThreadPool(
+      4, new ThreadFactoryBuilder().setDaemon(true).setNameFormat("tellus-map-load-%d").build()
+   );
+   private final Queue<InputStream> loadingStreams = new LinkedBlockingQueue<>();
+   private final Path cacheRoot = Minecraft.getInstance().gameDirectory.toPath().resolve("tellus/cache/map");
+   private volatile boolean shuttingDown;
+   private final LoadingCache<SlippyMapTilePos, SlippyMapTile> tileCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).removalListener(notification -> {
+      SlippyMapTile tile = (SlippyMapTile)notification.getValue();
+      if (tile != null) {
+         tile.delete();
+      }
+   }).build(new CacheLoader<SlippyMapTilePos, SlippyMapTile>() {
+      public SlippyMapTile load(SlippyMapTilePos key) {
+         SlippyMapTile tile = new SlippyMapTile(key);
+         try {
+            SlippyMapTileCache.this.loadingService.submit(() -> {
+               NativeImage image = SlippyMapTileCache.this.downloadImage(key);
+               if (SlippyMapTileCache.this.shuttingDown) {
+                  image.close();
+               } else {
+                  tile.supplyImage(image);
+               }
+            });
+         } catch (RejectedExecutionException ignored) {
+            tile.supplyImage(SlippyMapTileCache.this.createErrorImage());
+         }
+
+         return tile;
+      }
+   });
+
+   public SlippyMapTile getTile(SlippyMapTilePos pos) {
+      try {
+         return (SlippyMapTile)this.tileCache.get(pos);
+      } catch (Exception var4) {
+         SlippyMapTile tile = new SlippyMapTile(pos);
+         tile.supplyImage(this.createErrorImage());
+         return tile;
+      }
+   }
+
+   public void shutdown() {
+      this.shuttingDown = true;
+      this.loadingService.shutdownNow();
+      this.tileCache.invalidateAll();
+      this.tileCache.cleanUp();
+
+      while (!this.loadingStreams.isEmpty()) {
+         try {
+            InputStream poll = this.loadingStreams.poll();
+            if (poll != null) {
+               poll.close();
+            }
+         } catch (IOException var3) {
+            Tellus.LOGGER.warn("Failed to close loading map stream", var3);
+         }
+      }
+   }
+
+   private NativeImage downloadImage(SlippyMapTilePos pos) {
+      try {
+         NativeImage var3;
+         try (InputStream input = Objects.requireNonNull(this.getStream(pos), "tileStream")) {
+            var3 = NativeImage.read(input);
+         }
+
+         return var3;
+      } catch (IOException var7) {
+         Tellus.LOGGER.error("Failed to load map tile {}", pos, var7);
+         return this.createErrorImage();
+      }
+   }
+
+   
+   private InputStream getStream(SlippyMapTilePos pos) throws IOException {
+      Path cachePath = this.cacheRoot.resolve(pos.getCacheName());
+      if (Files.exists(cachePath)) {
+         return new BufferedInputStream(Files.newInputStream(cachePath));
+      } else {
+         URI uri = URI.create(String.format("https://tile.openstreetmap.org/%s/%s/%s.png", pos.getZoom(), pos.getX(), pos.getY()));
+         URL url = uri.toURL();
+         HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+         try {
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            connection.setRequestProperty("User-Agent", "Tellus/2.0.0 (Minecraft Mod)");
+            int responseCode = connection.getResponseCode();
+            if (responseCode != 200) {
+               throw new IOException("OpenStreetMap tile request failed with HTTP " + responseCode + " for " + pos);
+            }
+
+            InputStream stream = Objects.requireNonNull(connection.getInputStream(), "tileStream");
+            this.loadingStreams.add(stream);
+
+            try (InputStream input = new BufferedInputStream(stream)) {
+               byte[] data = input.readAllBytes();
+               this.cacheData(cachePath, data);
+               return new ByteArrayInputStream(data);
+            } finally {
+               this.loadingStreams.remove(stream);
+            }
+         } finally {
+            connection.disconnect();
+         }
+      }
+   }
+
+   private void cacheData(Path cachePath, byte[] data) {
+      try {
+         Files.createDirectories(Objects.requireNonNull(cachePath.getParent(), "cachePathParent"));
+      } catch (IOException var7) {
+         Tellus.LOGGER.error("Failed to create cache root", var7);
+      }
+
+      try (OutputStream output = Files.newOutputStream(cachePath)) {
+         output.write(data);
+      } catch (IOException var9) {
+         Tellus.LOGGER.error("Failed to cache map tile", var9);
+      }
+   }
+
+   private NativeImage createErrorImage() {
+      NativeImage result = new NativeImage(256, 256, false);
+
+      for (int x = 0; x < 256; x++) {
+         for (int y = 0; y < 256; y++) {
+            result.setPixelRGBA(x, y, -16776961);
+         }
+      }
+
+      return result;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapTilePos.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapTilePos.java
@@ -1,0 +1,51 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+
+@OnlyIn(Dist.CLIENT)
+public class SlippyMapTilePos {
+   private final int x;
+   private final int y;
+   private final int zoom;
+
+   public SlippyMapTilePos(int x, int y, int zoom) {
+      this.x = x;
+      this.y = y;
+      this.zoom = zoom;
+   }
+
+   public int getX() {
+      return this.x;
+   }
+
+   public int getY() {
+      return this.y;
+   }
+
+   public int getZoom() {
+      return this.zoom;
+   }
+
+   public String getCacheName() {
+      return this.zoom + "_" + this.x + "_" + this.y + ".png";
+   }
+
+   @Override
+   public int hashCode() {
+      int result = Integer.hashCode(this.x);
+      result = 31 * result + Integer.hashCode(this.y);
+      result = 31 * result + Integer.hashCode(this.zoom);
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      return !(obj instanceof SlippyMapTilePos tilePos) ? false : tilePos.x == this.x && tilePos.y == this.y && tilePos.zoom == this.zoom;
+   }
+
+   @Override
+   public String toString() {
+      return this.x + "_" + this.y + "_" + this.zoom;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapWidget.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/SlippyMapWidget.java
@@ -1,0 +1,180 @@
+package com.yucareux.tellus.client.widget.map;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.client.widget.map.component.MapComponent;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+
+@OnlyIn(Dist.CLIENT)
+public class SlippyMapWidget extends AbstractWidget {
+   private static final String ATTRIBUTION = "(c) OpenStreetMap Contributors";
+   private final SlippyMap map;
+   private final List<MapComponent> components = new ArrayList<>();
+   private boolean mouseDown;
+   private boolean mouseDragged;
+   private int attributionBottomPadding;
+
+   public SlippyMapWidget(int x, int y, int width, int height) {
+      super(x, y, width, height, Component.empty());
+      this.map = new SlippyMap(width, height);
+   }
+
+   public SlippyMap getMap() {
+      return this.map;
+   }
+
+   public <T extends MapComponent> T addComponent(T component) {
+      this.components.add(component);
+      return component;
+   }
+
+   public void setAttributionBottomPadding(int padding) {
+      this.attributionBottomPadding = Math.max(0, padding);
+   }
+
+   protected void renderWidget( GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+      this.drawBackground(graphics);
+      graphics.enableScissor(this.getX() + 4, this.getY() + 4, this.getX() + this.width - 4, this.getY() + this.height - 4);
+      int cameraX = this.map.getCameraX();
+      int cameraY = this.map.getCameraY();
+      int cameraZoom = this.map.getCameraZoom();
+      List<SlippyMapTilePos> tiles = this.map.getVisibleTiles();
+      List<SlippyMapTilePos> cascadedTiles = this.map.cascadeTiles(tiles);
+      cascadedTiles.sort(Comparator.comparingInt(SlippyMapTilePos::getZoom));
+
+      for (SlippyMapTilePos pos : cascadedTiles) {
+         SlippyMapTile tile = this.map.getTile(pos);
+         this.renderTile(graphics, cameraX, cameraY, cameraZoom, pos, tile, delta);
+      }
+
+      SlippyMapPoint mouse = this.getPointUnderMouse(mouseX, mouseY);
+      graphics.pose().pushPose();
+      graphics.pose().translate(this.getX(), this.getY(), 0.0F);
+
+      for (MapComponent component : this.components) {
+         component.onDrawMap(this.map, graphics, mouseX, mouseY, mouse);
+      }
+
+      graphics.pose().popPose();
+      graphics.disableScissor();
+      int maxX = this.getX() + this.width - 4;
+      int maxY = this.getY() + this.height - 4 - this.attributionBottomPadding;
+      int attributionWidth = Minecraft.getInstance().font.width(ATTRIBUTION) + 20;
+      int attributionOriginX = maxX - attributionWidth;
+      int attributionOriginY = maxY - 9 - 4;
+      graphics.fill(attributionOriginX, attributionOriginY, maxX, maxY, -1072689136);
+      graphics.drawString(Minecraft.getInstance().font, ATTRIBUTION, attributionOriginX + 10, attributionOriginY + 2, -1);
+   }
+
+   private void renderTile(GuiGraphics graphics, int cameraX, int cameraY, int cameraZoom, SlippyMapTilePos pos, SlippyMapTile image, float delta) {
+      image.update(delta);
+      ResourceLocation location = image.getLocation();
+      if (location != null) {
+         int deltaZoom = cameraZoom - pos.getZoom();
+         double zoomScale = Math.pow(2.0, deltaZoom);
+         int size = Mth.floor(256.0 * zoomScale);
+         int renderX = (pos.getX() << deltaZoom) * 256 - cameraX;
+         int renderY = (pos.getY() << deltaZoom) * 256 - cameraY;
+         int textureSize = Math.max(256, size);
+         graphics.pose().pushPose();
+         graphics.pose().translate(this.getX(), this.getY(), 0.0F);
+         int scaleFactor = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+         float scale = 1.0F / scaleFactor;
+         graphics.pose().scale(scale, scale, 1.0F);
+         graphics.blit(Objects.requireNonNull(location, "tileLocation"), renderX, renderY, 0, 0.0F, 0.0F, size, size, textureSize, textureSize);
+         graphics.pose().popPose();
+      }
+   }
+
+   private void drawBackground(GuiGraphics graphics) {
+      graphics.fill(this.getX(), this.getY(), this.getX() + this.width, this.getY() + this.height, -14671840);
+      graphics.renderOutline(this.getX(), this.getY(), this.width, this.height, -16777216);
+   }
+
+   public boolean mouseClicked(double mouseX, double mouseY, int button) {
+      if (!this.isMouseOver(mouseX, mouseY)) {
+         return false;
+      } else {
+         this.mouseDown = true;
+         if (button == 0) {
+            SlippyMapPoint mouse = this.getPointUnderMouse(mouseX, mouseY);
+
+            for (MapComponent component : this.components) {
+               if (component.onMouseClicked(this.map, mouse, button)) {
+                  return true;
+               }
+            }
+         }
+
+         return true;
+      }
+   }
+
+   public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+      if (this.mouseDown) {
+         this.map.drag((int)(-dragX), (int)(-dragY));
+         this.mouseDragged = true;
+         return true;
+      } else {
+         return false;
+      }
+   }
+
+   public boolean mouseReleased(double mouseX, double mouseY, int button) {
+      if (button == 0 && this.mouseDown && !this.mouseDragged && this.isMouseOver(mouseX, mouseY)) {
+         SlippyMapPoint mouse = this.getPointUnderMouse(mouseX, mouseY);
+
+         for (MapComponent component : this.components) {
+            if (component.onMouseReleased(this.map, mouse, button)) {
+               return true;
+            }
+         }
+      }
+
+      this.mouseDown = false;
+      this.mouseDragged = false;
+      return false;
+   }
+
+   public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+      if (this.isMouseOver(mouseX, mouseY)) {
+         int zoom = (int)Math.signum(scrollY);
+         if (zoom != 0) {
+            this.map.zoom(zoom, (int)(mouseX - this.getX()), (int)(mouseY - this.getY()));
+         }
+
+         return true;
+      } else {
+         return false;
+      }
+   }
+
+   public void close() {
+      this.map.shutdown();
+   }
+
+   public void cancelInteraction() {
+      this.mouseDown = false;
+      this.mouseDragged = false;
+   }
+
+   private SlippyMapPoint getPointUnderMouse(double mouseX, double mouseY) {
+      int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+      int mapX = (int)((mouseX - this.getX()) * scale) + this.map.getCameraX();
+      int mapY = (int)((mouseY - this.getY()) * scale) + this.map.getCameraY();
+      return new SlippyMapPoint(mapX, mapY, this.map.getCameraZoom());
+   }
+
+   protected void updateWidgetNarration( NarrationElementOutput narration) {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/component/MapComponent.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/component/MapComponent.java
@@ -1,0 +1,20 @@
+package com.yucareux.tellus.client.widget.map.component;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.client.widget.map.SlippyMap;
+import com.yucareux.tellus.client.widget.map.SlippyMapPoint;
+import net.minecraft.client.gui.GuiGraphics;
+
+@OnlyIn(Dist.CLIENT)
+public interface MapComponent {
+   void onDrawMap(SlippyMap var1, GuiGraphics var2, int var3, int var4, SlippyMapPoint var5);
+
+   default boolean onMouseClicked(SlippyMap map, SlippyMapPoint mouse, int button) {
+      return false;
+   }
+
+   default boolean onMouseReleased(SlippyMap map, SlippyMapPoint mouse, int button) {
+      return false;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/component/MarkerMapComponent.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/client/widget/map/component/MarkerMapComponent.java
@@ -1,0 +1,83 @@
+package com.yucareux.tellus.client.widget.map.component;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.client.widget.map.SlippyMap;
+import com.yucareux.tellus.client.widget.map.SlippyMapPoint;
+import java.util.Objects;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+
+@OnlyIn(Dist.CLIENT)
+public class MarkerMapComponent implements MapComponent {
+   
+   private static final ResourceLocation WIDGETS_TEXTURE = Objects.requireNonNull(Tellus.id("textures/gui/widgets.png"), "widgetsTexture");
+   private static final int TEXTURE_SIZE = 256;
+   private static final int MARKER_SIZE = 16;
+   private SlippyMapPoint marker;
+   private boolean canMove;
+   private float offsetX = 0.0F;
+   private float offsetY = 32.0F;
+   private boolean visible = true;
+
+   public MarkerMapComponent(SlippyMapPoint marker) {
+      this.marker = marker;
+   }
+
+   public MarkerMapComponent() {
+      this(null);
+   }
+
+   public MarkerMapComponent allowMovement() {
+      this.canMove = true;
+      return this;
+   }
+
+   @Override
+   public void onDrawMap(SlippyMap map, GuiGraphics graphics, int mouseX, int mouseY, SlippyMapPoint mouse) {
+      if (this.marker != null && this.visible) {
+         int scale = Math.max(1, (int)Math.round(Minecraft.getInstance().getWindow().getGuiScale()));
+         int markerX = this.marker.getX(map.getCameraZoom()) - map.getCameraX();
+         int markerY = this.marker.getY(map.getCameraZoom()) - map.getCameraY();
+         int guiMarkerX = markerX / scale;
+         int guiMarkerY = markerY / scale;
+         graphics.blit(WIDGETS_TEXTURE, guiMarkerX - MARKER_SIZE / 2, guiMarkerY - MARKER_SIZE, 0, this.offsetX, this.offsetY, MARKER_SIZE, MARKER_SIZE, TEXTURE_SIZE, TEXTURE_SIZE);
+      }
+   }
+
+   @Override
+   public boolean onMouseReleased(SlippyMap map, SlippyMapPoint mouse, int button) {
+      if (this.canMove) {
+         this.marker = mouse;
+         return true;
+      } else {
+         return false;
+      }
+   }
+
+   public void moveMarker(double latitude, double longitude) {
+      this.marker = new SlippyMapPoint(latitude, longitude);
+   }
+
+   public SlippyMapPoint getMarker() {
+      return this.marker;
+   }
+
+   public void setOffsetX(float x) {
+      this.offsetX = x;
+   }
+
+   public void setOffsetY(float y) {
+      this.offsetY = y;
+   }
+
+   public void setVisible(boolean visible) {
+      this.visible = visible;
+   }
+
+   public boolean isVisible() {
+      return this.visible;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/config/HmaAccessConfig.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/config/HmaAccessConfig.java
@@ -1,0 +1,83 @@
+package com.yucareux.tellus.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Properties;
+import net.neoforged.fml.loading.FMLPaths;
+
+public final class HmaAccessConfig {
+   private static final String TOKEN_KEY = "earthdata_bearer_token";
+   private static final Path CONFIG_PATH = FMLPaths.CONFIGDIR.get().resolve("tellus-hma-access.properties");
+   private static final Object LOCK = new Object();
+   private static volatile String bearerToken = loadToken();
+
+   private HmaAccessConfig() {
+   }
+
+   public static String bearerToken() {
+      return bearerToken;
+   }
+
+   public static boolean hasBearerToken() {
+      return !bearerToken().isBlank();
+   }
+
+   public static Path configPath() {
+      return CONFIG_PATH;
+   }
+
+   public static void setBearerToken(String token) {
+      String normalized = normalize(token);
+      synchronized (LOCK) {
+         bearerToken = normalized;
+         try {
+            saveLocked(normalized);
+         } catch (IOException error) {
+            throw new IllegalStateException("Failed to save HMA access config", error);
+         }
+      }
+   }
+
+   public static void clearBearerToken() {
+      setBearerToken("");
+   }
+
+   private static String loadToken() {
+      synchronized (LOCK) {
+         if (!Files.exists(CONFIG_PATH)) {
+            return "";
+         } else {
+            Properties properties = new Properties();
+
+            try (InputStream input = Files.newInputStream(CONFIG_PATH)) {
+               properties.load(input);
+               return normalize(properties.getProperty(TOKEN_KEY, ""));
+            } catch (IOException error) {
+               return "";
+            }
+         }
+      }
+   }
+
+   private static void saveLocked(String token) throws IOException {
+      if (token.isBlank()) {
+         Files.deleteIfExists(CONFIG_PATH);
+      } else {
+         Files.createDirectories(Objects.requireNonNull(CONFIG_PATH.getParent(), "configParent"));
+         Properties properties = new Properties();
+         properties.setProperty(TOKEN_KEY, token);
+
+         try (OutputStream output = Files.newOutputStream(CONFIG_PATH)) {
+            properties.store(output, "Tellus HMA Earthdata access");
+         }
+      }
+   }
+
+   private static String normalize(String token) {
+      return token == null ? "" : token.trim();
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/integration/distant_horizons/DistantHorizonsIntegration.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/integration/distant_horizons/DistantHorizonsIntegration.java
@@ -1,0 +1,78 @@
+package com.yucareux.tellus.integration.distant_horizons;
+
+import com.mojang.logging.LogUtils;
+import com.seibel.distanthorizons.api.DhApi;
+import com.seibel.distanthorizons.api.interfaces.world.IDhApiLevelWrapper;
+import com.seibel.distanthorizons.api.methods.events.DhApiEventRegister;
+import com.seibel.distanthorizons.api.methods.events.abstractEvents.DhApiLevelLoadEvent;
+import com.seibel.distanthorizons.api.methods.events.sharedParameterObjects.DhApiEventParam;
+import com.seibel.distanthorizons.api.objects.DhApiResult;
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import net.minecraft.server.level.ServerLevel;
+import net.neoforged.fml.ModList;
+import org.slf4j.Logger;
+
+public final class DistantHorizonsIntegration {
+   private static final Logger LOGGER = LogUtils.getLogger();
+   private static final String VOXY_MOD_ID = "voxy";
+
+   private DistantHorizonsIntegration() {
+   }
+
+   private static boolean checkApiVersion() {
+      int apiMajor = DhApi.getApiMajorVersion();
+      int apiMinor = DhApi.getApiMinorVersion();
+      int apiPatch = DhApi.getApiPatchVersion();
+      if (apiMajor < 4) {
+         LOGGER.warn(
+            "Detected Distant Horizons {}, but API {}.{}.{} is too old - won't enable integration with Tellus",
+            new Object[]{DhApi.getModVersion(), apiMajor, apiMinor, apiPatch}
+         );
+         return false;
+      } else {
+         LOGGER.info(
+            "Detected Distant Horizons {} (API {}.{}.{}), enabling integration with Tellus",
+            new Object[]{DhApi.getModVersion(), apiMajor, apiMinor, apiPatch}
+         );
+         return true;
+      }
+   }
+
+   public static void bootstrap() {
+      if (checkApiVersion()) {
+         DhApiEventRegister.on(DhApiLevelLoadEvent.class, new DhApiLevelLoadEvent() {
+            public void onLevelLoad(DhApiEventParam<DhApiLevelLoadEvent.EventParam> param) {
+               DistantHorizonsIntegration.onLevelLoad(param.value.levelWrapper);
+            }
+         });
+      }
+   }
+
+   private static void onLevelLoad(IDhApiLevelWrapper levelWrapper) {
+      if (levelWrapper.getWrappedMcObject() instanceof ServerLevel level
+            && level.getChunkSource().getGenerator() instanceof EarthChunkGenerator generator) {
+         EarthGeneratorSettings settings = generator.settings();
+         if (settings.voxyChunkPregenEnabled() && ModList.get().isLoaded(VOXY_MOD_ID)) {
+            LOGGER.info("Voxy pregen enabled; skipping Tellus Distant Horizons integration override");
+            return;
+         }
+
+         if (settings.distantHorizonsRenderMode() == EarthGeneratorSettings.DistantHorizonsRenderMode.DETAILED) {
+            LOGGER.info("Distant Horizons render mode set to detailed; using chunk-based generator");
+            TellusChunkLodGenerator chunkGenerator = new TellusChunkLodGenerator(level);
+            DhApiResult<Void> result = DhApi.worldGenOverrides.registerWorldGeneratorOverride(levelWrapper, chunkGenerator);
+            if (!result.success) {
+               LOGGER.warn("Failed to register Tellus chunk LOD generator: {}", result.message);
+            }
+            return;
+         }
+
+         TellusLodGenerator lodGenerator = new TellusLodGenerator(levelWrapper, generator);
+         DhApiResult<Void> result = DhApi.worldGenOverrides.registerWorldGeneratorOverride(levelWrapper, lodGenerator);
+         if (!result.success) {
+            LOGGER.warn("Failed to register Tellus LOD generator: {}", result.message);
+         }
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/integration/distant_horizons/TellusChunkLodGenerator.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/integration/distant_horizons/TellusChunkLodGenerator.java
@@ -1,0 +1,36 @@
+package com.yucareux.tellus.integration.distant_horizons;
+
+import com.seibel.distanthorizons.api.enums.worldGeneration.EDhApiDistantGeneratorMode;
+import com.seibel.distanthorizons.api.enums.worldGeneration.EDhApiWorldGeneratorReturnType;
+import com.seibel.distanthorizons.api.interfaces.override.worldGenerator.AbstractDhApiChunkWorldGenerator;
+import com.seibel.distanthorizons.api.objects.data.DhApiChunk;
+import java.util.Objects;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
+
+public final class TellusChunkLodGenerator extends AbstractDhApiChunkWorldGenerator {
+   private final ServerLevel level;
+
+   public TellusChunkLodGenerator(ServerLevel level) {
+      this.level = Objects.requireNonNull(level, "level");
+   }
+
+   public EDhApiWorldGeneratorReturnType getReturnType() {
+      return EDhApiWorldGeneratorReturnType.VANILLA_CHUNKS;
+   }
+
+   public Object[] generateChunk(int chunkPosX, int chunkPosZ, EDhApiDistantGeneratorMode generatorMode) {
+      LevelChunk chunk = this.level.getChunk(chunkPosX, chunkPosZ);
+      return new Object[]{chunk, this.level};
+   }
+
+   public DhApiChunk generateApiChunk(int chunkPosX, int chunkPosZ, EDhApiDistantGeneratorMode generatorMode) {
+      throw new UnsupportedOperationException("TellusChunkLodGenerator uses vanilla chunks");
+   }
+
+   public void preGeneratorTaskStart() {
+   }
+
+   public void close() {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/integration/distant_horizons/TellusLodGenerator.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/integration/distant_horizons/TellusLodGenerator.java
@@ -1,0 +1,4063 @@
+package com.yucareux.tellus.integration.distant_horizons;
+
+import com.mojang.logging.LogUtils;
+import com.seibel.distanthorizons.api.DhApi.Delayed;
+import com.seibel.distanthorizons.api.enums.worldGeneration.EDhApiDistantGeneratorMode;
+import com.seibel.distanthorizons.api.enums.worldGeneration.EDhApiWorldGeneratorReturnType;
+import com.seibel.distanthorizons.api.interfaces.block.IDhApiBiomeWrapper;
+import com.seibel.distanthorizons.api.interfaces.block.IDhApiBlockStateWrapper;
+import com.seibel.distanthorizons.api.interfaces.override.worldGenerator.IDhApiWorldGenerator;
+import com.seibel.distanthorizons.api.interfaces.world.IDhApiLevelWrapper;
+import com.seibel.distanthorizons.api.objects.data.DhApiTerrainDataPoint;
+import com.seibel.distanthorizons.api.objects.data.IDhApiFullDataSource;
+import com.yucareux.tellus.world.data.elevation.TellusElevationSource;
+import com.yucareux.tellus.world.data.osm.BridgeSupportLayout;
+import com.yucareux.tellus.world.data.osm.OsmBuildingFeature;
+import com.yucareux.tellus.world.data.osm.OsmPerf;
+import com.yucareux.tellus.world.data.osm.OsmQueryMode;
+import com.yucareux.tellus.world.data.osm.RoadClass;
+import com.yucareux.tellus.world.data.osm.RoadFeature;
+import com.yucareux.tellus.world.data.osm.RoadMode;
+import com.yucareux.tellus.world.realtime.TellusRealtimeState;
+import com.yucareux.tellus.worldgen.DhLodWaterResolver;
+import com.yucareux.tellus.worldgen.EarthBiomeSource;
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import com.yucareux.tellus.worldgen.WaterSurfaceResolver;
+import com.yucareux.tellus.worldgen.building.BuildingBlueprint;
+import com.yucareux.tellus.worldgen.building.BuildingProfile;
+import com.yucareux.tellus.worldgen.building.BuildingPlacementSupport;
+import com.yucareux.tellus.worldgen.building.TellusBuildingBlueprints;
+import com.yucareux.tellus.worldgen.building.TellusBuildingLighting;
+import com.yucareux.tellus.worldgen.building.TellusBuildingMaterials;
+import com.yucareux.tellus.worldgen.building.TellusBuildingProfiles;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import java.io.InterruptedIOException;
+import java.io.IOException;
+import java.nio.channels.ClosedByInterruptException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import net.minecraft.core.Holder;
+import net.minecraft.core.SectionPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.slf4j.Logger;
+
+public final class TellusLodGenerator implements IDhApiWorldGenerator {
+   private static final Logger LOGGER = LogUtils.getLogger();
+   private static final boolean LOD_TIMING_LOGGING = Boolean.parseBoolean(System.getProperty("tellus.dhLodTiming", "false"));
+   private static final long PREFETCH_DEDUP_WINDOW_MS = 3000L;
+   private static final long PREFETCH_STALE_WINDOW_MS = 15000L;
+   private static final int PREFETCH_DEDUP_MAX = 4096;
+   private static final int FAST_RENDER_ULTRA_FAST_MIN_DETAIL = intProperty("tellus.dhFastRenderUltraFastMinDetail", 4, 0, 24);
+   private static final int FAST_RENDER_SKIP_SHORELINE_MIN_DETAIL = intProperty("tellus.dhFastRenderSkipShorelineMinDetail", 3, 0, 24);
+   private static final double ESA_WORLD_COVER_RESOLUTION_METERS = 10.0;
+   private static final int ESA_NO_DATA = 0;
+   private static final int ESA_BUILT_UP = 50;
+   private static final int ESA_SNOW_ICE = 70;
+   private static final int ESA_WATER = 80;
+   private static final int ESA_MANGROVES = 95;
+   private static final double ROAD_LIGHT_BASE_SPACING_METERS = 40.0;
+   private static final int ROAD_LIGHT_BLOCK_LIGHT = 15;
+   private static final TellusLodGenerator.CanopyProfile TREE_COVER_FALLBACK_CANOPY_PROFILE = new TellusLodGenerator.CanopyProfile(
+      false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, 70, 3, 2, 3, 10
+   );
+   private static final Map<Holder<Biome>, TellusLodGenerator.CanopyProfile> CANOPY_PROFILES = new ConcurrentHashMap<>();
+   private final EarthChunkGenerator generator;
+   private final EarthBiomeSource biomeSource;
+   private final DhLodWaterResolver dhWaterResolver;
+   private final ThreadLocal<TellusLodGenerator.WrapperCache> wrapperCache;
+   private final ConcurrentHashMap<Object, Long> recentPrefetches = new ConcurrentHashMap<>();
+   private final AtomicInteger prefetchCleanupCounter = new AtomicInteger();
+
+   public TellusLodGenerator(IDhApiLevelWrapper levelWrapper, EarthChunkGenerator generator) {
+      this.generator = generator;
+      this.biomeSource = (EarthBiomeSource)generator.getBiomeSource();
+      this.dhWaterResolver = new DhLodWaterResolver(generator);
+      this.wrapperCache = ThreadLocal.withInitial(() -> new TellusLodGenerator.WrapperCache(levelWrapper));
+   }
+
+   public void preGeneratorTaskStart() {
+   }
+
+   public byte getLargestDataDetailLevel() {
+      return 24;
+   }
+
+   public CompletableFuture<Void> generateLod(
+      int chunkPosMinX,
+      int chunkPosMinZ,
+      int lodPosX,
+      int lodPosZ,
+      byte detailLevel,
+      IDhApiFullDataSource pooledFullDataSource,
+      EDhApiDistantGeneratorMode generatorMode,
+      ExecutorService worldGeneratorThreadPool,
+      Consumer<IDhApiFullDataSource> resultConsumer
+   ) {
+      return CompletableFuture.runAsync(() -> {
+         boolean handledCancellation = false;
+         TellusLodGenerator.LodTimingTrace timingTrace = new TellusLodGenerator.LodTimingTrace(
+            chunkPosMinX,
+            chunkPosMinZ,
+            detailLevel,
+            pooledFullDataSource.getWidthInDataColumns(),
+            1 << detailLevel,
+            generatorMode,
+            this.generator.settings().distantHorizonsRenderMode()
+         );
+
+         try {
+            timingTrace.addPhase("prefetch", 0L);
+            long prefetchStart = beginTimingPhase(timingTrace);
+            this.prefetchLodResources(chunkPosMinX, chunkPosMinZ, detailLevel, pooledFullDataSource.getWidthInDataColumns());
+            endTimingPhase(timingTrace, "prefetch", prefetchStart);
+            this.buildLod(pooledFullDataSource, chunkPosMinX, chunkPosMinZ, detailLevel, generatorMode, timingTrace);
+            timingTrace.logSuccess();
+         } catch (Throwable throwable) {
+            handledCancellation = isInterruptedLodGeneration(throwable);
+            this.resetLodOutput(pooledFullDataSource);
+            if (handledCancellation) {
+               timingTrace.logCancelled();
+            } else {
+               timingTrace.logFailure(throwable);
+            }
+         }
+
+         resultConsumer.accept(pooledFullDataSource);
+         if (handledCancellation) {
+            Thread.interrupted();
+         }
+      }, worldGeneratorThreadPool);
+   }
+
+   private static boolean isInterruptedLodGeneration(Throwable throwable) {
+      if (Thread.currentThread().isInterrupted()) {
+         return true;
+      } else {
+         for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof CancellationException
+               || current instanceof InterruptedException
+               || current instanceof InterruptedIOException
+               || current instanceof ClosedByInterruptException) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+   }
+
+   private void resetLodOutput(IDhApiFullDataSource output) {
+      int width = output.getWidthInDataColumns();
+      List<DhApiTerrainDataPoint> emptyColumn = List.of();
+
+      for (int z = 0; z < width; z++) {
+         for (int x = 0; x < width; x++) {
+            output.setApiDataPointColumn(x, z, emptyColumn);
+         }
+      }
+   }
+
+   private static void throwIfLodCancelled() {
+      if (Thread.currentThread().isInterrupted()) {
+         throw new CancellationException("DH LOD generation interrupted");
+      }
+   }
+
+   private static long beginTimingPhase(TellusLodGenerator.LodTimingTrace trace) {
+      return trace.isEnabled() ? System.nanoTime() : 0L;
+   }
+
+   private static void endTimingPhase(TellusLodGenerator.LodTimingTrace trace, String phase, long startNanos) {
+      if (trace.isEnabled()) {
+         trace.addPhase(phase, System.nanoTime() - startNanos);
+      }
+   }
+
+   private void buildLod(
+      IDhApiFullDataSource output,
+      int chunkPosMinX,
+      int chunkPosMinZ,
+      byte detailLevel,
+      EDhApiDistantGeneratorMode generatorMode,
+      TellusLodGenerator.LodTimingTrace trace
+   ) {
+      int detail = Byte.toUnsignedInt(detailLevel);
+      trace.note("surfaceMode", this.useUltraFastLodMode(detail) ? "ultra_fast" : "detailed");
+      if (this.useUltraFastLodMode(detail)) {
+         this.buildUltraFastLod(output, chunkPosMinX, chunkPosMinZ, detailLevel, trace);
+      } else {
+         int lodSizePoints = output.getWidthInDataColumns();
+         int cellSize = 1 << detailLevel;
+         int cellOffset = cellSize >> 1;
+         EarthGeneratorSettings settings = this.generator.settings();
+         double previewResolutionMeters = lodPreviewResolutionMeters(settings, cellSize);
+         boolean baseDetailedWater = settings.distantHorizonsWaterResolver() && detailLevel <= 5;
+         TellusRealtimeState.PrecipitationMode precipitationMode = TellusRealtimeState.precipitationMode();
+         boolean snowActive = TellusRealtimeState.isWeatherEnabled() && precipitationMode == TellusRealtimeState.PrecipitationMode.SNOW
+            || TellusRealtimeState.isHistoricalSnowEnabled();
+         int baseX = SectionPos.sectionToBlockCoord(chunkPosMinX);
+         int baseZ = SectionPos.sectionToBlockCoord(chunkPosMinZ);
+         int[] worldXs = new int[lodSizePoints];
+         int[] worldZs = new int[lodSizePoints];
+
+         for (int i = 0; i < lodSizePoints; i++) {
+            worldXs[i] = baseX + i * cellSize + cellOffset;
+            worldZs[i] = baseZ + i * cellSize + cellOffset;
+         }
+
+         boolean roadsActive = this.shouldRenderDhRoads(detail);
+         boolean buildingsActive = this.shouldRenderDhBuildings(detail);
+         boolean preferNonBlockingOsm = settings.distantHorizonsOsmNonBlockingFetch();
+         OsmQueryMode osmQueryMode = preferNonBlockingOsm ? OsmQueryMode.NON_BLOCKING : OsmQueryMode.BLOCKING;
+         boolean mainRoadsOnly = roadsActive && detail == settings.distantHorizonsOsmRoadMaxDetail();
+         trace.note("roads", roadsActive);
+         trace.note("buildings", buildingsActive);
+         trace.note("osm", osmQueryMode);
+         trace.note("coverStride", coverSampleStride(detailLevel, lodSizePoints));
+         trace.note("waterStride", detailedWaterStride(detailLevel, lodSizePoints));
+         trace.addPhase("sample", 0L);
+         trace.addPhase("waterProbe", 0L);
+         trace.addPhase("detailedWater", 0L);
+         trace.addPhase("buildingMask", 0L);
+         trace.addPhase("roadMask", 0L);
+         trace.addPhase("terrainMetrics", 0L);
+         trace.addPhase("sharedTerrainCache", 0L);
+         trace.addPhase("shorelineCache", 0L);
+         trace.addPhase("mountainTransitionCache", 0L);
+         trace.addPhase("emit", 0L);
+         trace.addPhase("emit.surfaceResolve", 0L);
+         trace.addPhase("emit.surfaceResolve.local", 0L);
+         trace.addPhase("emit.surfaceResolve.generator", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.effectiveCover", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.surfaceCoverClass", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.basePalette", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.shoreline", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.shoreline.context", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.shoreline.classify", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.slopeOverride", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.slope.transition", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.slope.context", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.slope.rockPalette", 0L);
+         trace.addPhase("emit.surfaceResolve.generator.result", 0L);
+         trace.addPhase("emit.baseLayers", 0L);
+         trace.addPhase("emit.canopy", 0L);
+         trace.addPhase("emit.water", 0L);
+         trace.addPhase("emit.features", 0L);
+         trace.addPhase("emit.output", 0L);
+         int minY = this.generator.getMinY();
+         int maxY = minY + this.generator.getGenDepth();
+         int absoluteTop = maxY - minY;
+         TellusLodGenerator.WrapperCache wrappers = this.wrapperCache.get();
+         IDhApiBlockStateWrapper waterBlock = wrappers.getBlockState(Blocks.WATER.defaultBlockState());
+         IDhApiBlockStateWrapper roadMainBlock = wrappers.getBlockState(Blocks.GRAY_CONCRETE.defaultBlockState());
+         IDhApiBlockStateWrapper roadNormalBlock = wrappers.getBlockState(Blocks.CYAN_TERRACOTTA.defaultBlockState());
+         IDhApiBlockStateWrapper roadDirtBlock = wrappers.getBlockState(Blocks.DIRT_PATH.defaultBlockState());
+         IDhApiBlockStateWrapper bridgeSupportShaftBlock = wrappers.getBlockState(Blocks.QUARTZ_PILLAR.defaultBlockState());
+         IDhApiBlockStateWrapper bridgeSupportCapBlock = wrappers.getBlockState(Blocks.QUARTZ_BRICKS.defaultBlockState());
+         IDhApiBlockStateWrapper roadLightBaseBlock = wrappers.getBlockState(Blocks.STONE_BRICK_WALL.defaultBlockState());
+         IDhApiBlockStateWrapper roadLightFenceBlock = wrappers.getBlockState(Blocks.OAK_FENCE.defaultBlockState());
+         IDhApiBlockStateWrapper roadLightGlowBlock = wrappers.getBlockState(Blocks.GLOWSTONE.defaultBlockState());
+         IDhApiBlockStateWrapper roadLightCapBlock = wrappers.getBlockState(Blocks.SPRUCE_TRAPDOOR.defaultBlockState());
+         List<DhApiTerrainDataPoint> columnDataPoints = new ArrayList<>(12);
+         int coverStride = coverSampleStride(detailLevel, lodSizePoints);
+         boolean allowWaterVegetation = detailLevel <= 4;
+         int area = lodSizePoints * lodSizePoints;
+         int[] baseTerrainSurface = new int[area];
+         int[] surfaceYs = new int[area];
+         int[] vegetationSurfaceYs = new int[area];
+         int[] waterSurfaces = new int[area];
+         boolean[] underwaterFlags = new boolean[area];
+         int[] coverClasses = new int[area];
+         int[] visualCoverClasses = new int[area];
+         IDhApiBiomeWrapper[] biomeWrappers = new IDhApiBiomeWrapper[area];
+         Holder<Biome>[] biomeHolders = newBiomeHolderArray(area);
+         int[] lodSlopeDiffs = new int[area];
+         int[] lodConvexities = new int[area];
+         BlockState lastTopState = null;
+         BlockState lastFillerState = null;
+         TellusLodGenerator.SurfaceWrapperPair lastSurfaceWrapper = null;
+         boolean sampleVisualCover = shouldSampleVisualCover(settings, previewResolutionMeters);
+         boolean useSharedTerrainCache = detailLevel == 2;
+         EarthChunkGenerator.LodSharedTerrainCache sharedTerrainCache = null;
+         EarthChunkGenerator.LodShorelineCache shorelineCache = null;
+         EarthChunkGenerator.LodMountainTransitionCache mountainTransitionCache = null;
+         boolean suppressCoarseShoreline = this.shouldSuppressCoarseShoreline(detail);
+         trace.note("shorelineMode", suppressCoarseShoreline ? "suppressed" : "full");
+         long phaseStart = beginTimingPhase(trace);
+         if (useSharedTerrainCache) {
+            sharedTerrainCache = this.generator.buildLodSharedTerrainCache(
+               worldXs[0], worldXs[lodSizePoints - 1], worldZs[0], worldZs[lodSizePoints - 1], previewResolutionMeters
+            );
+         }
+         endTimingPhase(trace, "sharedTerrainCache", phaseStart);
+         trace.note("sharedTerrainCache", sharedTerrainCache == null ? "disabled" : sharedTerrainCache.mode());
+         if (sharedTerrainCache != null) {
+            shorelineCache = sharedTerrainCache.shorelineCache();
+            mountainTransitionCache = sharedTerrainCache.mountainTransitionCache();
+         }
+
+         boolean reuseSharedPreviewCoverSamples = sharedTerrainCache != null;
+         phaseStart = beginTimingPhase(trace);
+
+         for (int baseLocalZ = 0; baseLocalZ < lodSizePoints; baseLocalZ += coverStride) {
+            throwIfLodCancelled();
+
+            for (int baseLocalX = 0; baseLocalX < lodSizePoints; baseLocalX += coverStride) {
+               int sampleWorldX = worldXs[baseLocalX];
+               int sampleWorldZ = worldZs[baseLocalZ];
+               int coverClass = reuseSharedPreviewCoverSamples
+                  ? sharedTerrainCache.sampleCoverClass(sampleWorldX, sampleWorldZ)
+                  : this.generator.sampleCoverClass(sampleWorldX, sampleWorldZ, previewResolutionMeters);
+               int visualCoverClass = sampleVisualCover && !isHardRawCoverClass(coverClass)
+                  ? reuseSharedPreviewCoverSamples
+                     ? sharedTerrainCache.sampleVisualCoverClass(sampleWorldX, sampleWorldZ)
+                     : this.generator.sampleVisualCoverClass(sampleWorldX, sampleWorldZ, coverClass, previewResolutionMeters)
+                  : coverClass;
+
+               for (int dz = 0; dz < coverStride; dz++) {
+                  int localZ = baseLocalZ + dz;
+                  if (localZ < lodSizePoints) {
+                     int worldZ = worldZs[localZ];
+
+                     for (int dx = 0; dx < coverStride; dx++) {
+                        int localX = baseLocalX + dx;
+                        if (localX < lodSizePoints) {
+                           int worldX = worldXs[localX];
+                           int index = localZ * lodSizePoints + localX;
+                           baseTerrainSurface[index] = this.generator.resolveLodTerrainSurface(worldX, worldZ, coverClass, previewResolutionMeters);
+                           coverClasses[index] = coverClass;
+                           visualCoverClasses[index] = visualCoverClass;
+                        }
+                     }
+                  }
+               }
+            }
+         }
+         endTimingPhase(trace, "sample", phaseStart);
+         trace.note("detailedWater", baseDetailedWater);
+         phaseStart = beginTimingPhase(trace);
+         DhLodWaterResolver.AreaResult waterArea = this.dhWaterResolver.resolveArea(
+            baseX,
+            baseZ,
+            lodSizePoints,
+            cellSize,
+            worldXs,
+            worldZs,
+            baseTerrainSurface,
+            coverClasses,
+            baseDetailedWater
+         );
+         endTimingPhase(trace, "detailedWater", phaseStart);
+
+         int[] resolvedTerrainSurface = waterArea.terrainSurface();
+         int[] resolvedWaterSurface = waterArea.waterSurface();
+         boolean[] resolvedHasWater = waterArea.hasWater();
+         boolean[] resolvedOcean = waterArea.ocean();
+
+         for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+            throwIfLodCancelled();
+            int worldZ = worldZs[localZ];
+            int row = localZ * lodSizePoints;
+
+            for (int localX = 0; localX < lodSizePoints; localX++) {
+               int index = row + localX;
+               int worldX = worldXs[localX];
+               int surfaceY = Mth.clamp(resolvedTerrainSurface[index], minY, maxY - 1);
+               int waterSurface = Mth.clamp(resolvedWaterSurface[index], minY, maxY - 1);
+               boolean hasWater = resolvedHasWater[index];
+               boolean isOcean = resolvedOcean[index];
+               int vegetationSurface = isOcean ? Mth.clamp(baseTerrainSurface[index], minY, maxY - 1) : surfaceY;
+               surfaceYs[index] = surfaceY;
+               vegetationSurfaceYs[index] = Mth.clamp(vegetationSurface, minY, maxY - 1);
+               waterSurfaces[index] = waterSurface;
+               underwaterFlags[index] = hasWater && waterSurface > surfaceY;
+               Holder<Biome> biomeHolder = this.biomeSource.getBiomeAtBlock(worldX, worldZ, coverClasses[index], visualCoverClasses[index], hasWater, isOcean);
+               biomeHolders[index] = biomeHolder;
+               biomeWrappers[index] = wrappers.getBiome(biomeHolder);
+            }
+         }
+
+         phaseStart = beginTimingPhase(trace);
+         TellusLodGenerator.LodBuildingMaskResult buildingMaskResult = buildingsActive
+            ? this.buildLodBuildingMask(worldXs, worldZs, surfaceYs, lodSizePoints, cellSize, osmQueryMode)
+            : new TellusLodGenerator.LodBuildingMaskResult(null, null, false);
+         endTimingPhase(trace, "buildingMask", phaseStart);
+
+         TellusLodGenerator.LodBuildingColumn[] buildingColumns = buildingMaskResult.columns();
+         phaseStart = beginTimingPhase(trace);
+         TellusLodGenerator.LodRoadMaskResult roadMaskResult = roadsActive
+            ? this.buildLodRoadClassMask(worldXs, worldZs, surfaceYs, lodSizePoints, cellSize, mainRoadsOnly, osmQueryMode, buildingColumns)
+            : new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, false);
+         endTimingPhase(trace, "roadMask", phaseStart);
+         phaseStart = beginTimingPhase(trace);
+         for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+            int row = localZ * lodSizePoints;
+
+            for (int localX = 0; localX < lodSizePoints; localX++) {
+               int index = row + localX;
+               lodSlopeDiffs[index] = lodSlopeDiff(surfaceYs, lodSizePoints, localX, localZ, cellSize);
+               lodConvexities[index] = lodConvexity(surfaceYs, lodSizePoints, localX, localZ, cellSize);
+            }
+         }
+         endTimingPhase(trace, "terrainMetrics", phaseStart);
+         if (cellSize > 4) {
+            phaseStart = beginTimingPhase(trace);
+            for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+               int worldZ = worldZs[localZ];
+               int row = localZ * lodSizePoints;
+               for (int localX = 0; localX < lodSizePoints; localX++) {
+                  int index = row + localX;
+                  if (coverClasses[index] == ESA_SNOW_ICE || visualCoverClasses[index] == ESA_SNOW_ICE) {
+                     long packed = this.generator.sampleLodSnowSlopeShape(worldXs[localX], worldZ);
+                     lodSlopeDiffs[index] = (int)(packed >> 32);
+                     lodConvexities[index] = (int)packed;
+                  }
+               }
+            }
+            endTimingPhase(trace, "snowSlopeRefine", phaseStart);
+         }
+         if (shorelineCache == null) {
+            phaseStart = beginTimingPhase(trace);
+            shorelineCache = this.generator.buildLodShorelineCache(
+               worldXs[0], worldXs[lodSizePoints - 1], worldZs[0], worldZs[lodSizePoints - 1], previewResolutionMeters
+            );
+            endTimingPhase(trace, "shorelineCache", phaseStart);
+         }
+         trace.note("shorelineCache", shorelineCache.mode());
+         if (mountainTransitionCache == null) {
+            phaseStart = beginTimingPhase(trace);
+            mountainTransitionCache = this.generator.buildLodMountainTransitionCache(
+               worldXs[0], worldXs[lodSizePoints - 1], worldZs[0], worldZs[lodSizePoints - 1], previewResolutionMeters
+            );
+            endTimingPhase(trace, "mountainTransitionCache", phaseStart);
+         }
+         trace.note("mountainTransitionCache", mountainTransitionCache == null ? "disabled" : mountainTransitionCache.mode());
+
+         byte[] roadClassMask = roadMaskResult.mask();
+         int[] roadBridgeDeckYMask = roadMaskResult.bridgeDeckY();
+         int[] bridgeSupportShaftBottomMask = roadMaskResult.bridgeSupportShaftBottomY();
+         int[] bridgeSupportShaftTopMask = roadMaskResult.bridgeSupportShaftTopY();
+         int[] bridgeSupportCapBottomMask = roadMaskResult.bridgeSupportCapBottomY();
+         int[] bridgeSupportCapTopMask = roadMaskResult.bridgeSupportCapTopY();
+         int[] roadLightBaseYMask = roadMaskResult.roadLightBaseY();
+         byte[] roadLightFenceCountMask = roadMaskResult.roadLightFenceCount();
+         int[] buildingFlattenedSurface = buildingMaskResult.flattenedSurface();
+         boolean emitTimingEnabled = trace.isEnabled();
+         long emitSurfaceResolveNanos = 0L;
+         long emitSurfaceResolveLocalNanos = 0L;
+         long emitSurfaceResolveGeneratorNanos = 0L;
+         long emitBaseLayersNanos = 0L;
+         long emitCanopyNanos = 0L;
+         long emitWaterNanos = 0L;
+         long emitFeaturesNanos = 0L;
+         long emitOutputNanos = 0L;
+         int emitColumns = 0;
+         int emitPoints = 0;
+         int emitMaxPoints = 0;
+         int emitColumnsOverInitialCapacity = 0;
+         int emitBuildingColumns = 0;
+         int emitRoadColumns = 0;
+         int emitBridgeRoadColumns = 0;
+         int emitBridgeSupportColumns = 0;
+         int emitUnderwaterColumns = 0;
+         int emitCanopyColumns = 0;
+         int emitBadlandsColumns = 0;
+         TellusLodGenerator.LodSurfaceResolveProfiler surfaceResolveProfiler = emitTimingEnabled
+            ? new TellusLodGenerator.LodSurfaceResolveProfiler()
+            : null;
+         phaseStart = beginTimingPhase(trace);
+         this.generator.setLodMountainTransitionCache(mountainTransitionCache);
+         this.generator.setLodShorelineOverrideSuppressed(suppressCoarseShoreline);
+
+         try {
+            for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+               throwIfLodCancelled();
+               int worldZ = worldZs[localZ];
+
+               for (int localXx = 0; localXx < lodSizePoints; localXx++) {
+                  int worldX = worldXs[localXx];
+                  int index = localZ * lodSizePoints + localXx;
+                  int surfaceY = surfaceYs[index];
+                  int vegetationSurfaceY = vegetationSurfaceYs[index];
+                  int waterSurface = waterSurfaces[index];
+                  boolean underwater = underwaterFlags[index];
+                  int coverClass = coverClasses[index];
+                  int visualCoverClass = visualCoverClasses[index];
+                  Holder<Biome> biomeHolder = biomeHolders[index];
+                  IDhApiBiomeWrapper biome = biomeWrappers[index];
+                  TellusLodGenerator.CanopyProfile biomeCanopyProfile = canopyProfile(biomeHolder);
+                  TellusLodGenerator.CanopyProfile canopyProfile = resolveTreeCoverCanopyProfile(biomeCanopyProfile, coverClass);
+                  boolean isMangrove = canopyProfile.isMangrove() || coverClass == ESA_MANGROVES;
+                  TellusLodGenerator.LodBuildingColumn buildingColumn = buildingColumns == null ? null : buildingColumns[index];
+                  boolean hasBuilding = buildingColumn != null;
+                  int originalSurfaceY = surfaceY;
+                  if (hasBuilding) {
+                     int flattenedSurface = buildingFlattenedSurface == null ? Integer.MIN_VALUE : buildingFlattenedSurface[index];
+                     if (flattenedSurface != Integer.MIN_VALUE) {
+                        surfaceY = Mth.clamp(flattenedSurface, minY, maxY - 1);
+                        vegetationSurfaceY = surfaceY;
+                        waterSurface = surfaceY;
+                        underwater = false;
+                     }
+                  }
+
+                  long columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  boolean reusePrecomputedSurface = !hasBuilding || surfaceY == originalSurfaceY;
+                  long generatorSurfaceResolveNanos = 0L;
+                  EarthChunkGenerator.LodSurface lodSurface;
+                  if (reusePrecomputedSurface) {
+                     if (emitTimingEnabled) {
+                        long generatorStart = System.nanoTime();
+                        lodSurface = this.generator.resolveLodSurface(
+                           biomeHolder,
+                           worldX,
+                           worldZ,
+                           surfaceY,
+                           underwater,
+                           coverClass,
+                           visualCoverClass,
+                           lodSlopeDiffs[index],
+                           lodConvexities[index],
+                           surfaceResolveProfiler,
+                           shorelineCache
+                        );
+                        generatorSurfaceResolveNanos = System.nanoTime() - generatorStart;
+                     } else {
+                        lodSurface = this.generator.resolveLodSurface(
+                           biomeHolder,
+                           worldX,
+                           worldZ,
+                           surfaceY,
+                           underwater,
+                           coverClass,
+                           visualCoverClass,
+                           lodSlopeDiffs[index],
+                           lodConvexities[index],
+                           shorelineCache
+                        );
+                     }
+                  } else if (emitTimingEnabled) {
+                     long generatorStart = System.nanoTime();
+                     lodSurface = this.generator.resolveLodSurface(
+                        biomeHolder, worldX, worldZ, surfaceY, underwater, coverClass, visualCoverClass, surfaceResolveProfiler, shorelineCache
+                     );
+                     generatorSurfaceResolveNanos = System.nanoTime() - generatorStart;
+                  } else {
+                     lodSurface = this.generator.resolveLodSurface(
+                        biomeHolder, worldX, worldZ, surfaceY, underwater, coverClass, visualCoverClass, shorelineCache
+                     );
+                  }
+
+                  BlockState topState = lodSurface.top();
+                  BlockState fillerState = lodSurface.filler();
+                  TellusLodGenerator.SurfaceWrapperPair surfaceWrapper;
+                  if (topState == lastTopState && fillerState == lastFillerState && lastSurfaceWrapper != null) {
+                     surfaceWrapper = lastSurfaceWrapper;
+                  } else {
+                     surfaceWrapper = new TellusLodGenerator.SurfaceWrapperPair(
+                        wrappers.getBlockState(topState), wrappers.getBlockState(fillerState)
+                     );
+                     lastTopState = topState;
+                     lastFillerState = fillerState;
+                     lastSurfaceWrapper = surfaceWrapper;
+                  }
+
+                  IDhApiBlockStateWrapper fillerBlock = surfaceWrapper.filler();
+                  IDhApiBlockStateWrapper topBlock = surfaceWrapper.top();
+                  int roadClassId = roadClassMask == null ? 0 : roadClassMask[index];
+                  boolean hasRoad = roadClassId > 0 && !hasBuilding;
+                  int bridgeSupportShaftBottomY = bridgeSupportShaftBottomMask == null ? Integer.MIN_VALUE : bridgeSupportShaftBottomMask[index];
+                  int bridgeSupportShaftTopY = bridgeSupportShaftTopMask == null ? Integer.MIN_VALUE : bridgeSupportShaftTopMask[index];
+                  int bridgeSupportCapBottomY = bridgeSupportCapBottomMask == null ? Integer.MIN_VALUE : bridgeSupportCapBottomMask[index];
+                  int bridgeSupportCapTopY = bridgeSupportCapTopMask == null ? Integer.MIN_VALUE : bridgeSupportCapTopMask[index];
+                  boolean hasBridgeShaft = bridgeSupportShaftBottomY != Integer.MIN_VALUE && bridgeSupportShaftTopY != Integer.MIN_VALUE;
+                  boolean hasBridgeCap = bridgeSupportCapBottomY != Integer.MIN_VALUE && bridgeSupportCapTopY != Integer.MIN_VALUE;
+                  boolean hasBridgeSupport = !hasBuilding && hasBridgeCap;
+                  int roadLightBaseY = roadLightBaseYMask == null ? Integer.MIN_VALUE : roadLightBaseYMask[index];
+                  IDhApiBlockStateWrapper roadBlock = null;
+                  int bridgeDeckY = Integer.MIN_VALUE;
+                  boolean bridgeRoad = false;
+                  if (hasRoad) {
+                     roadBlock = switch (roadClassId) {
+                        case 1 -> roadMainBlock;
+                        case 2 -> roadNormalBlock;
+                        default -> roadDirtBlock;
+                     };
+                     int bridgeDeckCandidate = roadBridgeDeckYMask == null ? Integer.MIN_VALUE : roadBridgeDeckYMask[index];
+                     if (bridgeDeckCandidate != Integer.MIN_VALUE && bridgeDeckCandidate > surfaceY) {
+                        bridgeDeckY = Mth.clamp(bridgeDeckCandidate, minY, maxY - 1);
+                        bridgeRoad = true;
+                     } else {
+                        topBlock = roadBlock;
+                        if (underwater) {
+                           surfaceY = Math.max(surfaceY, waterSurface);
+                           vegetationSurfaceY = Math.min(vegetationSurfaceY, surfaceY);
+                           underwater = false;
+                        }
+                     }
+                  }
+
+                  if (bridgeRoad) {
+                     topBlock = surfaceWrapper.top();
+                     if (surfaceY > bridgeDeckY) {
+                        bridgeRoad = false;
+                        topBlock = roadBlock;
+                     }
+                  }
+
+                  if (!hasRoad && !hasBuilding && !underwater && snowActive && TellusRealtimeState.shouldApplySnow(worldX, worldZ)) {
+                     topBlock = wrappers.getBlockState(Blocks.SNOW_BLOCK.defaultBlockState());
+                  }
+
+                  int slopeDiff = lodSlopeDiffs[index];
+                  boolean useBadlandsBands = !underwater
+                     && !hasRoad
+                     && !hasBuilding
+                     && !hasBridgeSupport
+                     && slopeDiff >= 3
+                     && biomeHolder.is(BiomeTags.IS_BADLANDS);
+                  if (emitTimingEnabled) {
+                     long totalSurfaceResolveNanos = System.nanoTime() - columnPhaseStart;
+                     emitSurfaceResolveNanos += totalSurfaceResolveNanos;
+                     emitSurfaceResolveGeneratorNanos += generatorSurfaceResolveNanos;
+                     emitSurfaceResolveLocalNanos += Math.max(0L, totalSurfaceResolveNanos - generatorSurfaceResolveNanos);
+                  }
+
+                  emitColumns++;
+                  if (hasBuilding) {
+                     emitBuildingColumns++;
+                  }
+
+                  if (hasRoad) {
+                     emitRoadColumns++;
+                  }
+
+                  if (bridgeRoad) {
+                     emitBridgeRoadColumns++;
+                  }
+
+                  if (hasBridgeSupport) {
+                     emitBridgeSupportColumns++;
+                  }
+
+                  if (underwater) {
+                     emitUnderwaterColumns++;
+                  }
+
+                  if (useBadlandsBands) {
+                     emitBadlandsColumns++;
+                  }
+
+                  int lastLayerTop = 0;
+                  int surfaceTop = toLayerTop(surfaceY, minY, absoluteTop);
+                  int topLayerBase = Math.max(0, surfaceTop - 1);
+                  columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  if (useBadlandsBands) {
+                     int bandDepth = Math.min(16, surfaceY - minY + 1);
+                     int bandBottomY = Math.max(minY, surfaceY - bandDepth + 1);
+                     int bandBottomLayer = toLayerTop(bandBottomY, minY, absoluteTop);
+                     if (bandBottomLayer > lastLayerTop) {
+                        columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, bandBottomLayer, fillerBlock, biome));
+                        lastLayerTop = bandBottomLayer;
+                     }
+
+                     while (lastLayerTop < topLayerBase) {
+                        int segmentTop = Math.min(topLayerBase, lastLayerTop + 3);
+                        int bandY = segmentTop - 1;
+                        IDhApiBlockStateWrapper bandBlock = wrappers.getBlockState(this.generator.resolveBadlandsBandBlock(worldX, worldZ, bandY));
+                        columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, segmentTop, bandBlock, biome));
+                        lastLayerTop = segmentTop;
+                     }
+                  } else if (topLayerBase > lastLayerTop) {
+                     columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, topLayerBase, fillerBlock, biome));
+                     lastLayerTop = topLayerBase;
+                  }
+
+                  if (surfaceTop > lastLayerTop) {
+                     columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, surfaceTop, topBlock, biome));
+                     lastLayerTop = surfaceTop;
+                  }
+
+                  if (emitTimingEnabled) {
+                     emitBaseLayersNanos += System.nanoTime() - columnPhaseStart;
+                  }
+
+                  boolean allowCanopy = !hasRoad && !hasBuilding && !hasBridgeSupport && (coverClass == 10 && !underwater || isMangrove);
+                  columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  TellusLodGenerator.CanopyColumn canopyColumn = allowCanopy ? resolveCanopyColumn(canopyProfile, worldX, worldZ, cellSize) : null;
+                  if (canopyColumn != null) {
+                     emitCanopyColumns++;
+                  }
+
+                  boolean deferMangroveCanopy = isMangrove && underwater;
+                  if (!deferMangroveCanopy) {
+                     lastLayerTop = appendCanopyColumn(canopyColumn, lastLayerTop, absoluteTop, wrappers, biome, columnDataPoints);
+                  }
+
+                  if (emitTimingEnabled) {
+                     emitCanopyNanos += System.nanoTime() - columnPhaseStart;
+                  }
+
+                  columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  if (underwater && !hasBridgeSupport) {
+                     int waterTop = toLayerTop(waterSurface, minY, absoluteTop);
+                     if (waterTop > lastLayerTop) {
+                        int waterDepth = waterSurface - vegetationSurfaceY;
+                        TellusLodGenerator.WaterVegetationColumn vegetation = allowWaterVegetation
+                           ? resolveWaterVegetationColumn(canopyProfile, worldX, worldZ, waterDepth)
+                           : null;
+                        if (vegetation != null) {
+                           int vegetationBaseTop = toLayerTop(vegetationSurfaceY, minY, absoluteTop);
+                           vegetationBaseTop = Mth.clamp(vegetationBaseTop, lastLayerTop, waterTop);
+                           if (vegetationBaseTop > lastLayerTop) {
+                              columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, vegetationBaseTop, waterBlock, biome));
+                              lastLayerTop = vegetationBaseTop;
+                           }
+
+                           int vegTop = Math.min(waterTop, lastLayerTop + vegetation.height);
+                           if (vegTop > lastLayerTop) {
+                              IDhApiBlockStateWrapper vegBlock = wrappers.getBlockState(vegetation.blockState);
+                              columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, vegTop, vegBlock, biome));
+                              lastLayerTop = vegTop;
+                           }
+
+                           if (waterTop > lastLayerTop) {
+                              columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, waterTop, waterBlock, biome));
+                              lastLayerTop = waterTop;
+                           }
+                        } else {
+                           columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, waterTop, waterBlock, biome));
+                           lastLayerTop = waterTop;
+                        }
+                     }
+                  }
+
+                  if (emitTimingEnabled) {
+                     emitWaterNanos += System.nanoTime() - columnPhaseStart;
+                  }
+
+                  if (deferMangroveCanopy) {
+                     columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                     lastLayerTop = appendCanopyColumn(canopyColumn, lastLayerTop, absoluteTop, wrappers, biome, columnDataPoints);
+                     if (emitTimingEnabled) {
+                        emitCanopyNanos += System.nanoTime() - columnPhaseStart;
+                     }
+                  }
+
+                  columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  if (hasBridgeSupport) {
+                     if (hasBridgeShaft) {
+                        int shaftBottomTop = toLayerTop(bridgeSupportShaftBottomY - 1, minY, absoluteTop);
+                        int shaftTopTop = toLayerTop(bridgeSupportShaftTopY, minY, absoluteTop);
+                        if (shaftBottomTop > lastLayerTop) {
+                           columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, shaftBottomTop, wrappers.airBlock(), biome));
+                           lastLayerTop = shaftBottomTop;
+                        }
+
+                        if (shaftTopTop > lastLayerTop) {
+                           columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, shaftTopTop, bridgeSupportShaftBlock, biome));
+                           lastLayerTop = shaftTopTop;
+                        }
+                     }
+
+                     int capBottomTop = toLayerTop(bridgeSupportCapBottomY - 1, minY, absoluteTop);
+                     int capTopTop = toLayerTop(bridgeSupportCapTopY, minY, absoluteTop);
+                     if (capBottomTop > lastLayerTop) {
+                        columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, capBottomTop, wrappers.airBlock(), biome));
+                        lastLayerTop = capBottomTop;
+                     }
+
+                     if (capTopTop > lastLayerTop) {
+                        columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, capTopTop, bridgeSupportCapBlock, biome));
+                        lastLayerTop = capTopTop;
+                     }
+                  }
+
+                  if (bridgeRoad && roadBlock != null) {
+                     int bridgeDeckTop = toLayerTop(bridgeDeckY, minY, absoluteTop);
+                     if (bridgeDeckTop > lastLayerTop) {
+                        int deckBaseTop = Math.max(lastLayerTop, bridgeDeckTop - 1);
+                        if (deckBaseTop > lastLayerTop) {
+                           columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, deckBaseTop, wrappers.airBlock(), biome));
+                           lastLayerTop = deckBaseTop;
+                        }
+
+                        columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, bridgeDeckTop, roadBlock, biome));
+                        lastLayerTop = bridgeDeckTop;
+                     }
+                  }
+
+                  if (buildingColumn != null) {
+                     lastLayerTop = appendBuildingColumn(buildingColumn, lastLayerTop, minY, absoluteTop, wrappers, biome, columnDataPoints);
+                  }
+
+                  if (roadLightBaseY != Integer.MIN_VALUE && !hasBuilding && !hasBridgeSupport) {
+                     int roadLightFenceCount = roadLightFenceCountMask == null ? 0 : Byte.toUnsignedInt(roadLightFenceCountMask[index]);
+                     lastLayerTop = appendRoadLightColumn(
+                        roadLightBaseY,
+                        roadLightFenceCount,
+                        lastLayerTop,
+                        minY,
+                        absoluteTop,
+                        roadLightBaseBlock,
+                        roadLightFenceBlock,
+                        roadLightGlowBlock,
+                        roadLightCapBlock,
+                        biome,
+                        columnDataPoints
+                     );
+                  }
+
+                  if (lastLayerTop < absoluteTop) {
+                     columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, absoluteTop, wrappers.airBlock(), biome));
+                  }
+
+                  if (emitTimingEnabled) {
+                     emitFeaturesNanos += System.nanoTime() - columnPhaseStart;
+                  }
+
+                  int columnPointCount = columnDataPoints.size();
+                  emitPoints += columnPointCount;
+                  emitMaxPoints = Math.max(emitMaxPoints, columnPointCount);
+                  if (columnPointCount > 12) {
+                     emitColumnsOverInitialCapacity++;
+                  }
+
+                  columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  output.setApiDataPointColumn(localXx, localZ, columnDataPoints);
+                  columnDataPoints.clear();
+                  if (emitTimingEnabled) {
+                     emitOutputNanos += System.nanoTime() - columnPhaseStart;
+                  }
+               }
+            }
+         } finally {
+            this.generator.clearLodMountainTransitionCache();
+            this.generator.clearLodShorelineOverrideSuppressed();
+         }
+         endTimingPhase(trace, "emit", phaseStart);
+         trace.addPhase("emit.surfaceResolve", emitSurfaceResolveNanos);
+         trace.addPhase("emit.surfaceResolve.local", emitSurfaceResolveLocalNanos);
+         trace.addPhase("emit.surfaceResolve.generator", emitSurfaceResolveGeneratorNanos);
+         if (surfaceResolveProfiler != null) {
+            surfaceResolveProfiler.flushTo(trace);
+         }
+         trace.addPhase("emit.baseLayers", emitBaseLayersNanos);
+         trace.addPhase("emit.canopy", emitCanopyNanos);
+         trace.addPhase("emit.water", emitWaterNanos);
+         trace.addPhase("emit.features", emitFeaturesNanos);
+         trace.addPhase("emit.output", emitOutputNanos);
+         trace.stat("emit.columns", emitColumns);
+         trace.stat("emit.points", emitPoints);
+         trace.stat("emit.avgPointsPerColumn", emitColumns == 0 ? "0.00" : String.format(Locale.ROOT, "%.2f", (double)emitPoints / (double)emitColumns));
+         trace.stat("emit.maxPointsPerColumn", emitMaxPoints);
+         trace.stat("emit.columnsOverInitialCapacity", emitColumnsOverInitialCapacity);
+         trace.stat("emit.underwaterColumns", emitUnderwaterColumns);
+         trace.stat("emit.canopyColumns", emitCanopyColumns);
+         trace.stat("emit.buildingColumns", emitBuildingColumns);
+         trace.stat("emit.roadColumns", emitRoadColumns);
+         trace.stat("emit.bridgeRoadColumns", emitBridgeRoadColumns);
+         trace.stat("emit.bridgeSupportColumns", emitBridgeSupportColumns);
+         trace.stat("emit.badlandsColumns", emitBadlandsColumns);
+      }
+   }
+
+   private void buildUltraFastLod(
+      IDhApiFullDataSource output, int chunkPosMinX, int chunkPosMinZ, byte detailLevel, TellusLodGenerator.LodTimingTrace trace
+   ) {
+      int detail = Byte.toUnsignedInt(detailLevel);
+      int lodSizePoints = output.getWidthInDataColumns();
+      int cellSize = 1 << detailLevel;
+      int cellOffset = cellSize >> 1;
+      int baseX = SectionPos.sectionToBlockCoord(chunkPosMinX);
+      int baseZ = SectionPos.sectionToBlockCoord(chunkPosMinZ);
+      int minY = this.generator.getMinY();
+      int maxY = minY + this.generator.getGenDepth();
+      int absoluteTop = maxY - minY;
+      TellusLodGenerator.WrapperCache wrappers = this.wrapperCache.get();
+      IDhApiBlockStateWrapper snowTopBlock = wrappers.getBlockState(Blocks.SNOW_BLOCK.defaultBlockState());
+      IDhApiBlockStateWrapper waterBlock = wrappers.getBlockState(Blocks.WATER.defaultBlockState());
+      IDhApiBlockStateWrapper roadMainBlock = wrappers.getBlockState(Blocks.GRAY_CONCRETE.defaultBlockState());
+      IDhApiBlockStateWrapper roadNormalBlock = wrappers.getBlockState(Blocks.CYAN_TERRACOTTA.defaultBlockState());
+      IDhApiBlockStateWrapper roadDirtBlock = wrappers.getBlockState(Blocks.DIRT_PATH.defaultBlockState());
+      IDhApiBlockStateWrapper airBlock = wrappers.airBlock();
+      List<DhApiTerrainDataPoint> columnDataPoints = new ArrayList<>(8);
+      EarthGeneratorSettings settings = this.generator.settings();
+      double previewResolutionMeters = lodPreviewResolutionMeters(settings, cellSize);
+      boolean roadsActive = this.shouldRenderDhRoads(detail);
+      boolean buildingsActive = this.shouldRenderDhBuildings(detail);
+      boolean baseDetailedWater = settings.distantHorizonsWaterResolver()
+         && detailLevel <= 5
+         && settings.distantHorizonsRenderMode() != EarthGeneratorSettings.DistantHorizonsRenderMode.ULTRA_FAST;
+      boolean preferNonBlockingOsm = settings.distantHorizonsOsmNonBlockingFetch();
+      OsmQueryMode osmQueryMode = preferNonBlockingOsm ? OsmQueryMode.NON_BLOCKING : OsmQueryMode.BLOCKING;
+      boolean mainRoadsOnly = roadsActive && detail == settings.distantHorizonsOsmRoadMaxDetail();
+      TellusRealtimeState.PrecipitationMode precipitationMode = TellusRealtimeState.precipitationMode();
+      boolean snowActive = TellusRealtimeState.isWeatherEnabled() && precipitationMode == TellusRealtimeState.PrecipitationMode.SNOW
+         || TellusRealtimeState.isHistoricalSnowEnabled();
+      trace.note("roads", roadsActive);
+      trace.note("buildings", buildingsActive);
+      trace.note("detailedWater", false);
+      trace.note("osm", roadsActive || buildingsActive || settings.enableWater() ? osmQueryMode : "DISABLED");
+      trace.addPhase("sample", 0L);
+      trace.addPhase("waterProbe", 0L);
+      trace.addPhase("detailedWater", 0L);
+      trace.addPhase("buildingMask", 0L);
+      trace.addPhase("roadMask", 0L);
+      trace.addPhase("terrainMetrics", 0L);
+      trace.addPhase("emit", 0L);
+      trace.addPhase("emit.classify", 0L);
+      trace.addPhase("emit.baseLayers", 0L);
+      trace.addPhase("emit.canopy", 0L);
+      trace.addPhase("emit.features", 0L);
+      trace.addPhase("emit.output", 0L);
+      boolean sampleVisualCover = shouldSampleVisualCover(settings, previewResolutionMeters);
+      boolean remaSnowEnabled = TellusElevationSource.usesPolarDem(settings.demSelection()) && settings.worldScale() > 0.0;
+      double remaSnowBoundaryZ = remaSnowEnabled ? TellusElevationSource.remaBoundaryBlockZ(settings.worldScale()) : Double.POSITIVE_INFINITY;
+      int area = lodSizePoints * lodSizePoints;
+      int[] worldXs = new int[lodSizePoints];
+      int[] worldZs = new int[lodSizePoints];
+
+      for (int i = 0; i < lodSizePoints; i++) {
+         worldXs[i] = baseX + i * cellSize + cellOffset;
+         worldZs[i] = baseZ + i * cellSize + cellOffset;
+      }
+
+      int[] baseTerrainSurface = new int[area];
+      int[] surfaceYs = new int[area];
+      int[] waterSurfaces = new int[area];
+      boolean[] underwaterFlags = new boolean[area];
+      int[] coverClasses = new int[area];
+      int[] visualCoverClasses = new int[area];
+      int[] lodSlopeDiffs = new int[area];
+      int[] lodConvexities = new int[area];
+      IDhApiBiomeWrapper[] biomeWrappers = new IDhApiBiomeWrapper[area];
+      Holder<Biome>[] biomeHolders = newBiomeHolderArray(area);
+      boolean[] remaSnowTerrainFlags = new boolean[area];
+      long phaseStart = beginTimingPhase(trace);
+
+      for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+         throwIfLodCancelled();
+         int worldZ = worldZs[localZ];
+         boolean remaSnowTerrain = remaSnowEnabled && worldZ >= remaSnowBoundaryZ;
+
+         for (int localX = 0; localX < lodSizePoints; localX++) {
+            int index = localZ * lodSizePoints + localX;
+            int worldX = worldXs[localX];
+            int coverClass = this.generator.sampleCoverClass(worldX, worldZ, previewResolutionMeters);
+            int visualCoverClass = sampleVisualCover && !isHardRawCoverClass(coverClass)
+               ? this.generator.sampleVisualCoverClass(worldX, worldZ, coverClass, previewResolutionMeters)
+               : coverClass;
+            baseTerrainSurface[index] = this.generator.resolveLodTerrainSurface(worldX, worldZ, coverClass, previewResolutionMeters);
+            coverClasses[index] = coverClass;
+            visualCoverClasses[index] = visualCoverClass;
+            remaSnowTerrainFlags[index] = remaSnowTerrain;
+         }
+      }
+      endTimingPhase(trace, "sample", phaseStart);
+      trace.note("detailedWater", baseDetailedWater);
+      phaseStart = beginTimingPhase(trace);
+      DhLodWaterResolver.AreaResult waterArea = this.dhWaterResolver.resolveArea(
+         baseX,
+         baseZ,
+         lodSizePoints,
+         cellSize,
+         worldXs,
+         worldZs,
+         baseTerrainSurface,
+         coverClasses,
+         baseDetailedWater
+      );
+      endTimingPhase(trace, "detailedWater", phaseStart);
+
+      int[] resolvedTerrainSurface = waterArea.terrainSurface();
+      int[] resolvedWaterSurface = waterArea.waterSurface();
+      boolean[] resolvedHasWater = waterArea.hasWater();
+      boolean[] resolvedOcean = waterArea.ocean();
+
+      for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+         throwIfLodCancelled();
+         int worldZ = worldZs[localZ];
+
+         for (int localX = 0; localX < lodSizePoints; localX++) {
+            int index = localZ * lodSizePoints + localX;
+            int worldX = worldXs[localX];
+            int surfaceY = Mth.clamp(resolvedTerrainSurface[index], minY, maxY - 1);
+            int waterSurface = Mth.clamp(resolvedWaterSurface[index], minY, maxY - 1);
+            boolean hasWater = resolvedHasWater[index];
+            boolean isOcean = resolvedOcean[index];
+            surfaceYs[index] = surfaceY;
+            waterSurfaces[index] = waterSurface;
+            underwaterFlags[index] = hasWater && waterSurface > surfaceY;
+            Holder<Biome> biomeHolder = this.biomeSource.getBiomeAtBlock(worldX, worldZ, coverClasses[index], visualCoverClasses[index], hasWater, isOcean);
+            biomeHolders[index] = biomeHolder;
+            biomeWrappers[index] = wrappers.getBiome(biomeHolder);
+         }
+      }
+
+      phaseStart = beginTimingPhase(trace);
+      TellusLodGenerator.LodBuildingMaskResult buildingMaskResult = buildingsActive
+         ? this.buildLodBuildingMask(worldXs, worldZs, surfaceYs, lodSizePoints, cellSize, osmQueryMode)
+         : new TellusLodGenerator.LodBuildingMaskResult(null, null, false);
+      endTimingPhase(trace, "buildingMask", phaseStart);
+      TellusLodGenerator.LodBuildingColumn[] buildingColumns = buildingMaskResult.columns();
+      int[] buildingFlattenedSurface = buildingMaskResult.flattenedSurface();
+      phaseStart = beginTimingPhase(trace);
+      TellusLodGenerator.LodRoadMaskResult roadMaskResult = roadsActive
+         ? this.buildUltraFastRoadMask(worldXs, worldZs, lodSizePoints, cellSize, mainRoadsOnly, osmQueryMode)
+         : new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, false);
+      endTimingPhase(trace, "roadMask", phaseStart);
+      phaseStart = beginTimingPhase(trace);
+      for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+         int row = localZ * lodSizePoints;
+
+         for (int localX = 0; localX < lodSizePoints; localX++) {
+            int index = row + localX;
+            lodSlopeDiffs[index] = lodSlopeDiff(surfaceYs, lodSizePoints, localX, localZ, cellSize);
+            lodConvexities[index] = lodConvexity(surfaceYs, lodSizePoints, localX, localZ, cellSize);
+         }
+      }
+      endTimingPhase(trace, "terrainMetrics", phaseStart);
+      if (cellSize > 4) {
+         phaseStart = beginTimingPhase(trace);
+         for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+            int worldZ = worldZs[localZ];
+            int row = localZ * lodSizePoints;
+            for (int localX = 0; localX < lodSizePoints; localX++) {
+               int index = row + localX;
+               if (coverClasses[index] == ESA_SNOW_ICE || visualCoverClasses[index] == ESA_SNOW_ICE) {
+                  long packed = this.generator.sampleLodSnowSlopeShape(worldXs[localX], worldZ);
+                  lodSlopeDiffs[index] = (int)(packed >> 32);
+                  lodConvexities[index] = (int)packed;
+               }
+            }
+         }
+         endTimingPhase(trace, "snowSlopeRefine", phaseStart);
+      }
+      byte[] roadClassMask = roadMaskResult.mask();
+      boolean emitTimingEnabled = trace.isEnabled();
+      long emitClassifyNanos = 0L;
+      long emitBaseLayersNanos = 0L;
+      long emitCanopyNanos = 0L;
+      long emitFeaturesNanos = 0L;
+      long emitOutputNanos = 0L;
+      int emitColumns = 0;
+      int emitPoints = 0;
+      int emitMaxPoints = 0;
+      int emitColumnsOverInitialCapacity = 0;
+      int emitUnderwaterColumns = 0;
+      int emitCanopyColumns = 0;
+      int emitBuildingColumns = 0;
+      int emitRoadColumns = 0;
+      BlockState lastTopState = null;
+      BlockState lastFillerState = null;
+      TellusLodGenerator.SurfaceWrapperPair lastSurfaceWrapper = null;
+      phaseStart = beginTimingPhase(trace);
+
+      for (int localZ = 0; localZ < lodSizePoints; localZ++) {
+         throwIfLodCancelled();
+
+         for (int localX = 0; localX < lodSizePoints; localX++) {
+            int index = localZ * lodSizePoints + localX;
+            int worldX = worldXs[localX];
+            int worldZ = worldZs[localZ];
+            int surfaceY = surfaceYs[index];
+            int waterSurface = waterSurfaces[index];
+            boolean underwater = underwaterFlags[index];
+            int coverClass = coverClasses[index];
+            int visualCoverClass = visualCoverClasses[index];
+            Holder<Biome> biomeHolder = biomeHolders[index];
+            IDhApiBiomeWrapper biome = biomeWrappers[index];
+            TellusLodGenerator.CanopyProfile biomeCanopyProfile = canopyProfile(biomeHolder);
+            TellusLodGenerator.CanopyProfile sampledCanopyProfile = resolveTreeCoverCanopyProfile(biomeCanopyProfile, coverClass);
+            boolean isMangrove = sampledCanopyProfile.isMangrove() || coverClass == ESA_MANGROVES;
+            TellusLodGenerator.LodBuildingColumn buildingColumn = buildingColumns == null ? null : buildingColumns[index];
+            boolean hasBuilding = buildingColumn != null;
+            if (hasBuilding) {
+               int flattenedSurface = buildingFlattenedSurface == null ? Integer.MIN_VALUE : buildingFlattenedSurface[index];
+               if (flattenedSurface != Integer.MIN_VALUE) {
+                  surfaceY = Mth.clamp(flattenedSurface, minY, maxY - 1);
+                  waterSurface = surfaceY;
+                  underwater = false;
+               }
+            }
+
+            long columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+            EarthChunkGenerator.LodSurface lodSurface = this.generator.resolveUltraFastLodSurface(
+               biomeHolder,
+               worldX,
+               worldZ,
+               surfaceY,
+               underwater,
+               coverClass,
+               visualCoverClass,
+               lodSlopeDiffs[index],
+               lodConvexities[index],
+               remaSnowTerrainFlags[index]
+            );
+            BlockState topState = lodSurface.top();
+            BlockState fillerState = lodSurface.filler();
+            TellusLodGenerator.SurfaceWrapperPair surfaceWrapper;
+            if (topState == lastTopState && fillerState == lastFillerState && lastSurfaceWrapper != null) {
+               surfaceWrapper = lastSurfaceWrapper;
+            } else {
+               surfaceWrapper = new TellusLodGenerator.SurfaceWrapperPair(
+                  wrappers.getBlockState(topState), wrappers.getBlockState(fillerState)
+               );
+               lastTopState = topState;
+               lastFillerState = fillerState;
+               lastSurfaceWrapper = surfaceWrapper;
+            }
+            IDhApiBlockStateWrapper fillerBlock = surfaceWrapper.filler();
+            IDhApiBlockStateWrapper topBlock = surfaceWrapper.top();
+            int roadClassId = roadClassMask == null ? 0 : roadClassMask[index];
+            boolean hasRoad = roadClassId > 0 && !hasBuilding;
+            if (hasRoad) {
+               topBlock = switch (roadClassId) {
+                  case 1 -> roadMainBlock;
+                  case 2 -> roadNormalBlock;
+                  default -> roadDirtBlock;
+               };
+               if (underwater) {
+                  surfaceY = Math.max(surfaceY, waterSurface);
+                  underwater = false;
+               }
+            } else if (!hasBuilding && !underwater && snowActive && TellusRealtimeState.shouldApplySnow(worldX, worldZ)) {
+               topBlock = snowTopBlock;
+            }
+
+            if (emitTimingEnabled) {
+               emitClassifyNanos += System.nanoTime() - columnPhaseStart;
+            }
+
+            emitColumns++;
+            if (hasBuilding) {
+               emitBuildingColumns++;
+            }
+
+            if (hasRoad) {
+               emitRoadColumns++;
+            }
+
+            if (underwater) {
+               emitUnderwaterColumns++;
+            }
+
+            int lastLayerTop = 0;
+            int surfaceTop = toLayerTop(surfaceY, minY, absoluteTop);
+            int topLayerBase = Math.max(0, surfaceTop - 1);
+            columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+            if (topLayerBase > lastLayerTop) {
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, topLayerBase, fillerBlock, biome));
+               lastLayerTop = topLayerBase;
+            }
+
+            if (surfaceTop > lastLayerTop) {
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, surfaceTop, topBlock, biome));
+               lastLayerTop = surfaceTop;
+            }
+
+            if (underwater) {
+               int waterTop = toLayerTop(waterSurface, minY, absoluteTop);
+               if (waterTop > lastLayerTop) {
+                  columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, waterTop, waterBlock, biome));
+                  lastLayerTop = waterTop;
+               }
+            }
+
+            if (emitTimingEnabled) {
+               emitBaseLayersNanos += System.nanoTime() - columnPhaseStart;
+            }
+
+            boolean allowCanopy = !hasRoad && !hasBuilding && (coverClass == 10 && !underwater || isMangrove);
+            columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+            TellusLodGenerator.CanopyColumn canopyColumn = allowCanopy ? resolveCanopyColumn(sampledCanopyProfile, worldX, worldZ, cellSize) : null;
+            boolean deferMangroveCanopy = isMangrove && underwater;
+            if (!deferMangroveCanopy) {
+               lastLayerTop = appendCanopyColumn(canopyColumn, lastLayerTop, absoluteTop, wrappers, biome, columnDataPoints);
+            }
+
+            if (canopyColumn != null) {
+               emitCanopyColumns++;
+            }
+
+            if (emitTimingEnabled) {
+               emitCanopyNanos += System.nanoTime() - columnPhaseStart;
+            }
+
+            if (lastLayerTop < absoluteTop) {
+               if (deferMangroveCanopy) {
+                  columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+                  lastLayerTop = appendCanopyColumn(canopyColumn, lastLayerTop, absoluteTop, wrappers, biome, columnDataPoints);
+                  if (emitTimingEnabled) {
+                     emitCanopyNanos += System.nanoTime() - columnPhaseStart;
+                  }
+               }
+
+               columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+               if (buildingColumn != null) {
+                  lastLayerTop = appendBuildingColumn(buildingColumn, lastLayerTop, minY, absoluteTop, wrappers, biome, columnDataPoints);
+               }
+
+               if (emitTimingEnabled) {
+                  emitFeaturesNanos += System.nanoTime() - columnPhaseStart;
+               }
+
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, absoluteTop, airBlock, biome));
+            }
+
+            int columnPointCount = columnDataPoints.size();
+            emitPoints += columnPointCount;
+            emitMaxPoints = Math.max(emitMaxPoints, columnPointCount);
+            if (columnPointCount > 8) {
+               emitColumnsOverInitialCapacity++;
+            }
+
+            columnPhaseStart = emitTimingEnabled ? System.nanoTime() : 0L;
+            output.setApiDataPointColumn(localX, localZ, columnDataPoints);
+            columnDataPoints.clear();
+            if (emitTimingEnabled) {
+               emitOutputNanos += System.nanoTime() - columnPhaseStart;
+            }
+         }
+      }
+      endTimingPhase(trace, "emit", phaseStart);
+      trace.addPhase("emit.classify", emitClassifyNanos);
+      trace.addPhase("emit.baseLayers", emitBaseLayersNanos);
+      trace.addPhase("emit.canopy", emitCanopyNanos);
+      trace.addPhase("emit.features", emitFeaturesNanos);
+      trace.addPhase("emit.output", emitOutputNanos);
+      trace.stat("emit.columns", emitColumns);
+      trace.stat("emit.points", emitPoints);
+      trace.stat("emit.avgPointsPerColumn", emitColumns == 0 ? "0.00" : String.format(Locale.ROOT, "%.2f", (double)emitPoints / (double)emitColumns));
+      trace.stat("emit.maxPointsPerColumn", emitMaxPoints);
+      trace.stat("emit.columnsOverInitialCapacity", emitColumnsOverInitialCapacity);
+      trace.stat("emit.underwaterColumns", emitUnderwaterColumns);
+      trace.stat("emit.canopyColumns", emitCanopyColumns);
+      trace.stat("emit.buildingColumns", emitBuildingColumns);
+      trace.stat("emit.roadColumns", emitRoadColumns);
+   }
+
+   private boolean useUltraFastLodMode(int detailLevel) {
+      EarthGeneratorSettings.DistantHorizonsRenderMode renderMode = this.generator.settings().distantHorizonsRenderMode();
+      return renderMode == EarthGeneratorSettings.DistantHorizonsRenderMode.ULTRA_FAST
+         || renderMode == EarthGeneratorSettings.DistantHorizonsRenderMode.FAST && detailLevel >= FAST_RENDER_ULTRA_FAST_MIN_DETAIL;
+   }
+
+   private boolean shouldSuppressCoarseShoreline(int detailLevel) {
+      return this.generator.settings().distantHorizonsRenderMode() == EarthGeneratorSettings.DistantHorizonsRenderMode.FAST
+         && detailLevel >= FAST_RENDER_SKIP_SHORELINE_MIN_DETAIL;
+   }
+
+   private static int toLayerTop(int inclusiveTopY, int minY, int absoluteTop) {
+      return Mth.clamp(inclusiveTopY - minY + 1, 0, absoluteTop);
+   }
+
+   private static int roadLightSpacingBlocks(double worldScale) {
+      if (!(worldScale > 0.0)) {
+         return 40;
+      } else {
+         return Mth.clamp((int)Math.round(ROAD_LIGHT_BASE_SPACING_METERS / worldScale), 3, 40);
+      }
+   }
+
+   private static int roadLightMinimumSpacingBlocks(int spacingBlocks) {
+      return Math.max(3, (int)Math.round(spacingBlocks * 0.75));
+   }
+
+   private static int roadLightFenceCount(double worldScale) {
+      if (worldScale <= 3.0) {
+         return 3;
+      } else {
+         return worldScale <= 8.0 ? 2 : 1;
+      }
+   }
+
+   private static TellusLodGenerator.SampledRoadStation sampleRoadStation(
+      double[] worldXs, double[] worldZs, double[] segmentStarts, double[] segmentLengths, double station
+   ) {
+      for (int i = 0; i < segmentLengths.length; i++) {
+         double segmentLength = segmentLengths[i];
+         if (!(segmentLength <= 1.0E-6)) {
+            double segmentStart = segmentStarts[i];
+            double segmentEnd = segmentStart + segmentLength;
+            if (station <= segmentEnd + 1.0E-6 || i == segmentLengths.length - 1) {
+               double dx = worldXs[i + 1] - worldXs[i];
+               double dz = worldZs[i + 1] - worldZs[i];
+               double t = Mth.clamp((station - segmentStart) / segmentLength, 0.0, 1.0);
+               return new TellusLodGenerator.SampledRoadStation(worldXs[i] + dx * t, worldZs[i] + dz * t, dx / segmentLength, dz / segmentLength);
+            }
+         }
+      }
+
+      return null;
+   }
+
+   private static int appendRoadLightColumn(
+      int baseY,
+      int fenceCount,
+      int lastLayerTop,
+      int minY,
+      int absoluteTop,
+      IDhApiBlockStateWrapper baseBlock,
+      IDhApiBlockStateWrapper fenceBlock,
+      IDhApiBlockStateWrapper glowBlock,
+      IDhApiBlockStateWrapper capBlock,
+      IDhApiBiomeWrapper biome,
+      List<DhApiTerrainDataPoint> columnDataPoints
+   ) {
+      int layerTop = lastLayerTop;
+      int wallTop = toLayerTop(baseY + 1, minY, absoluteTop);
+      if (wallTop > layerTop) {
+         columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, layerTop, wallTop, baseBlock, biome));
+         layerTop = wallTop;
+      }
+
+      int fenceTop = toLayerTop(baseY + fenceCount + 1, minY, absoluteTop);
+      if (fenceTop > layerTop) {
+         columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, layerTop, fenceTop, fenceBlock, biome));
+         layerTop = fenceTop;
+      }
+
+      int glowTop = toLayerTop(baseY + fenceCount + 2, minY, absoluteTop);
+      if (glowTop > layerTop) {
+         columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, ROAD_LIGHT_BLOCK_LIGHT, 15, layerTop, glowTop, glowBlock, biome));
+         layerTop = glowTop;
+      }
+
+      int capTop = toLayerTop(baseY + fenceCount + 3, minY, absoluteTop);
+      if (capTop > layerTop) {
+         columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, ROAD_LIGHT_BLOCK_LIGHT, 15, layerTop, capTop, capBlock, biome));
+         layerTop = capTop;
+      }
+
+      return layerTop;
+   }
+
+   private static int lodSlopeDiff(int[] surfaceYs, int gridSize, int x, int z, int cellSize) {
+      int index = z * gridSize + x;
+      int center = surfaceYs[index];
+      int east = surfaceYs[z * gridSize + Math.min(gridSize - 1, x + 1)];
+      int west = surfaceYs[z * gridSize + Math.max(0, x - 1)];
+      int north = surfaceYs[Math.max(0, z - 1) * gridSize + x];
+      int south = surfaceYs[Math.min(gridSize - 1, z + 1) * gridSize + x];
+      int maxDiff = Math.max(Math.max(Math.abs(east - center), Math.abs(west - center)), Math.max(Math.abs(north - center), Math.abs(south - center)));
+      int scaledStep = Math.max(4, cellSize);
+      return maxDiff * 4 / scaledStep;
+   }
+
+   private static int lodConvexity(int[] surfaceYs, int gridSize, int x, int z, int cellSize) {
+      int index = z * gridSize + x;
+      int center = surfaceYs[index];
+      int east = surfaceYs[z * gridSize + Math.min(gridSize - 1, x + 1)];
+      int west = surfaceYs[z * gridSize + Math.max(0, x - 1)];
+      int north = surfaceYs[Math.max(0, z - 1) * gridSize + x];
+      int south = surfaceYs[Math.min(gridSize - 1, z + 1) * gridSize + x];
+      int neighborAverage = (east + west + north + south) / 4;
+      int scaledStep = Math.max(4, cellSize);
+      return (neighborAverage - center) * 4 / scaledStep;
+   }
+
+   private void prefetchLodResources(int chunkPosMinX, int chunkPosMinZ, byte detailLevel, int lodSizePoints) {
+      if (lodSizePoints > 0) {
+         int detail = Byte.toUnsignedInt(detailLevel);
+         boolean roadsActive = this.shouldRenderDhRoads(detail);
+         boolean buildingsActive = this.shouldRenderDhBuildings(detail);
+         EarthGeneratorSettings settings = this.generator.settings();
+         int cellSize = 1 << detailLevel;
+         int cellOffset = cellSize >> 1;
+         double previewResolutionMeters = lodPreviewResolutionMeters(settings, cellSize);
+         int baseX = SectionPos.sectionToBlockCoord(chunkPosMinX);
+         int baseZ = SectionPos.sectionToBlockCoord(chunkPosMinZ);
+         int minBlockX = baseX + cellOffset;
+         int minBlockZ = baseZ + cellOffset;
+         int maxBlockX = baseX + (lodSizePoints - 1) * cellSize + cellOffset;
+         int maxBlockZ = baseZ + (lodSizePoints - 1) * cellSize + cellOffset;
+         if (this.useUltraFastLodMode(detail)) {
+            if (roadsActive || buildingsActive) {
+               int grid = Math.min(3, Math.max(2, lodSizePoints / 16));
+               if (grid <= 1) {
+                  grid = 2;
+               }
+
+               for (int gz = 0; gz < grid; gz++) {
+                  int worldZ = lerpBlock(minBlockZ, maxBlockZ, gz, grid);
+
+                  for (int gx = 0; gx < grid; gx++) {
+                     int worldX = lerpBlock(minBlockX, maxBlockX, gx, grid);
+                     this.prefetchAtBlock(worldX, worldZ, roadsActive, buildingsActive, false, previewResolutionMeters);
+                  }
+               }
+            } else {
+               int center = Math.max(0, lodSizePoints / 2);
+               int centerX = baseX + center * cellSize + cellOffset;
+               int centerZ = baseZ + center * cellSize + cellOffset;
+               this.prefetchAtBlock(centerX, centerZ, false, false, false, previewResolutionMeters);
+            }
+         } else {
+            int grid = Math.min(5, Math.max(2, lodSizePoints / 8));
+            if (grid <= 1) {
+               grid = 2;
+            }
+
+            for (int gz = 0; gz < grid; gz++) {
+               int worldZ = lerpBlock(minBlockZ, maxBlockZ, gz, grid);
+
+               for (int gx = 0; gx < grid; gx++) {
+                  int worldX = lerpBlock(minBlockX, maxBlockX, gx, grid);
+                  this.prefetchAtBlock(worldX, worldZ, roadsActive, buildingsActive, false, previewResolutionMeters);
+               }
+            }
+         }
+      }
+   }
+
+   private static int coverSampleStride(int detailLevel, int lodSizePoints) {
+      if (detailLevel < 7) {
+         return 1;
+      } else {
+         int shift = Math.min(2, detailLevel - 7 + 1);
+         int stride = 1 << shift;
+         stride = Math.min(stride, 4);
+         return Math.min(stride, lodSizePoints);
+      }
+   }
+
+   private static boolean shouldSampleVisualCover(EarthGeneratorSettings settings, double previewResolutionMeters) {
+      double worldScale = settings.worldScale();
+      return worldScale > 0.0
+         && worldScale < ESA_WORLD_COVER_RESOLUTION_METERS
+         && effectiveCoverResolutionMeters(worldScale, previewResolutionMeters) < ESA_WORLD_COVER_RESOLUTION_METERS;
+   }
+
+   private static double effectiveCoverResolutionMeters(double worldScale, double previewResolutionMeters) {
+      return Double.isFinite(previewResolutionMeters) && previewResolutionMeters > 0.0
+         ? Math.max(worldScale, previewResolutionMeters)
+         : worldScale;
+   }
+
+   private static boolean isHardRawCoverClass(int coverClass) {
+      return coverClass == ESA_NO_DATA || coverClass == ESA_WATER || coverClass == ESA_MANGROVES || coverClass == ESA_BUILT_UP;
+   }
+
+   private static int detailedWaterStride(int detailLevel, int lodSizePoints) {
+      if (detailLevel < 5) {
+         return 1;
+      } else {
+         int shift = Math.min(2, detailLevel - 5 + 1);
+         int stride = 1 << shift;
+         stride = Math.min(stride, 4);
+         return Math.min(stride, lodSizePoints);
+      }
+   }
+
+   private static double lodPreviewResolutionMeters(EarthGeneratorSettings settings, int cellSize) {
+      double worldScale = settings.worldScale();
+      return worldScale > 0.0 ? Math.max(worldScale, worldScale * (double)cellSize) : Double.NaN;
+   }
+
+   private static int intProperty(String key, int defaultValue, int minInclusive, int maxInclusive) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Mth.clamp(Integer.parseInt(value), minInclusive, maxInclusive);
+         } catch (NumberFormatException error) {
+            LOGGER.debug("Invalid integer system property {}='{}', using {}", key, value, defaultValue);
+            return defaultValue;
+         }
+      }
+   }
+
+   private boolean shouldRenderDhRoads(int detailLevel) {
+      EarthGeneratorSettings settings = this.generator.settings();
+      return settings.enableRoads()
+         && settings.distantHorizonsOsmFeatures()
+         && settings.worldScale() > 0.0
+         && settings.worldScale() <= 15.0
+         && detailLevel <= settings.distantHorizonsOsmRoadMaxDetail();
+   }
+
+   private boolean shouldRenderDhBuildings(int detailLevel) {
+      EarthGeneratorSettings settings = this.generator.settings();
+      return settings.enableBuildings()
+         && settings.distantHorizonsOsmFeatures()
+         && settings.worldScale() > 0.0
+         && settings.worldScale() <= 15.0
+         && detailLevel <= settings.distantHorizonsOsmBuildingMaxDetail();
+   }
+
+   private TellusLodGenerator.LodRoadMaskResult buildUltraFastRoadMask(
+      int[] worldXs, int[] worldZs, int lodSizePoints, int cellSize, boolean mainRoadsOnly, OsmQueryMode fetchMode
+   ) {
+      long buildStartNs = OsmPerf.now();
+      if (lodSizePoints > 0 && worldXs.length >= lodSizePoints && worldZs.length >= lodSizePoints) {
+         EarthGeneratorSettings settings = this.generator.settings();
+         int minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+         int maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+         int minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+         int maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+         EarthChunkGenerator.OsmRoadQueryResult roadQuery = this.generator
+            .fetchOsmRoadsForAreaDetailed(minWorldX, minWorldZ, maxWorldX, maxWorldZ, 64, fetchMode);
+         List<RoadFeature> roads = roadQuery.features();
+         boolean hadCacheMisses = roadQuery.hadCacheMisses();
+         if (roads.isEmpty()) {
+            OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), 0);
+            return new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, hadCacheMisses);
+         } else {
+            List<RoadFeature> mainRoads = new ArrayList<>();
+            List<RoadFeature> normalRoads = mainRoadsOnly ? List.<RoadFeature>of() : new ArrayList<>();
+            List<RoadFeature> dirtRoads = mainRoadsOnly ? List.<RoadFeature>of() : new ArrayList<>();
+
+            for (RoadFeature road : roads) {
+               throwIfLodCancelled();
+               switch (road.roadClass()) {
+                  case MAIN:
+                     mainRoads.add(road);
+                     break;
+                  case NORMAL:
+                     if (!mainRoadsOnly) {
+                        normalRoads.add(road);
+                     }
+                     break;
+                  case DIRT:
+                     if (!mainRoadsOnly) {
+                        dirtRoads.add(road);
+                     }
+               }
+            }
+
+            double blocksPerDegree = EarthProjection.blocksPerDegree(settings.worldScale());
+            int mainRoadWidth = roadWidthForScale(RoadClass.MAIN.baseWidth(), settings.worldScale());
+            int normalRoadWidth = roadWidthForScale(RoadClass.NORMAL.baseWidth(), settings.worldScale());
+            int dirtRoadWidth = roadWidthForScale(RoadClass.DIRT.baseWidth(), settings.worldScale());
+            byte[] selectedClass = new byte[lodSizePoints * lodSizePoints];
+            rasterizeLodRoadClass(mainRoads, (byte)1, mainRoadWidth, blocksPerDegree, worldXs, worldZs, lodSizePoints, cellSize, selectedClass);
+            if (!mainRoadsOnly) {
+               rasterizeLodRoadClass(normalRoads, (byte)2, normalRoadWidth, blocksPerDegree, worldXs, worldZs, lodSizePoints, cellSize, selectedClass);
+               rasterizeLodRoadClass(dirtRoads, (byte)3, dirtRoadWidth, blocksPerDegree, worldXs, worldZs, lodSizePoints, cellSize, selectedClass);
+            }
+
+            boolean hasRoadCoverage = false;
+            for (byte classId : selectedClass) {
+               if (classId > 0) {
+                  hasRoadCoverage = true;
+                  break;
+               }
+            }
+
+            OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), roads.size());
+            return !hasRoadCoverage ? new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, hadCacheMisses)
+               : new TellusLodGenerator.LodRoadMaskResult(selectedClass, null, null, null, null, null, null, null, hadCacheMisses);
+         }
+      } else {
+         OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), 0);
+         return new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, false);
+      }
+   }
+
+   private TellusLodGenerator.LodRoadMaskResult buildLodRoadClassMask(
+      int[] worldXs,
+      int[] worldZs,
+      int[] surfaceYs,
+      int lodSizePoints,
+      int cellSize,
+      boolean mainRoadsOnly,
+      OsmQueryMode fetchMode,
+      TellusLodGenerator.LodBuildingColumn[] buildingColumns
+   ) {
+      long buildStartNs = OsmPerf.now();
+      if (lodSizePoints > 0 && worldXs.length >= lodSizePoints && worldZs.length >= lodSizePoints) {
+         EarthGeneratorSettings settings = this.generator.settings();
+         int minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+         int maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+         int minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+         int maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+         EarthChunkGenerator.OsmRoadQueryResult roadQuery = this.generator
+            .fetchOsmRoadsForAreaDetailed(minWorldX, minWorldZ, maxWorldX, maxWorldZ, 64, fetchMode);
+         List<RoadFeature> roads = roadQuery.features();
+         boolean hadCacheMisses = roadQuery.hadCacheMisses();
+         if (roads.isEmpty()) {
+            OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), 0);
+            return new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, hadCacheMisses);
+         } else {
+            List<RoadFeature> mainRoads = new ArrayList<>();
+            List<RoadFeature> mainBridgeRoads = new ArrayList<>();
+            List<RoadFeature> normalRoads = mainRoadsOnly ? List.<RoadFeature>of() : new ArrayList<>();
+            List<RoadFeature> normalBridgeRoads = mainRoadsOnly ? List.<RoadFeature>of() : new ArrayList<>();
+            List<RoadFeature> dirtRoads = mainRoadsOnly ? List.<RoadFeature>of() : new ArrayList<>();
+            List<RoadFeature> dirtBridgeRoads = mainRoadsOnly ? List.<RoadFeature>of() : new ArrayList<>();
+
+            for (RoadFeature road : roads) {
+               throwIfLodCancelled();
+               switch (road.roadClass()) {
+                  case MAIN:
+                     mainRoads.add(road);
+                     if (road.mode() == RoadMode.BRIDGE) {
+                        mainBridgeRoads.add(road);
+                     }
+                     break;
+                  case NORMAL:
+                     if (!mainRoadsOnly) {
+                        normalRoads.add(road);
+                        if (road.mode() == RoadMode.BRIDGE) {
+                           normalBridgeRoads.add(road);
+                        }
+                     }
+                     break;
+                  case DIRT:
+                     if (!mainRoadsOnly) {
+                        dirtRoads.add(road);
+                        if (road.mode() == RoadMode.BRIDGE) {
+                           dirtBridgeRoads.add(road);
+                        }
+                     }
+               }
+            }
+
+            double blocksPerDegree = EarthProjection.blocksPerDegree(settings.worldScale());
+            int mainRoadWidth = roadWidthForScale(RoadClass.MAIN.baseWidth(), settings.worldScale());
+            int normalRoadWidth = roadWidthForScale(RoadClass.NORMAL.baseWidth(), settings.worldScale());
+            int dirtRoadWidth = roadWidthForScale(RoadClass.DIRT.baseWidth(), settings.worldScale());
+            byte[] selectedClass = new byte[lodSizePoints * lodSizePoints];
+            rasterizeLodRoadClass(mainRoads, (byte)1, mainRoadWidth, blocksPerDegree, worldXs, worldZs, lodSizePoints, cellSize, selectedClass);
+            if (!mainRoadsOnly) {
+               rasterizeLodRoadClass(normalRoads, (byte)2, normalRoadWidth, blocksPerDegree, worldXs, worldZs, lodSizePoints, cellSize, selectedClass);
+               rasterizeLodRoadClass(dirtRoads, (byte)3, dirtRoadWidth, blocksPerDegree, worldXs, worldZs, lodSizePoints, cellSize, selectedClass);
+            }
+
+            boolean hasRoadCoverage = false;
+
+            for (byte classId : selectedClass) {
+               if (classId > 0) {
+                  hasRoadCoverage = true;
+                  break;
+               }
+            }
+
+            if (!hasRoadCoverage) {
+               OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), roads.size());
+               return new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, hadCacheMisses);
+            } else {
+               boolean hasBridgeDeck = false;
+               int[] bridgeDeckY = null;
+               boolean hasBridgeSupport = false;
+               int[] bridgeSupportShaftBottomY = null;
+               int[] bridgeSupportShaftTopY = null;
+               int[] bridgeSupportCapBottomY = null;
+               int[] bridgeSupportCapTopY = null;
+               boolean hasRoadLights = false;
+               int[] roadLightBaseY = null;
+               byte[] roadLightFenceCount = null;
+               if (!mainBridgeRoads.isEmpty() || !normalBridgeRoads.isEmpty() || !dirtBridgeRoads.isEmpty()) {
+                  bridgeDeckY = new int[selectedClass.length];
+                  Arrays.fill(bridgeDeckY, Integer.MIN_VALUE);
+                  Map<Long, Integer> roadSurfaceCache = new HashMap<>();
+                  hasBridgeDeck = this.rasterizeLodBridgeDeck(
+                     mainBridgeRoads,
+                     (byte)1,
+                     mainRoadWidth,
+                     blocksPerDegree,
+                     worldXs,
+                     worldZs,
+                     lodSizePoints,
+                     cellSize,
+                     selectedClass,
+                     bridgeDeckY,
+                     roadSurfaceCache
+                  );
+                  if (!mainRoadsOnly) {
+                     hasBridgeDeck |= this.rasterizeLodBridgeDeck(
+                        normalBridgeRoads,
+                        (byte)2,
+                        normalRoadWidth,
+                        blocksPerDegree,
+                        worldXs,
+                        worldZs,
+                        lodSizePoints,
+                        cellSize,
+                        selectedClass,
+                        bridgeDeckY,
+                        roadSurfaceCache
+                     );
+                     hasBridgeDeck |= this.rasterizeLodBridgeDeck(
+                        dirtBridgeRoads,
+                        (byte)3,
+                        dirtRoadWidth,
+                        blocksPerDegree,
+                        worldXs,
+                        worldZs,
+                        lodSizePoints,
+                        cellSize,
+                        selectedClass,
+                        bridgeDeckY,
+                        roadSurfaceCache
+                     );
+                  }
+
+                  if (!mainBridgeRoads.isEmpty() || !normalBridgeRoads.isEmpty()) {
+                     bridgeSupportShaftBottomY = new int[selectedClass.length];
+                     bridgeSupportShaftTopY = new int[selectedClass.length];
+                     bridgeSupportCapBottomY = new int[selectedClass.length];
+                     bridgeSupportCapTopY = new int[selectedClass.length];
+                     Arrays.fill(bridgeSupportShaftBottomY, Integer.MIN_VALUE);
+                     Arrays.fill(bridgeSupportShaftTopY, Integer.MIN_VALUE);
+                     Arrays.fill(bridgeSupportCapBottomY, Integer.MIN_VALUE);
+                     Arrays.fill(bridgeSupportCapTopY, Integer.MIN_VALUE);
+                     hasBridgeSupport = this.rasterizeLodBridgeSupports(
+                        mainBridgeRoads,
+                        mainRoadWidth,
+                        blocksPerDegree,
+                        worldXs,
+                        worldZs,
+                        surfaceYs,
+                        lodSizePoints,
+                        cellSize,
+                        selectedClass,
+                        bridgeDeckY,
+                        buildingColumns,
+                        roadSurfaceCache,
+                        bridgeSupportShaftBottomY,
+                        bridgeSupportShaftTopY,
+                        bridgeSupportCapBottomY,
+                        bridgeSupportCapTopY
+                     );
+                     if (!mainRoadsOnly) {
+                        hasBridgeSupport |= this.rasterizeLodBridgeSupports(
+                           normalBridgeRoads,
+                           normalRoadWidth,
+                           blocksPerDegree,
+                           worldXs,
+                           worldZs,
+                           surfaceYs,
+                           lodSizePoints,
+                           cellSize,
+                           selectedClass,
+                           bridgeDeckY,
+                           buildingColumns,
+                           roadSurfaceCache,
+                           bridgeSupportShaftBottomY,
+                           bridgeSupportShaftTopY,
+                           bridgeSupportCapBottomY,
+                           bridgeSupportCapTopY
+                        );
+                     }
+                  }
+               }
+
+               int roadLightSpacing = roadLightSpacingBlocks(settings.worldScale());
+               if (cellSize <= roadLightSpacing) {
+                  roadLightBaseY = new int[selectedClass.length];
+                  roadLightFenceCount = new byte[selectedClass.length];
+                  Arrays.fill(roadLightBaseY, Integer.MIN_VALUE);
+                  boolean[] occupiedLightCells = new boolean[selectedClass.length];
+                  IntArrayList occupiedLightIndices = new IntArrayList();
+                  hasRoadLights = this.rasterizeLodRoadLights(
+                     mainRoads,
+                     (byte)1,
+                     mainRoadWidth,
+                     blocksPerDegree,
+                     worldXs,
+                     worldZs,
+                     surfaceYs,
+                     lodSizePoints,
+                     cellSize,
+                     selectedClass,
+                     bridgeDeckY,
+                     bridgeSupportShaftBottomY,
+                     bridgeSupportShaftTopY,
+                     bridgeSupportCapBottomY,
+                     bridgeSupportCapTopY,
+                     buildingColumns,
+                     roadLightBaseY,
+                     roadLightFenceCount,
+                     occupiedLightCells,
+                     occupiedLightIndices
+                  );
+                  if (!mainRoadsOnly) {
+                     hasRoadLights |= this.rasterizeLodRoadLights(
+                        normalRoads,
+                        (byte)2,
+                        normalRoadWidth,
+                        blocksPerDegree,
+                        worldXs,
+                        worldZs,
+                        surfaceYs,
+                        lodSizePoints,
+                        cellSize,
+                        selectedClass,
+                        bridgeDeckY,
+                        bridgeSupportShaftBottomY,
+                        bridgeSupportShaftTopY,
+                        bridgeSupportCapBottomY,
+                        bridgeSupportCapTopY,
+                        buildingColumns,
+                        roadLightBaseY,
+                        roadLightFenceCount,
+                        occupiedLightCells,
+                        occupiedLightIndices
+                     );
+                     hasRoadLights |= this.rasterizeLodRoadLights(
+                        dirtRoads,
+                        (byte)3,
+                        dirtRoadWidth,
+                        blocksPerDegree,
+                        worldXs,
+                        worldZs,
+                        surfaceYs,
+                        lodSizePoints,
+                        cellSize,
+                        selectedClass,
+                        bridgeDeckY,
+                        bridgeSupportShaftBottomY,
+                        bridgeSupportShaftTopY,
+                        bridgeSupportCapBottomY,
+                        bridgeSupportCapTopY,
+                        buildingColumns,
+                        roadLightBaseY,
+                        roadLightFenceCount,
+                        occupiedLightCells,
+                        occupiedLightIndices
+                     );
+                  }
+               }
+
+               OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), roads.size());
+               return new TellusLodGenerator.LodRoadMaskResult(
+                  selectedClass,
+                  hasBridgeDeck ? bridgeDeckY : null,
+                  hasBridgeSupport ? bridgeSupportShaftBottomY : null,
+                  hasBridgeSupport ? bridgeSupportShaftTopY : null,
+                  hasBridgeSupport ? bridgeSupportCapBottomY : null,
+                  hasBridgeSupport ? bridgeSupportCapTopY : null,
+                  hasRoadLights ? roadLightBaseY : null,
+                  hasRoadLights ? roadLightFenceCount : null,
+                  hadCacheMisses
+               );
+            }
+         }
+      } else {
+         OsmPerf.recordDhRoadMaskBuild(OsmPerf.elapsedSince(buildStartNs), 0);
+         return new TellusLodGenerator.LodRoadMaskResult(null, null, null, null, null, null, null, null, false);
+      }
+   }
+
+   private TellusLodGenerator.LodBuildingMaskResult buildLodBuildingMask(
+      int[] worldXs, int[] worldZs, int[] terrainSurfaces, int lodSizePoints, int cellSize, OsmQueryMode fetchMode
+   ) {
+      long buildStartNs = OsmPerf.now();
+      if (lodSizePoints > 0 && worldXs.length >= lodSizePoints && worldZs.length >= lodSizePoints) {
+         int minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+         int maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+         int minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+         int maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+         int marginBlocks = Math.max(8, cellSize);
+         EarthChunkGenerator.OsmBuildingQueryResult query = this.generator
+            .fetchOsmBuildingsForAreaDetailed(minWorldX, minWorldZ, maxWorldX, maxWorldZ, marginBlocks, fetchMode);
+         List<OsmBuildingFeature> features = query.features();
+         boolean hadCacheMisses = query.hadCacheMisses();
+         if (features.isEmpty()) {
+            OsmPerf.recordDhBuildingMaskBuild(OsmPerf.elapsedSince(buildStartNs), 0);
+            return new TellusLodGenerator.LodBuildingMaskResult(null, null, hadCacheMisses);
+         } else {
+            Map<String, TellusLodGenerator.LodBuildingGroupScratch> groups = new HashMap<>();
+            List<TellusLodGenerator.LodRasterizedBuildingFeature> partFeatures = new ArrayList<>();
+            List<TellusLodGenerator.LodRasterizedBuildingFeature> footprintFeatures = new ArrayList<>();
+
+            for (OsmBuildingFeature feature : features) {
+               throwIfLodCancelled();
+               String groupId = feature.kind() == com.yucareux.tellus.world.data.osm.OsmBuildingKind.PART
+                  ? feature.buildingId() != null ? "part:" + feature.buildingId() : "part:" + feature.featureId()
+                  : "footprint:" + feature.featureId();
+               TellusLodGenerator.LodRasterizedBuildingFeature rasterized = rasterizeLodBuildingFeature(
+                  feature, groupId, worldXs, worldZs, lodSizePoints, cellSize, this.generator.settings().worldScale()
+               );
+               if (rasterized != null && rasterized.occupiedCells().length > 0) {
+                  TellusLodGenerator.LodBuildingGroupScratch group = groups.computeIfAbsent(
+                     groupId, id -> new TellusLodGenerator.LodBuildingGroupScratch()
+                  );
+                  boolean groundContact = feature.kind() != com.yucareux.tellus.world.data.osm.OsmBuildingKind.PART
+                     || buildingMinHeightBlocks(feature.minHeightMeters(), this.generator.settings().worldScale()) <= 0;
+
+                  for (int cellIndex : rasterized.occupiedCells()) {
+                     group.fallbackSamples().add(terrainSurfaces[cellIndex]);
+                     if (groundContact) {
+                        group.groundSamples().add(terrainSurfaces[cellIndex]);
+                     }
+                  }
+                  if (feature.kind() == com.yucareux.tellus.world.data.osm.OsmBuildingKind.PART) {
+                     partFeatures.add(rasterized);
+                  } else {
+                     footprintFeatures.add(rasterized);
+                  }
+               }
+            }
+
+            if (partFeatures.isEmpty() && footprintFeatures.isEmpty()) {
+               OsmPerf.recordDhBuildingMaskBuild(OsmPerf.elapsedSince(buildStartNs), features.size());
+               return new TellusLodGenerator.LodBuildingMaskResult(null, null, hadCacheMisses);
+            } else {
+               for (TellusLodGenerator.LodBuildingGroupScratch group : groups.values()) {
+                  IntArrayList samples = !group.groundSamples().isEmpty() ? group.groundSamples() : group.fallbackSamples();
+                  if (!samples.isEmpty()) {
+                     group.setBaseY(medianValue(samples));
+                  }
+               }
+
+               int area = lodSizePoints * lodSizePoints;
+               TellusLodGenerator.LodBuildingColumn[] columns = new TellusLodGenerator.LodBuildingColumn[area];
+               int[] flattenedSurface = new int[area];
+               Arrays.fill(flattenedSurface, Integer.MIN_VALUE);
+               int[] overlyingPartFloorY = new int[area];
+               Arrays.fill(overlyingPartFloorY, Integer.MAX_VALUE);
+
+               for (TellusLodGenerator.LodRasterizedBuildingFeature rasterized : partFeatures) {
+                  throwIfLodCancelled();
+                  int baseY = groups.get(rasterized.groupId()).baseY();
+                  addLodBuildingFeatureCoverage(
+                     rasterized,
+                     baseY,
+                     null,
+                     columns,
+                     flattenedSurface,
+                     overlyingPartFloorY,
+                     worldXs,
+                     worldZs,
+                     cellSize,
+                     this.generator.settings().worldScale()
+                  );
+               }
+
+               for (TellusLodGenerator.LodRasterizedBuildingFeature rasterized : footprintFeatures) {
+                  throwIfLodCancelled();
+                  int baseY = groups.get(rasterized.groupId()).baseY();
+                  addLodBuildingFeatureCoverage(
+                     rasterized,
+                     baseY,
+                     overlyingPartFloorY,
+                     columns,
+                     flattenedSurface,
+                     null,
+                     worldXs,
+                     worldZs,
+                     cellSize,
+                     this.generator.settings().worldScale()
+                  );
+               }
+
+               boolean hasCoverage = false;
+
+               for (TellusLodGenerator.LodBuildingColumn column : columns) {
+                  if (column != null && !column.isEmpty()) {
+                     hasCoverage = true;
+                     break;
+                  }
+               }
+
+               OsmPerf.recordDhBuildingMaskBuild(OsmPerf.elapsedSince(buildStartNs), features.size());
+               return !hasCoverage ? new TellusLodGenerator.LodBuildingMaskResult(null, null, hadCacheMisses)
+                  : new TellusLodGenerator.LodBuildingMaskResult(columns, flattenedSurface, hadCacheMisses);
+            }
+         }
+      } else {
+         OsmPerf.recordDhBuildingMaskBuild(OsmPerf.elapsedSince(buildStartNs), 0);
+         return new TellusLodGenerator.LodBuildingMaskResult(null, null, false);
+      }
+   }
+
+   private static TellusLodGenerator.LodRasterizedBuildingFeature rasterizeLodBuildingFeature(
+      OsmBuildingFeature feature, String groupId, int[] worldXs, int[] worldZs, int lodSizePoints, int cellSize, double worldScale
+   ) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+      double maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+      double minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+      double maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+      double featureMinX = feature.minBlockX(blocksPerDegree);
+      double featureMaxX = feature.maxBlockX(blocksPerDegree);
+      double featureMinZ = feature.minBlockZ(worldScale);
+      double featureMaxZ = feature.maxBlockZ(worldScale);
+      IntArrayList occupiedCells = new IntArrayList();
+      if (!(featureMaxX < minWorldX - cellSize)
+         && !(featureMinX > maxWorldX + cellSize)
+         && !(featureMaxZ < minWorldZ - cellSize)
+         && !(featureMinZ > maxWorldZ + cellSize)) {
+         int minGridX = Mth.clamp((int)Math.floor((featureMinX - minWorldX - cellSize) / cellSize), 0, lodSizePoints - 1);
+         int maxGridX = Mth.clamp((int)Math.floor((featureMaxX - minWorldX + cellSize) / cellSize), 0, lodSizePoints - 1);
+         int minGridZ = Mth.clamp((int)Math.floor((featureMinZ - minWorldZ - cellSize) / cellSize), 0, lodSizePoints - 1);
+         int maxGridZ = Mth.clamp((int)Math.floor((featureMaxZ - minWorldZ + cellSize) / cellSize), 0, lodSizePoints - 1);
+         int width = maxGridX - minGridX + 1;
+         int height = maxGridZ - minGridZ + 1;
+         boolean[] occupiedMask = new boolean[Math.max(1, width * height)];
+
+         for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+            int worldZ = worldZs[gz];
+            int row = gz * lodSizePoints;
+
+            for (int gx = minGridX; gx <= maxGridX; gx++) {
+               int worldX = worldXs[gx];
+               if (feature.containsWorld(worldX + 0.5, worldZ + 0.5, worldScale)) {
+                  occupiedMask[(gx - minGridX) + (gz - minGridZ) * width] = true;
+                  occupiedCells.add(row + gx);
+               }
+            }
+         }
+
+         if (!occupiedCells.isEmpty()) {
+            return new TellusLodGenerator.LodRasterizedBuildingFeature(
+               feature, groupId, lodSizePoints, minGridX, minGridZ, width, height, occupiedMask, occupiedCells.toIntArray()
+            );
+         }
+      }
+
+      return null;
+   }
+
+   private static void addLodBuildingFeatureCoverage(
+      TellusLodGenerator.LodRasterizedBuildingFeature rasterized,
+      int baseY,
+      int[] overlyingPartFloorY,
+      TellusLodGenerator.LodBuildingColumn[] columns,
+      int[] flattenedSurface,
+      int[] recordedPartFloorY,
+      int[] worldXs,
+      int[] worldZs,
+      int cellSize,
+      double worldScale
+   ) {
+      if (baseY != Integer.MIN_VALUE) {
+         int minHeightBlocks = buildingMinHeightBlocks(rasterized.feature().minHeightMeters(), worldScale);
+         int floorY = baseY + minHeightBlocks + 1;
+         BuildingProfile profile = TellusBuildingProfiles.resolveProfile(rasterized.feature(), worldScale, null, false);
+         int roofBaseY = Math.max(baseY + buildingHeightBlocks(rasterized.feature().heightMeters(), worldScale), floorY + profile.floorCount() * profile.storeyHeightBlocks());
+         int topY = roofBaseY + Math.max(profile.parapetHeight(), profile.roofRise());
+         BuildingBlueprint blueprint = TellusBuildingBlueprints.create(rasterized.groupId(), rasterized.feature(), profile, 0L, baseY, floorY, roofBaseY, topY, List.of(), worldScale);
+         TellusBuildingMaterials.BuildingMaterialPalette palette = TellusBuildingMaterials.resolvePalette(blueprint);
+         int[] boundaryDistance = computeLodBoundaryDistance(rasterized);
+         boolean groundContact = rasterized.feature().kind() != com.yucareux.tellus.world.data.osm.OsmBuildingKind.PART || minHeightBlocks <= 0;
+
+         for (int order = 0; order < rasterized.occupiedCells().length; order++) {
+            int cellIndex = rasterized.occupiedCells()[order];
+            int localX = cellIndex % worldXs.length;
+            int localZ = cellIndex / worldXs.length;
+            int distance = boundaryDistance[order];
+            int cellTopY = blueprint.roofTopY(worldXs[localX], worldZs[localZ], distance);
+            if (profile.roofProfile() == BuildingProfile.RoofProfile.FLAT
+               || profile.roofProfile() == BuildingProfile.RoofProfile.FLAT_CROWN
+               || profile.roofProfile() == BuildingProfile.RoofProfile.FLAT_SKYLIGHT) {
+               cellTopY += profile.parapetHeight();
+            }
+
+            if (overlyingPartFloorY != null) {
+               cellTopY = BuildingPlacementSupport.capLowerColumnTopY(floorY, cellTopY, overlyingPartFloorY[cellIndex]);
+            }
+
+            if (cellTopY < floorY) {
+               continue;
+            }
+
+            TellusLodGenerator.LodBuildingColumn column = columns[cellIndex];
+            if (column == null) {
+               column = new TellusLodGenerator.LodBuildingColumn();
+               columns[cellIndex] = column;
+            }
+
+            int highestFloor = blueprint.highestActiveFloor(distance);
+            int roofStart = Math.max(floorY, blueprint.roofBaseY(distance));
+            int facadeEnd = Math.min(cellTopY, roofStart - 1);
+            if (facadeEnd >= floorY) {
+               int facadeFloor = Math.min(highestFloor, blueprint.floorIndexAtY((floorY + facadeEnd) >> 1));
+               BlockState facadeBlock = TellusBuildingMaterials.resolveLodFacadeBlock(blueprint, palette, distance, facadeFloor);
+               column.addSpan(
+                  floorY,
+                  facadeEnd,
+                  facadeBlock,
+                  TellusBuildingLighting.resolveLodFacadeLightLevel(
+                     blueprint, facadeBlock, palette.window(), distance, worldXs[localX], worldZs[localZ], facadeFloor, cellSize
+                  )
+               );
+            }
+
+            if (cellTopY >= roofStart) {
+               column.addSpan(
+                  roofStart,
+                  cellTopY,
+                  TellusBuildingMaterials.resolveLodRoofBlock(palette, blueprint.isFacadeCell(distance, highestFloor)),
+                  (byte)0
+               );
+            }
+
+            if (groundContact && floorY - 1 > flattenedSurface[cellIndex]) {
+               flattenedSurface[cellIndex] = floorY - 1;
+            }
+
+            if (recordedPartFloorY != null) {
+               recordedPartFloorY[cellIndex] = Math.min(recordedPartFloorY[cellIndex], floorY);
+            }
+         }
+      }
+   }
+
+   private static int[] computeLodBoundaryDistance(TellusLodGenerator.LodRasterizedBuildingFeature rasterized) {
+      int width = rasterized.width();
+      int height = rasterized.height();
+      int[] distance = new int[width * height];
+      Arrays.fill(distance, Integer.MAX_VALUE);
+      boolean[] occupied = rasterized.occupiedMask();
+      ArrayDeque<Integer> queue = new ArrayDeque<>();
+
+      for (int localZ = 0; localZ < height; localZ++) {
+         for (int localX = 0; localX < width; localX++) {
+            int index = localX + localZ * width;
+            if (!occupied[index]) {
+               continue;
+            }
+
+            boolean boundary = localX == 0
+               || localX == width - 1
+               || localZ == 0
+               || localZ == height - 1
+               || !occupied[Math.max(0, localX - 1) + localZ * width]
+               || !occupied[Math.min(width - 1, localX + 1) + localZ * width]
+               || !occupied[localX + Math.max(0, localZ - 1) * width]
+               || !occupied[localX + Math.min(height - 1, localZ + 1) * width];
+            if (boundary) {
+               distance[index] = 0;
+               queue.add(index);
+            }
+         }
+      }
+
+      while (!queue.isEmpty()) {
+         int index = queue.removeFirst();
+         int localX = index % width;
+         int localZ = index / width;
+         int nextDistance = distance[index] + 1;
+         if (localX > 0) {
+            propagateLodBoundaryDistance(occupied, distance, queue, index - 1, nextDistance);
+         }
+         if (localX + 1 < width) {
+            propagateLodBoundaryDistance(occupied, distance, queue, index + 1, nextDistance);
+         }
+         if (localZ > 0) {
+            propagateLodBoundaryDistance(occupied, distance, queue, index - width, nextDistance);
+         }
+         if (localZ + 1 < height) {
+            propagateLodBoundaryDistance(occupied, distance, queue, index + width, nextDistance);
+         }
+      }
+
+      int[] ordered = new int[rasterized.occupiedCells().length];
+      for (int order = 0; order < rasterized.occupiedCells().length; order++) {
+         int globalIndex = rasterized.occupiedCells()[order];
+         int gridX = globalIndex % rasterized.lodSize();
+         int gridZ = globalIndex / rasterized.lodSize();
+         int localIndex = (gridX - rasterized.minGridX()) + (gridZ - rasterized.minGridZ()) * width;
+         ordered[order] = localIndex >= 0 && localIndex < distance.length && distance[localIndex] != Integer.MAX_VALUE ? distance[localIndex] : 0;
+      }
+      return ordered;
+   }
+
+   private static void propagateLodBoundaryDistance(boolean[] occupied, int[] distance, ArrayDeque<Integer> queue, int index, int nextDistance) {
+      if (occupied[index] && nextDistance < distance[index]) {
+         distance[index] = nextDistance;
+         queue.add(index);
+      }
+   }
+
+   private static int buildingHeightBlocks(double meters, double worldScale) {
+      return Math.max(3, (int)Math.round(meters / worldScale));
+   }
+
+   private static int buildingMinHeightBlocks(double meters, double worldScale) {
+      return Math.max(0, (int)Math.round(meters / worldScale));
+   }
+
+   private static int medianValue(IntArrayList values) {
+      int[] sorted = values.toIntArray();
+      Arrays.sort(sorted);
+      return sorted[sorted.length >> 1];
+   }
+
+   private static void rasterizeLodRoadClass(
+      List<RoadFeature> roads,
+      byte classId,
+      int widthBlocks,
+      double blocksPerDegree,
+      int[] worldXs,
+      int[] worldZs,
+      int lodSizePoints,
+      int cellSize,
+      byte[] selectedClass
+   ) {
+      if (!roads.isEmpty() && widthBlocks > 0 && lodSizePoints > 0 && cellSize > 0) {
+         double worldScale = EarthProjection.worldScaleFromBlocksPerDegree(blocksPerDegree);
+         double minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+         double minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+         double maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+         double maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+         double halfWidth = Math.max(0.5, (widthBlocks - 1) * 0.5) + cellSize * 0.5;
+         double radiusSq = halfWidth * halfWidth + 1.0E-6;
+
+         for (RoadFeature road : roads) {
+            int points = road.pointCount();
+            if (points >= 2) {
+               double roadMinX = road.minLon() * blocksPerDegree;
+               double roadMaxX = road.maxLon() * blocksPerDegree;
+               double roadMinZ = EarthProjection.latToBlockZ(road.maxLat(), worldScale);
+               double roadMaxZ = EarthProjection.latToBlockZ(road.minLat(), worldScale);
+               if (!(roadMaxX < minWorldX - halfWidth)
+                  && !(roadMinX > maxWorldX + halfWidth)
+                  && !(roadMaxZ < minWorldZ - halfWidth)
+                  && !(roadMinZ > maxWorldZ + halfWidth)) {
+                  double x1 = road.lonAt(0) * blocksPerDegree;
+                  double z1 = EarthProjection.latToBlockZ(road.latAt(0), worldScale);
+
+                  for (int i = 1; i < points; i++) {
+                     double x2 = road.lonAt(i) * blocksPerDegree;
+                     double z2 = EarthProjection.latToBlockZ(road.latAt(i), worldScale);
+                     double dx = x2 - x1;
+                     double dz = z2 - z1;
+                     double lenSq = dx * dx + dz * dz;
+                     if (lenSq <= 1.0E-6) {
+                        x1 = x2;
+                        z1 = z2;
+                     } else {
+                        int minGridX = Mth.clamp((int)Math.floor((Math.min(x1, x2) - halfWidth - minWorldX) / cellSize), 0, lodSizePoints - 1);
+                        int maxGridX = Mth.clamp((int)Math.floor((Math.max(x1, x2) + halfWidth - minWorldX) / cellSize), 0, lodSizePoints - 1);
+                        int minGridZ = Mth.clamp((int)Math.floor((Math.min(z1, z2) - halfWidth - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+                        int maxGridZ = Mth.clamp((int)Math.floor((Math.max(z1, z2) + halfWidth - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+
+                        for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+                           double sampleZ = worldZs[gz];
+                           int row = gz * lodSizePoints;
+
+                           for (int gx = minGridX; gx <= maxGridX; gx++) {
+                              int index = row + gx;
+                              if (selectedClass[index] == 0) {
+                                 double sampleX = worldXs[gx];
+                                 double t = ((sampleX - x1) * dx + (sampleZ - z1) * dz) / lenSq;
+                                 t = Mth.clamp(t, 0.0, 1.0);
+                                 double px = x1 + t * dx;
+                                 double pz = z1 + t * dz;
+                                 double ddx = sampleX - px;
+                                 double ddz = sampleZ - pz;
+                                 if (ddx * ddx + ddz * ddz <= radiusSq) {
+                                    selectedClass[index] = classId;
+                                 }
+                              }
+                           }
+                        }
+
+                        x1 = x2;
+                        z1 = z2;
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private boolean rasterizeLodRoadLights(
+      List<RoadFeature> roads,
+      byte classId,
+      int roadWidth,
+      double blocksPerDegree,
+      int[] worldXs,
+      int[] worldZs,
+      int[] surfaceYs,
+      int lodSizePoints,
+      int cellSize,
+      byte[] selectedClass,
+      int[] bridgeDeckY,
+      int[] bridgeSupportShaftBottomY,
+      int[] bridgeSupportShaftTopY,
+      int[] bridgeSupportCapBottomY,
+      int[] bridgeSupportCapTopY,
+      TellusLodGenerator.LodBuildingColumn[] buildingColumns,
+      int[] roadLightBaseY,
+      byte[] roadLightFenceCount,
+      boolean[] occupiedLightCells,
+      IntArrayList occupiedLightIndices
+   ) {
+      if (roads.isEmpty() || roadWidth <= 0 || lodSizePoints <= 0 || cellSize <= 0) {
+         return false;
+      } else {
+         double worldScale = EarthProjection.worldScaleFromBlocksPerDegree(blocksPerDegree);
+         int spacingBlocks = roadLightSpacingBlocks(worldScale);
+         int minLampSpacingBlocks = roadLightMinimumSpacingBlocks(spacingBlocks);
+         int fenceCount = roadLightFenceCount(worldScale);
+         double minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+         double minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+         boolean hasRoadLights = false;
+
+         for (RoadFeature road : roads) {
+            if (road.mode() == RoadMode.TUNNEL) {
+               continue;
+            }
+
+            int segmentCount = road.pointCount() - 1;
+            if (segmentCount <= 0) {
+               continue;
+            }
+
+            double[] roadWorldXs = new double[road.pointCount()];
+            double[] roadWorldZs = new double[road.pointCount()];
+            double[] segmentStarts = new double[segmentCount];
+            double[] segmentLengths = new double[segmentCount];
+
+            for (int i = 0; i < road.pointCount(); i++) {
+               roadWorldXs[i] = road.lonAt(i) * blocksPerDegree;
+               roadWorldZs[i] = EarthProjection.latToBlockZ(road.latAt(i), worldScale);
+            }
+
+            double totalLength = 0.0;
+            for (int i = 0; i < segmentCount; i++) {
+               double dx = roadWorldXs[i + 1] - roadWorldXs[i];
+               double dz = roadWorldZs[i + 1] - roadWorldZs[i];
+               segmentStarts[i] = totalLength;
+               segmentLengths[i] = Math.sqrt(dx * dx + dz * dz);
+               totalLength += segmentLengths[i];
+            }
+
+            double endpointInset = Math.max(Math.max(4.0, roadWidth), spacingBlocks * 0.75);
+            if (!(totalLength > endpointInset * 2.0)) {
+               continue;
+            }
+
+            boolean placeLeft = true;
+            for (double station = endpointInset; station <= totalLength - endpointInset + 1.0E-6; station += spacingBlocks) {
+               TellusLodGenerator.SampledRoadStation sampled = sampleRoadStation(roadWorldXs, roadWorldZs, segmentStarts, segmentLengths, station);
+               if (sampled == null) {
+                  placeLeft = !placeLeft;
+                  continue;
+               }
+
+               int anchorIndex = findLodRoadLightAnchor(
+                  sampled,
+                  placeLeft,
+                  roadWidth,
+                  classId,
+                  road.mode(),
+                  worldXs,
+                  worldZs,
+                  lodSizePoints,
+                  cellSize,
+                  minWorldX,
+                  minWorldZ,
+                  selectedClass,
+                  bridgeDeckY
+               );
+               if (anchorIndex >= 0
+                  && !occupiedLightCells[anchorIndex]
+                  && !hasNearbyLodRoadLight(anchorIndex, worldXs, worldZs, minLampSpacingBlocks, occupiedLightIndices)) {
+                  int baseY = road.mode() == RoadMode.BRIDGE && bridgeDeckY != null && bridgeDeckY[anchorIndex] != Integer.MIN_VALUE
+                     ? bridgeDeckY[anchorIndex]
+                     : surfaceYs[anchorIndex];
+                  int minLampY = baseY + 1;
+                  int maxLampY = baseY + fenceCount + 3;
+                  TellusLodGenerator.LodBuildingColumn buildingColumn = buildingColumns == null ? null : buildingColumns[anchorIndex];
+                  if ((buildingColumn == null || !buildingColumn.intersectsSpan(minLampY, maxLampY))
+                     && !lodRoadLightBridgeSupportConflicts(
+                        anchorIndex, minLampY, maxLampY, bridgeSupportShaftBottomY, bridgeSupportShaftTopY, bridgeSupportCapBottomY, bridgeSupportCapTopY
+                     )) {
+                     roadLightBaseY[anchorIndex] = baseY;
+                     roadLightFenceCount[anchorIndex] = (byte)fenceCount;
+                     occupiedLightCells[anchorIndex] = true;
+                     occupiedLightIndices.add(anchorIndex);
+                     hasRoadLights = true;
+                  }
+               }
+
+               placeLeft = !placeLeft;
+            }
+         }
+
+         return hasRoadLights;
+      }
+   }
+
+   private static int findLodRoadLightAnchor(
+      TellusLodGenerator.SampledRoadStation sampled,
+      boolean placeLeft,
+      int roadWidth,
+      byte classId,
+      RoadMode roadMode,
+      int[] worldXs,
+      int[] worldZs,
+      int lodSizePoints,
+      int cellSize,
+      double minWorldX,
+      double minWorldZ,
+      byte[] selectedClass,
+      int[] bridgeDeckY
+   ) {
+      double normalX = placeLeft ? -sampled.tangentZ() : sampled.tangentZ();
+      double normalZ = placeLeft ? sampled.tangentX() : -sampled.tangentX();
+      double scanRadius = Math.max(cellSize + 1.0, roadWidth + cellSize);
+      double alongTolerance = Math.max(cellSize * 0.6, roadWidth * 0.45 + cellSize * 0.25);
+      int minGridX = Mth.clamp((int)Math.floor((sampled.worldX() - scanRadius - minWorldX) / cellSize), 0, lodSizePoints - 1);
+      int maxGridX = Mth.clamp((int)Math.floor((sampled.worldX() + scanRadius - minWorldX) / cellSize), 0, lodSizePoints - 1);
+      int minGridZ = Mth.clamp((int)Math.floor((sampled.worldZ() - scanRadius - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+      int maxGridZ = Mth.clamp((int)Math.floor((sampled.worldZ() + scanRadius - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+      int bestIndex = -1;
+      double bestLateral = Double.NEGATIVE_INFINITY;
+      double bestAlong = Double.POSITIVE_INFINITY;
+      double bestDistanceSq = Double.POSITIVE_INFINITY;
+      double minLateral = Double.POSITIVE_INFINITY;
+      double maxLateral = Double.NEGATIVE_INFINITY;
+
+      for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+         double sampleZ = worldZs[gz];
+         int row = gz * lodSizePoints;
+
+         for (int gx = minGridX; gx <= maxGridX; gx++) {
+            int index = row + gx;
+            boolean bridgeCell = bridgeDeckY != null && bridgeDeckY[index] != Integer.MIN_VALUE;
+            boolean modeMatches = roadMode == RoadMode.BRIDGE ? bridgeCell : !bridgeCell;
+            if (selectedClass[index] == classId && modeMatches) {
+               double dx = worldXs[gx] - sampled.worldX();
+               double dz = sampleZ - sampled.worldZ();
+               double along = dx * sampled.tangentX() + dz * sampled.tangentZ();
+               if (!(Math.abs(along) > alongTolerance)) {
+                  double lateral = dx * normalX + dz * normalZ;
+                  minLateral = Math.min(minLateral, lateral);
+                  maxLateral = Math.max(maxLateral, lateral);
+                  if (!(lateral <= 0.05)) {
+                     double distanceSq = dx * dx + dz * dz;
+                     double absAlong = Math.abs(along);
+                     if (lateral > bestLateral + 1.0E-6
+                        || Math.abs(lateral - bestLateral) <= 1.0E-6 && absAlong < bestAlong - 1.0E-6
+                        || Math.abs(lateral - bestLateral) <= 1.0E-6 && Math.abs(absAlong - bestAlong) <= 1.0E-6 && distanceSq < bestDistanceSq) {
+                        bestLateral = lateral;
+                        bestAlong = absAlong;
+                        bestDistanceSq = distanceSq;
+                        bestIndex = index;
+                     }
+                  }
+               }
+            }
+         }
+      }
+
+      if (bestIndex < 0 || minLateral == Double.POSITIVE_INFINITY || maxLateral == Double.NEGATIVE_INFINITY) {
+         return -1;
+      }
+
+      double span = maxLateral - minLateral;
+      if (span < Math.max(0.75, cellSize * 0.35)) {
+         return -1;
+      }
+
+      if (span > roadWidth + cellSize * 0.75) {
+         return -1;
+      }
+
+      return bestIndex;
+   }
+
+   private static boolean hasNearbyLodRoadLight(
+      int anchorIndex, int[] worldXs, int[] worldZs, int minSpacingBlocks, IntArrayList occupiedLightIndices
+   ) {
+      if (occupiedLightIndices == null || occupiedLightIndices.isEmpty()) {
+         return false;
+      } else {
+         int gridSize = worldXs.length;
+         int anchorX = anchorIndex % gridSize;
+         int anchorZ = anchorIndex / gridSize;
+         int anchorWorldX = worldXs[anchorX];
+         int anchorWorldZ = worldZs[anchorZ];
+         int minSpacingSq = minSpacingBlocks * minSpacingBlocks;
+
+         for (int i = 0; i < occupiedLightIndices.size(); i++) {
+            int occupiedIndex = occupiedLightIndices.getInt(i);
+            int occupiedX = occupiedIndex % gridSize;
+            int occupiedZ = occupiedIndex / gridSize;
+            int dx = worldXs[occupiedX] - anchorWorldX;
+            int dz = worldZs[occupiedZ] - anchorWorldZ;
+            if (dx * dx + dz * dz < minSpacingSq) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+   }
+
+   private static boolean lodRoadLightBridgeSupportConflicts(
+      int index,
+      int minY,
+      int maxY,
+      int[] bridgeSupportShaftBottomY,
+      int[] bridgeSupportShaftTopY,
+      int[] bridgeSupportCapBottomY,
+      int[] bridgeSupportCapTopY
+   ) {
+      return bridgeSupportShaftBottomY != null
+            && bridgeSupportShaftTopY != null
+            && bridgeSupportShaftBottomY[index] != Integer.MIN_VALUE
+            && bridgeSupportShaftTopY[index] != Integer.MIN_VALUE
+            && bridgeSupportShaftTopY[index] >= minY
+            && bridgeSupportShaftBottomY[index] <= maxY
+         || bridgeSupportCapBottomY != null
+            && bridgeSupportCapTopY != null
+            && bridgeSupportCapBottomY[index] != Integer.MIN_VALUE
+            && bridgeSupportCapTopY[index] != Integer.MIN_VALUE
+            && bridgeSupportCapTopY[index] >= minY
+            && bridgeSupportCapBottomY[index] <= maxY;
+   }
+
+   private boolean rasterizeLodBridgeDeck(
+      List<RoadFeature> roads,
+      byte classId,
+      int widthBlocks,
+      double blocksPerDegree,
+      int[] worldXs,
+      int[] worldZs,
+      int lodSizePoints,
+      int cellSize,
+      byte[] selectedClass,
+      int[] bridgeDeckY,
+      Map<Long, Integer> roadSurfaceCache
+   ) {
+      if (!roads.isEmpty() && widthBlocks > 0 && lodSizePoints > 0 && cellSize > 0) {
+         double worldScale = EarthProjection.worldScaleFromBlocksPerDegree(blocksPerDegree);
+         double minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+         double minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+         double maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+         double maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+         double halfWidth = Math.max(0.5, (widthBlocks - 1) * 0.5) + cellSize * 0.5;
+         double radiusSq = halfWidth * halfWidth + 1.0E-6;
+         boolean hasBridgeDeck = false;
+
+         for (RoadFeature road : roads) {
+            int points = road.pointCount();
+            if (points >= 2) {
+               double roadMinX = road.minLon() * blocksPerDegree;
+               double roadMaxX = road.maxLon() * blocksPerDegree;
+               double roadMinZ = EarthProjection.latToBlockZ(road.maxLat(), worldScale);
+               double roadMaxZ = EarthProjection.latToBlockZ(road.minLat(), worldScale);
+               if (!(roadMaxX < minWorldX - halfWidth)
+                  && !(roadMinX > maxWorldX + halfWidth)
+                  && !(roadMaxZ < minWorldZ - halfWidth)
+                  && !(roadMinZ > maxWorldZ + halfWidth)) {
+                  double startWorldX = road.lonAt(0) * blocksPerDegree;
+                  double startWorldZ = EarthProjection.latToBlockZ(road.latAt(0), worldScale);
+                  double previousX = startWorldX;
+                  double previousZ = startWorldZ;
+                  double endWorldX = startWorldX;
+                  double endWorldZ = startWorldZ;
+                  double totalLength = 0.0;
+
+                  for (int i = 1; i < points; i++) {
+                     double currentX = road.lonAt(i) * blocksPerDegree;
+                     double currentZ = EarthProjection.latToBlockZ(road.latAt(i), worldScale);
+                     double deltaX = currentX - previousX;
+                     double deltaZ = currentZ - previousZ;
+                     double segmentLength = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+                     totalLength += segmentLength;
+                     previousX = currentX;
+                     previousZ = currentZ;
+                     endWorldX = currentX;
+                     endWorldZ = currentZ;
+                  }
+
+                  if (!(totalLength <= 1.0E-6)) {
+                     int startSurface = this.sampleRoadSurfaceForLodBridge(Mth.floor(startWorldX), Mth.floor(startWorldZ), roadSurfaceCache);
+                     int endSurface = this.sampleRoadSurfaceForLodBridge(Mth.floor(endWorldX), Mth.floor(endWorldZ), roadSurfaceCache);
+                     double segmentStart = 0.0;
+                     double x1 = startWorldX;
+                     double z1 = startWorldZ;
+
+                     for (int i = 1; i < points; i++) {
+                        double x2 = road.lonAt(i) * blocksPerDegree;
+                        double z2 = EarthProjection.latToBlockZ(road.latAt(i), worldScale);
+                        double dx = x2 - x1;
+                        double dz = z2 - z1;
+                        double lenSq = dx * dx + dz * dz;
+                        if (lenSq <= 1.0E-6) {
+                           x1 = x2;
+                           z1 = z2;
+                        } else {
+                           double segmentLength = Math.sqrt(lenSq);
+                           int minGridX = Mth.clamp((int)Math.floor((Math.min(x1, x2) - halfWidth - minWorldX) / cellSize), 0, lodSizePoints - 1);
+                           int maxGridX = Mth.clamp((int)Math.floor((Math.max(x1, x2) + halfWidth - minWorldX) / cellSize), 0, lodSizePoints - 1);
+                           int minGridZ = Mth.clamp((int)Math.floor((Math.min(z1, z2) - halfWidth - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+                           int maxGridZ = Mth.clamp((int)Math.floor((Math.max(z1, z2) + halfWidth - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+
+                           for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+                              double sampleZ = worldZs[gz];
+                              int row = gz * lodSizePoints;
+
+                              for (int gx = minGridX; gx <= maxGridX; gx++) {
+                                 int index = row + gx;
+                                 if (selectedClass[index] == classId) {
+                                    double sampleX = worldXs[gx];
+                                    double t = ((sampleX - x1) * dx + (sampleZ - z1) * dz) / lenSq;
+                                    t = Mth.clamp(t, 0.0, 1.0);
+                                    double px = x1 + t * dx;
+                                    double pz = z1 + t * dz;
+                                    double ddx = sampleX - px;
+                                    double ddz = sampleZ - pz;
+                                    if (!(ddx * ddx + ddz * ddz > radiusSq)) {
+                                       double station = segmentStart + t * segmentLength;
+                                       int localRoadSurface = this.sampleRoadSurfaceForLodBridge(
+                                          Mth.floor(sampleX), Mth.floor(sampleZ), roadSurfaceCache
+                                       );
+                                       int deckY = bridgeDeckYAtStation(
+                                          station,
+                                          totalLength,
+                                          startSurface,
+                                          endSurface,
+                                          localRoadSurface,
+                                          road.bridgeLevel(),
+                                          road.roadClass(),
+                                          worldScale
+                                       );
+                                       if (deckY > bridgeDeckY[index]) {
+                                          bridgeDeckY[index] = deckY;
+                                          hasBridgeDeck = true;
+                                       }
+                                    }
+                                 }
+                              }
+                           }
+
+                           segmentStart += segmentLength;
+                           x1 = x2;
+                           z1 = z2;
+                        }
+                     }
+                  }
+               }
+            }
+         }
+
+         return hasBridgeDeck;
+      } else {
+         return false;
+      }
+   }
+
+   private boolean rasterizeLodBridgeSupports(
+      List<RoadFeature> roads,
+      int roadWidth,
+      double blocksPerDegree,
+      int[] worldXs,
+      int[] worldZs,
+      int[] surfaceYs,
+      int lodSizePoints,
+      int cellSize,
+      byte[] selectedClass,
+      int[] bridgeDeckY,
+      TellusLodGenerator.LodBuildingColumn[] buildingColumns,
+      Map<Long, Integer> roadSurfaceCache,
+      int[] shaftBottomY,
+      int[] shaftTopY,
+      int[] capBottomY,
+      int[] capTopY
+   ) {
+      if (roads.isEmpty() || roadWidth <= 0 || lodSizePoints <= 0 || cellSize <= 0) {
+         return false;
+      }
+
+      double worldScale = EarthProjection.worldScaleFromBlocksPerDegree(blocksPerDegree);
+      double minWorldX = Math.min(worldXs[0], worldXs[lodSizePoints - 1]);
+      double minWorldZ = Math.min(worldZs[0], worldZs[lodSizePoints - 1]);
+      double maxWorldX = Math.max(worldXs[0], worldXs[lodSizePoints - 1]);
+      double maxWorldZ = Math.max(worldZs[0], worldZs[lodSizePoints - 1]);
+      boolean[] hasSupports = new boolean[1];
+
+      for (RoadFeature road : roads) {
+         int points = road.pointCount();
+         if (points < 2) {
+            continue;
+         }
+
+         BridgeSupportLayout.SupportStyle style = BridgeSupportLayout.styleFor(road.roadClass(), roadWidth);
+         double radius = style.maxFootprintRadius() + cellSize * 0.5;
+         double roadMinX = road.minLon() * blocksPerDegree;
+         double roadMaxX = road.maxLon() * blocksPerDegree;
+         double roadMinZ = EarthProjection.latToBlockZ(road.maxLat(), worldScale);
+         double roadMaxZ = EarthProjection.latToBlockZ(road.minLat(), worldScale);
+         if (roadMaxX < minWorldX - radius
+            || roadMinX > maxWorldX + radius
+            || roadMaxZ < minWorldZ - radius
+            || roadMinZ > maxWorldZ + radius) {
+            continue;
+         }
+
+         double startWorldX = road.lonAt(0) * blocksPerDegree;
+         double startWorldZ = EarthProjection.latToBlockZ(road.latAt(0), worldScale);
+         double endWorldX = road.lonAt(points - 1) * blocksPerDegree;
+         double endWorldZ = EarthProjection.latToBlockZ(road.latAt(points - 1), worldScale);
+         int startSurface = this.sampleRoadSurfaceForLodBridge(Mth.floor(startWorldX), Mth.floor(startWorldZ), roadSurfaceCache);
+         int endSurface = this.sampleRoadSurfaceForLodBridge(Mth.floor(endWorldX), Mth.floor(endWorldZ), roadSurfaceCache);
+
+         BridgeSupportLayout.forEachSupport(road, blocksPerDegree, worldScale, roadWidth, placement -> {
+            IntArrayList capCells = new IntArrayList();
+            IntArrayList[] shaftCells = new IntArrayList[style.shaftCount()];
+            int[] minTerrain = new int[style.shaftCount()];
+            int[] maxTerrain = new int[style.shaftCount()];
+
+            for (int i = 0; i < style.shaftCount(); i++) {
+               shaftCells[i] = new IntArrayList();
+               minTerrain[i] = Integer.MAX_VALUE;
+               maxTerrain[i] = Integer.MIN_VALUE;
+            }
+
+            int localRoadSurface = this.sampleRoadSurfaceForLodBridge(
+               Mth.floor(placement.centerX()), Mth.floor(placement.centerZ()), roadSurfaceCache
+            );
+            int deckY = bridgeDeckYAtStation(
+               placement.station(),
+               placement.totalLength(),
+               startSurface,
+               endSurface,
+               localRoadSurface,
+               road.bridgeLevel(),
+               road.roadClass(),
+               worldScale
+            );
+            int supportCapTop = deckY - 1;
+            int supportCapBottom = supportCapTop - style.capThickness() + 1;
+            if (supportCapTop < supportCapBottom) {
+               return;
+            }
+
+            int minGridX = Mth.clamp((int)Math.floor((placement.centerX() - radius - minWorldX) / cellSize), 0, lodSizePoints - 1);
+            int maxGridX = Mth.clamp((int)Math.floor((placement.centerX() + radius - minWorldX) / cellSize), 0, lodSizePoints - 1);
+            int minGridZ = Mth.clamp((int)Math.floor((placement.centerZ() - radius - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+            int maxGridZ = Mth.clamp((int)Math.floor((placement.centerZ() + radius - minWorldZ) / cellSize), 0, lodSizePoints - 1);
+
+            for (int gz = minGridZ; gz <= maxGridZ; gz++) {
+               double sampleZ = worldZs[gz];
+               int row = gz * lodSizePoints;
+
+               for (int gx = minGridX; gx <= maxGridX; gx++) {
+                  double sampleX = worldXs[gx];
+                  double deltaX = sampleX - placement.centerX();
+                  double deltaZ = sampleZ - placement.centerZ();
+                  double along = deltaX * placement.tangentX() + deltaZ * placement.tangentZ();
+                  double across = deltaX * placement.normalX() + deltaZ * placement.normalZ();
+                  int index = row + gx;
+                  if (Math.abs(along) <= style.capHalfAlong() + cellSize * 0.5 && Math.abs(across) <= style.capHalfAcross() + cellSize * 0.5) {
+                     capCells.add(index);
+                  }
+
+                  for (int shaftIndex = 0; shaftIndex < style.shaftCount(); shaftIndex++) {
+                     double shaftAcross = style.shaftCount() == 1 ? 0.0 : (shaftIndex == 0 ? -style.shaftOffset() : style.shaftOffset());
+                     if (Math.abs(along) <= style.shaftHalfAlong() + cellSize * 0.5 && Math.abs(across - shaftAcross) <= style.shaftHalfAcross() + cellSize * 0.5) {
+                        shaftCells[shaftIndex].add(index);
+                        int terrainY = surfaceYs[index];
+                        minTerrain[shaftIndex] = Math.min(minTerrain[shaftIndex], terrainY);
+                        maxTerrain[shaftIndex] = Math.max(maxTerrain[shaftIndex], terrainY);
+                     }
+                  }
+               }
+            }
+
+            if (capCells.isEmpty()) {
+               return;
+            }
+
+            int[] supportBottoms = new int[style.shaftCount()];
+            int[] supportTops = new int[style.shaftCount()];
+            int sharedBottom = Integer.MAX_VALUE;
+            int requiredClearance = Math.max(1, Math.min(style.minClearance(), bridgeTargetClearanceBlocks(road.roadClass(), worldScale)));
+            for (int shaftIndex = 0; shaftIndex < style.shaftCount(); shaftIndex++) {
+               if (shaftCells[shaftIndex].isEmpty() || minTerrain[shaftIndex] == Integer.MAX_VALUE || maxTerrain[shaftIndex] == Integer.MIN_VALUE) {
+                  return;
+               }
+
+               if (supportCapBottom - maxTerrain[shaftIndex] < requiredClearance) {
+                  return;
+               }
+
+               supportBottoms[shaftIndex] = minTerrain[shaftIndex];
+               supportTops[shaftIndex] = supportCapBottom - 1;
+               if (supportTops[shaftIndex] < supportBottoms[shaftIndex]) {
+                  return;
+               }
+
+               sharedBottom = Math.min(sharedBottom, supportBottoms[shaftIndex]);
+            }
+
+            for (int i = 0; i < capCells.size(); i++) {
+               if (this.lodBridgeSupportConflicts(
+                  capCells.getInt(i), supportCapBottom, supportCapTop, selectedClass, bridgeDeckY, surfaceYs, buildingColumns
+               )) {
+                  return;
+               }
+            }
+
+            for (int shaftIndex = 0; shaftIndex < style.shaftCount(); shaftIndex++) {
+               for (int i = 0; i < shaftCells[shaftIndex].size(); i++) {
+                  if (this.lodBridgeSupportConflicts(
+                     shaftCells[shaftIndex].getInt(i),
+                     supportBottoms[shaftIndex],
+                     supportTops[shaftIndex],
+                     selectedClass,
+                     bridgeDeckY,
+                     surfaceYs,
+                     buildingColumns
+                  )) {
+                     return;
+                  }
+               }
+            }
+
+            for (int i = 0; i < capCells.size(); i++) {
+               mergeLodSupportColumn(capCells.getInt(i), supportCapBottom, supportCapTop, capBottomY, capTopY);
+            }
+
+            for (int shaftIndex = 0; shaftIndex < style.shaftCount(); shaftIndex++) {
+               for (int i = 0; i < shaftCells[shaftIndex].size(); i++) {
+                  mergeLodSupportColumn(shaftCells[shaftIndex].getInt(i), supportBottoms[shaftIndex], supportTops[shaftIndex], shaftBottomY, shaftTopY);
+               }
+            }
+
+            hasSupports[0] = true;
+         });
+      }
+
+      return hasSupports[0];
+   }
+
+   private boolean lodBridgeSupportConflicts(
+      int index,
+      int bottomY,
+      int topY,
+      byte[] selectedClass,
+      int[] bridgeDeckY,
+      int[] surfaceYs,
+      TellusLodGenerator.LodBuildingColumn[] buildingColumns
+   ) {
+      if (topY < bottomY) {
+         return false;
+      }
+
+      if (selectedClass[index] > 0) {
+         int bridgeDeck = bridgeDeckY[index];
+         if (bridgeDeck != Integer.MIN_VALUE) {
+            if (bridgeDeck >= bottomY && bridgeDeck <= topY) {
+               return true;
+            }
+         } else {
+            int roadSurface = surfaceYs[index];
+            if (roadSurface >= bottomY && roadSurface <= topY) {
+               return true;
+            }
+         }
+      }
+
+      TellusLodGenerator.LodBuildingColumn buildingColumn = buildingColumns == null ? null : buildingColumns[index];
+      return buildingColumn != null && buildingColumn.intersectsSpan(bottomY, topY);
+   }
+
+   private static void mergeLodSupportColumn(int index, int bottomY, int topY, int[] bottoms, int[] tops) {
+      if (topY < bottomY) {
+         return;
+      }
+
+      if (tops[index] == Integer.MIN_VALUE) {
+         bottoms[index] = bottomY;
+         tops[index] = topY;
+      } else {
+         bottoms[index] = Math.min(bottoms[index], bottomY);
+         tops[index] = Math.max(tops[index], topY);
+      }
+   }
+
+   private int sampleRoadSurfaceForLodBridge(int worldX, int worldZ, Map<Long, Integer> roadSurfaceCache) {
+      long packed = packWorldColumn(worldX, worldZ);
+      Integer cached = roadSurfaceCache.get(packed);
+      if (cached != null) {
+         return cached;
+      } else {
+         WaterSurfaceResolver.WaterColumnData column = this.generator.resolveLodWaterColumn(worldX, worldZ);
+         int roadSurface = column.hasWater() && column.waterSurface() > column.terrainSurface() ? column.waterSurface() : column.terrainSurface();
+         roadSurfaceCache.put(packed, roadSurface);
+         return roadSurface;
+      }
+   }
+
+   private static long packWorldColumn(int worldX, int worldZ) {
+      return (long)worldX << 32 ^ worldZ & 4294967295L;
+   }
+
+   private static int roadWidthForScale(int baseWidth, double worldScale) {
+      double factor = roadWidthFactorForScale(worldScale);
+
+      return Math.max(1, (int)Math.round(baseWidth * factor));
+   }
+
+   private static double roadWidthFactorForScale(double worldScale) {
+      if (!(worldScale > 0.0)) {
+         return 0.25;
+      } else if (worldScale <= 1.0) {
+         return 1.8;
+      } else if (worldScale <= 5.0) {
+         double t = (worldScale - 1.0) / 4.0;
+         return Mth.lerp(Mth.clamp(t, 0.0, 1.0), 1.8, 1.0);
+      } else if (worldScale <= 10.0) {
+         double t = (worldScale - 5.0) / 5.0;
+         return Mth.lerp(Mth.clamp(t, 0.0, 1.0), 1.0, 0.5);
+      } else {
+         return 0.25;
+      }
+   }
+
+   private static int bridgeRiseAtStation(double station, double totalLength, int bridgeLevel) {
+      int requestedRise = Math.max(0, bridgeLevel) * 3;
+      requestedRise = Math.min(requestedRise, 10);
+      if (requestedRise > 0 && !(totalLength <= 1.0E-6)) {
+         double maxRiseByLength = totalLength / 8.0;
+         int targetRise = Math.min(requestedRise, Math.max(0, (int)Math.floor(maxRiseByLength)));
+         if (targetRise <= 0) {
+            return 0;
+         } else {
+            double clampedStation = Mth.clamp(station, 0.0, totalLength);
+            double rampLength = targetRise * 4;
+            double rise;
+            if (totalLength >= rampLength * 2.0) {
+               if (clampedStation < rampLength) {
+                  rise = targetRise * (clampedStation / rampLength);
+               } else if (clampedStation > totalLength - rampLength) {
+                  rise = targetRise * ((totalLength - clampedStation) / rampLength);
+               } else {
+                  rise = targetRise;
+               }
+            } else {
+               double half = totalLength * 0.5;
+               if (half <= 1.0E-6) {
+                  rise = targetRise;
+               } else if (clampedStation <= half) {
+                  rise = targetRise * (clampedStation / half);
+               } else {
+                  rise = targetRise * ((totalLength - clampedStation) / half);
+               }
+            }
+
+            return Math.max(0, (int)Math.round(Mth.clamp(rise, 0.0, targetRise)));
+         }
+      } else {
+         return 0;
+      }
+   }
+
+   private static int bridgeDeckBaselineAtStation(double station, double totalLength, int startSurface, int endSurface) {
+      return interpolateDeckAtStation(station, totalLength, startSurface, endSurface);
+   }
+
+   private static int bridgeDeckYAtStation(
+      double station,
+      double totalLength,
+      int startSurface,
+      int endSurface,
+      int localRoadSurface,
+      int bridgeLevel,
+      RoadClass roadClass,
+      double worldScale
+   ) {
+      int baseline = bridgeDeckBaselineAtStation(station, totalLength, startSurface, endSurface);
+      int rise = bridgeRiseAtStation(station, totalLength, bridgeLevel);
+      int clearance = bridgeClearanceAtStation(station, totalLength, roadClass, worldScale);
+      return Math.max(baseline + rise, localRoadSurface + clearance);
+   }
+
+   private static int bridgeClearanceAtStation(double station, double totalLength, RoadClass roadClass, double worldScale) {
+      int targetClearance = bridgeTargetClearanceBlocks(roadClass, worldScale);
+      if (targetClearance <= 0 || totalLength <= 1.0E-6) {
+         return 0;
+      } else {
+         double clampedStation = Mth.clamp(station, 0.0, totalLength);
+         double rampLength = targetClearance * 4.0;
+         double clearance;
+         if (totalLength >= rampLength * 2.0) {
+            if (clampedStation < rampLength) {
+               clearance = targetClearance * (clampedStation / rampLength);
+            } else if (clampedStation > totalLength - rampLength) {
+               clearance = targetClearance * ((totalLength - clampedStation) / rampLength);
+            } else {
+               clearance = targetClearance;
+            }
+         } else {
+            double half = totalLength * 0.5;
+            if (half <= 1.0E-6) {
+               clearance = targetClearance;
+            } else if (clampedStation <= half) {
+               clearance = targetClearance * (clampedStation / half);
+            } else {
+               clearance = targetClearance * ((totalLength - clampedStation) / half);
+            }
+         }
+
+         return Math.max(0, (int)Math.round(Mth.clamp(clearance, 0.0, targetClearance)));
+      }
+   }
+
+   private static int bridgeTargetClearanceBlocks(RoadClass roadClass, double worldScale) {
+      double safeScale = worldScale > 0.0 ? worldScale : 1.0;
+      double clearanceMeters = switch (roadClass) {
+         case MAIN -> 6.0;
+         case NORMAL -> 5.0;
+         case DIRT -> 3.0;
+      };
+      return Math.max(1, (int)Math.ceil(clearanceMeters / safeScale));
+   }
+
+   private static int interpolateDeckAtStation(double station, double totalLength, int startSurface, int endSurface) {
+      if (totalLength <= 1.0E-6) {
+         return startSurface;
+      } else {
+         double progress = Mth.clamp(station / totalLength, 0.0, 1.0);
+         double interpolated = startSurface + (endSurface - startSurface) * progress;
+         return (int)Math.round(interpolated);
+      }
+   }
+
+   private void prefetchAtBlock(
+      int blockX,
+      int blockZ,
+      boolean includeRoadsPrefetch,
+      boolean includeBuildingsPrefetch,
+      boolean includeDetailedWaterPrefetch,
+      double previewResolutionMeters
+   ) {
+      int chunkX = SectionPos.blockToSectionCoord(blockX);
+      int chunkZ = SectionPos.blockToSectionCoord(blockZ);
+      if (this.shouldRunPrefetch(
+         new TellusLodGenerator.ChunkPrefetchKey(
+            chunkX, chunkZ, includeRoadsPrefetch, includeBuildingsPrefetch, includeDetailedWaterPrefetch, previewResolutionMeters
+         )
+      )) {
+         this.generator.prefetchForChunk(
+            chunkX, chunkZ, includeRoadsPrefetch, includeDetailedWaterPrefetch, includeBuildingsPrefetch, previewResolutionMeters, false
+         );
+      }
+   }
+
+   private boolean shouldRunPrefetch(Object key) {
+      long now = System.currentTimeMillis();
+      boolean[] scheduled = new boolean[]{false};
+      this.recentPrefetches.compute(key, (ignored, last) -> {
+         if (last == null || now - last >= PREFETCH_DEDUP_WINDOW_MS) {
+            scheduled[0] = true;
+            return now;
+         } else {
+            return last;
+         }
+      });
+      if (scheduled[0]) {
+         this.cleanupRecentPrefetches(now);
+      }
+
+      return scheduled[0];
+   }
+
+   private void cleanupRecentPrefetches(long now) {
+      if (this.recentPrefetches.size() > PREFETCH_DEDUP_MAX || (this.prefetchCleanupCounter.incrementAndGet() & 255) == 0) {
+         for (Map.Entry<Object, Long> entry : this.recentPrefetches.entrySet()) {
+            if (now - entry.getValue() >= PREFETCH_STALE_WINDOW_MS) {
+               this.recentPrefetches.remove(entry.getKey(), entry.getValue());
+            }
+         }
+      }
+   }
+
+   private static int lerpBlock(int min, int max, int index, int count) {
+      if (count <= 1) {
+         return min;
+      } else {
+         double t = (double)index / (count - 1);
+         return (int)Math.round(min + (max - min) * t);
+      }
+   }
+
+   private static TellusLodGenerator.CanopyProfile canopyProfile(Holder<Biome> biome) {
+      return CANOPY_PROFILES.computeIfAbsent(biome, TellusLodGenerator::buildCanopyProfile);
+   }
+
+   private static TellusLodGenerator.CanopyProfile resolveTreeCoverCanopyProfile(TellusLodGenerator.CanopyProfile biomeProfile, int coverClass) {
+      return coverClass == 10 && !biomeProfile.isMangrove() && biomeProfile.canopyBaseChance() <= 0 ? TREE_COVER_FALLBACK_CANOPY_PROFILE : biomeProfile;
+   }
+
+   private static TellusLodGenerator.CanopyProfile buildCanopyProfile(Holder<Biome> biome) {
+      boolean isMangrove = biome.is(Biomes.MANGROVE_SWAMP);
+      boolean isDarkForest = biome.is(Biomes.DARK_FOREST);
+      boolean isBambooJungle = biome.is(Biomes.BAMBOO_JUNGLE);
+      boolean isSparseJungle = biome.is(Biomes.SPARSE_JUNGLE);
+      boolean isWindsweptForest = biome.is(Biomes.WINDSWEPT_FOREST);
+      boolean isWoodedBadlands = biome.is(Biomes.WOODED_BADLANDS);
+      boolean isWindsweptSavanna = biome.is(Biomes.WINDSWEPT_SAVANNA);
+      boolean isSavannaPlateau = biome.is(Biomes.SAVANNA_PLATEAU);
+      boolean isCherryGrove = biome.is(Biomes.CHERRY_GROVE);
+      boolean isSwamp = biome.is(Biomes.SWAMP);
+      boolean isWarmOcean = biome.is(Biomes.WARM_OCEAN);
+      boolean isLukewarmOcean = biome.is(Biomes.LUKEWARM_OCEAN);
+      boolean isDeepLukewarmOcean = biome.is(Biomes.DEEP_LUKEWARM_OCEAN);
+      boolean isJungle = biome.is(BiomeTags.IS_JUNGLE);
+      boolean isForest = biome.is(BiomeTags.IS_FOREST);
+      boolean isTaiga = biome.is(BiomeTags.IS_TAIGA);
+      boolean isSavanna = biome.is(BiomeTags.IS_SAVANNA);
+      boolean isOcean = biome.is(BiomeTags.IS_OCEAN);
+      boolean isRiver = biome.is(BiomeTags.IS_RIVER);
+      boolean isSavannaTree = isSavanna || isWindsweptSavanna || isSavannaPlateau;
+      int canopyBaseChance;
+      if (isMangrove) {
+         canopyBaseChance = 85;
+      } else if (isDarkForest) {
+         canopyBaseChance = 80;
+      } else if (isBambooJungle) {
+         canopyBaseChance = 75;
+      } else if (isSparseJungle) {
+         canopyBaseChance = 50;
+      } else if (isWindsweptForest) {
+         canopyBaseChance = 45;
+      } else if (isWoodedBadlands) {
+         canopyBaseChance = 40;
+      } else if (isWindsweptSavanna) {
+         canopyBaseChance = 35;
+      } else if (isSavannaPlateau) {
+         canopyBaseChance = 45;
+      } else if (isJungle) {
+         canopyBaseChance = 75;
+      } else if (isForest) {
+         canopyBaseChance = 70;
+      } else if (isTaiga) {
+         canopyBaseChance = 65;
+      } else if (isCherryGrove) {
+         canopyBaseChance = 60;
+      } else if (isSwamp) {
+         canopyBaseChance = 55;
+      } else if (isSavanna) {
+         canopyBaseChance = 50;
+      } else {
+         canopyBaseChance = 0;
+      }
+
+      int canopyBaseRadius;
+      if (isMangrove) {
+         canopyBaseRadius = 5;
+      } else if (isSparseJungle) {
+         canopyBaseRadius = 3;
+      } else if (isBambooJungle) {
+         canopyBaseRadius = 4;
+      } else if (isJungle) {
+         canopyBaseRadius = 5;
+      } else if (isDarkForest) {
+         canopyBaseRadius = 4;
+      } else if (isWindsweptForest || isWoodedBadlands) {
+         canopyBaseRadius = 2;
+      } else if (isSavannaTree) {
+         canopyBaseRadius = 3;
+      } else if (!isForest && !isTaiga && !isCherryGrove && !isSwamp) {
+         canopyBaseRadius = 0;
+      } else {
+         canopyBaseRadius = 3;
+      }
+
+      boolean isTallCanopy = isMangrove || isDarkForest || isJungle;
+      int canopyBaseHeight;
+      if (isMangrove) {
+         canopyBaseHeight = 4;
+      } else if (isJungle) {
+         canopyBaseHeight = 4;
+      } else if (isTallCanopy) {
+         canopyBaseHeight = 3;
+      } else if (isTaiga) {
+         canopyBaseHeight = 3;
+      } else {
+         canopyBaseHeight = 2;
+      }
+
+      int canopyMaxHeight;
+      if (isMangrove) {
+         canopyMaxHeight = 5;
+      } else if (isJungle) {
+         canopyMaxHeight = 5;
+      } else if (!isTallCanopy && !isTaiga) {
+         canopyMaxHeight = 3;
+      } else {
+         canopyMaxHeight = 4;
+      }
+
+      int waterVegetationChance;
+      if (isWarmOcean || isLukewarmOcean) {
+         waterVegetationChance = 19;
+      } else if (isDeepLukewarmOcean) {
+         waterVegetationChance = 18;
+      } else if (isMangrove) {
+         waterVegetationChance = 17;
+      } else if (isSwamp) {
+         waterVegetationChance = 14;
+      } else if (isOcean) {
+         waterVegetationChance = 15;
+      } else if (isRiver) {
+         waterVegetationChance = 12;
+      } else {
+         waterVegetationChance = 10;
+      }
+
+      return new TellusLodGenerator.CanopyProfile(
+         isMangrove,
+         isDarkForest,
+         isBambooJungle,
+         isSparseJungle,
+         isWindsweptForest,
+         isWoodedBadlands,
+         isWindsweptSavanna,
+         isSavannaPlateau,
+         isCherryGrove,
+         isSwamp,
+         isJungle,
+         isForest,
+         isTaiga,
+         isSavanna,
+         isOcean,
+         isRiver,
+         isWarmOcean,
+         isLukewarmOcean,
+         isDeepLukewarmOcean,
+         canopyBaseChance,
+         canopyBaseRadius,
+         canopyBaseHeight,
+         canopyMaxHeight,
+         waterVegetationChance
+      );
+   }
+
+   private static TellusLodGenerator.CanopyColumn resolveCanopyColumn(TellusLodGenerator.CanopyProfile profile, int worldX, int worldZ, int cellSize) {
+      int baseChance = canopyCenterChancePercent(profile);
+      int chance = boostCanopyChancePercent(baseChance);
+      if (chance <= 0) {
+         return null;
+      } else {
+         int gridSize = canopyGridSize(cellSize);
+         int cellX = Math.floorDiv(worldX, gridSize);
+         int cellZ = Math.floorDiv(worldZ, gridSize);
+         int bestDist = Integer.MAX_VALUE;
+         int bestRadius = 0;
+         int bestHash = 0;
+         boolean bestCenter = false;
+
+         for (int dz = -1; dz <= 1; dz++) {
+            int testCellZ = cellZ + dz;
+
+            for (int dx = -1; dx <= 1; dx++) {
+               int testCellX = cellX + dx;
+               int centerHash = mixHash(testCellX, testCellZ, 1831565813);
+               if (hasCanopyCenter(centerHash, chance)) {
+                  int offsetX = centerOffset(centerHash, gridSize);
+                  int offsetZ = centerOffset(centerHash >>> 8, gridSize);
+                  int centerX = testCellX * gridSize + offsetX;
+                  int centerZ = testCellZ * gridSize + offsetZ;
+                  int dist = Math.abs(worldX - centerX) + Math.abs(worldZ - centerZ);
+                  int radius = canopyRadius(profile, centerHash, gridSize);
+                  if (dist <= radius && dist < bestDist) {
+                     bestDist = dist;
+                     bestRadius = radius;
+                     bestHash = centerHash;
+                     bestCenter = dist == 0;
+                  }
+               }
+            }
+         }
+
+         if (bestDist == Integer.MAX_VALUE) {
+            return null;
+         } else {
+            int crownHeight = profile.canopyBaseHeight();
+            int falloff = bestRadius - bestDist;
+            if (falloff >= 2) {
+               crownHeight++;
+            }
+
+            if (falloff >= 4) {
+               crownHeight++;
+            }
+
+            int maxHeight = profile.canopyMaxHeight();
+            crownHeight += bestHash >>> 19 & 1;
+            if (bestCenter) {
+               crownHeight++;
+            }
+
+            crownHeight = Math.min(crownHeight, maxHeight);
+            if (crownHeight <= 0) {
+               return null;
+            } else {
+               int centerTrunkHeight = canopyTrunkHeight(profile, bestHash);
+               int trunkHeight = bestCenter ? centerTrunkHeight : 0;
+               int leafLift = canopyLeafLift(profile, bestCenter, centerTrunkHeight, bestDist, bestHash);
+               BlockState leavesBlock = selectCanopyBlock(profile, worldX, worldZ);
+               if (leavesBlock == null) {
+                  return null;
+               } else {
+                  BlockState trunkBlock = trunkHeight > 0 ? selectTrunkBlock(profile, worldX, worldZ, bestHash) : null;
+                  return new TellusLodGenerator.CanopyColumn(trunkHeight, leafLift, crownHeight, leavesBlock, trunkBlock);
+               }
+            }
+         }
+      }
+   }
+
+   private static int appendCanopyColumn(
+      TellusLodGenerator.CanopyColumn canopyColumn,
+      int lastLayerTop,
+      int absoluteTop,
+      TellusLodGenerator.WrapperCache wrappers,
+      IDhApiBiomeWrapper biome,
+      List<DhApiTerrainDataPoint> columnDataPoints
+   ) {
+      if (canopyColumn != null && lastLayerTop < absoluteTop) {
+         int layerTop = lastLayerTop;
+         if (canopyColumn.trunkHeight > 0 && canopyColumn.trunkBlock != null) {
+            int trunkTop = Math.min(absoluteTop, lastLayerTop + canopyColumn.trunkHeight);
+            if (trunkTop > lastLayerTop) {
+               IDhApiBlockStateWrapper trunkBlock = wrappers.getBlockState(canopyColumn.trunkBlock);
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, lastLayerTop, trunkTop, trunkBlock, biome));
+               layerTop = trunkTop;
+            }
+         }
+
+         if (canopyColumn.leafLift > 0) {
+            int liftTop = Math.min(absoluteTop, layerTop + canopyColumn.leafLift);
+            if (liftTop > layerTop) {
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, layerTop, liftTop, wrappers.airBlock(), biome));
+               layerTop = liftTop;
+            }
+         }
+
+         if (canopyColumn.leavesHeight > 0 && canopyColumn.leavesBlock != null) {
+            int canopyTop = Math.min(absoluteTop, layerTop + canopyColumn.leavesHeight);
+            if (canopyTop > layerTop) {
+               IDhApiBlockStateWrapper canopyBlock = wrappers.getBlockState(canopyColumn.leavesBlock);
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, layerTop, canopyTop, canopyBlock, biome));
+               layerTop = canopyTop;
+            }
+         }
+
+         return layerTop;
+      } else {
+         return lastLayerTop;
+      }
+   }
+
+   private static int appendBuildingColumn(
+      TellusLodGenerator.LodBuildingColumn buildingColumn,
+      int lastLayerTop,
+      int minY,
+      int absoluteTop,
+      TellusLodGenerator.WrapperCache wrappers,
+      IDhApiBiomeWrapper biome,
+      List<DhApiTerrainDataPoint> columnDataPoints
+   ) {
+      if (buildingColumn == null || buildingColumn.isEmpty()) {
+         return lastLayerTop;
+      } else {
+         int layerTop = lastLayerTop;
+
+         for (int i = 0; i < buildingColumn.size(); i++) {
+            int spanStart = buildingColumn.startY(i);
+            int spanEnd = buildingColumn.endY(i);
+            int spanBaseTop = toLayerTop(spanStart - 1, minY, absoluteTop);
+            int spanTop = toLayerTop(spanEnd, minY, absoluteTop);
+            if (spanBaseTop > layerTop) {
+               columnDataPoints.add(DhApiTerrainDataPoint.create((byte)0, 0, 15, layerTop, spanBaseTop, wrappers.airBlock(), biome));
+               layerTop = spanBaseTop;
+            }
+
+            if (spanTop > layerTop) {
+               columnDataPoints.add(
+                  DhApiTerrainDataPoint.create(
+                     (byte)0, buildingColumn.emittedLight(i), 15, layerTop, spanTop, wrappers.getBlockState(buildingColumn.blockState(i)), biome
+                  )
+               );
+               layerTop = spanTop;
+            }
+         }
+
+         return layerTop;
+      }
+   }
+
+   private static int canopyCenterChancePercent(TellusLodGenerator.CanopyProfile profile) {
+      return profile.canopyBaseChance();
+   }
+
+   private static int boostCanopyChancePercent(int baseChance) {
+      int boosted = (baseChance * 3 + 1) / 2;
+      return Math.min(100, boosted);
+   }
+
+   private static int canopyGridSize(int cellSize) {
+      int detailLevel = Math.max(0, Integer.numberOfTrailingZeros(cellSize));
+      int scale = Math.min(8, Math.max(0, detailLevel - 2));
+      int gridFromDetail = 8 + (scale << 1);
+      int gridFromCell = 8 + Math.max(-2, (cellSize - 8) / 4);
+      return Mth.clamp(Math.min(gridFromDetail, gridFromCell), 6, 24);
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Holder<Biome>[] newBiomeHolderArray(int size) {
+      return (Holder<Biome>[])new Holder<?>[size];
+   }
+
+   private static int canopyRadius(TellusLodGenerator.CanopyProfile profile, int centerHash, int gridSize) {
+      int baseRadius = profile.canopyBaseRadius();
+      if (baseRadius == 0) {
+         return 0;
+      } else {
+         int scaledRadius = Math.max(1, baseRadius * gridSize / 8);
+         scaledRadius = Math.min(scaledRadius, gridSize - 1);
+         return scaledRadius + (centerHash >>> 16 & 1);
+      }
+   }
+
+   private static boolean hasCanopyCenter(int centerHash, int chancePercent) {
+      int roll = centerHash >>> 24 & 0xFF;
+      int threshold = chancePercent * 255 / 100;
+      return roll < threshold;
+   }
+
+   private static int canopyTrunkHeight(TellusLodGenerator.CanopyProfile profile, int centerHash) {
+      int jitter = centerHash >>> 21 & 3;
+      if (jitter == 3) {
+         jitter = 2;
+      }
+
+      if (profile.isMangrove()) {
+         return 6 + jitter + (centerHash >>> 19 & 1);
+      } else if (profile.isJungle()) {
+         int height = 10 + jitter;
+         if ((centerHash >>> 18 & 7) == 0) {
+            height += 8;
+         }
+
+         return height;
+      } else if (profile.isSavannaFamily()) {
+         return 5 + jitter;
+      } else {
+         int height = 3 + jitter;
+         if (profile.isTallCanopy()) {
+            height = Math.min(5, height + 1);
+         }
+
+         return height;
+      }
+   }
+
+   private static int canopyLeafLift(TellusLodGenerator.CanopyProfile profile, boolean isCenter, int centerTrunkHeight, int bestDist, int centerHash) {
+      if (isCenter) {
+         return 0;
+      } else {
+         int baseLift = Math.max(1, centerTrunkHeight - Math.max(0, bestDist - 1));
+         int lift = profile.isTallCanopy() ? Math.max(2, baseLift) : Math.max(1, baseLift);
+         if (bestDist > 1 && (centerHash >>> 20 & 1) == 0) {
+            lift = Math.max(1, lift - 1);
+         }
+
+         return lift;
+      }
+   }
+
+   private static TellusLodGenerator.WaterVegetationColumn resolveWaterVegetationColumn(
+      TellusLodGenerator.CanopyProfile profile, int worldX, int worldZ, int waterDepth
+   ) {
+      if (waterDepth < 1) {
+         return null;
+      } else {
+         int chance = waterVegetationChancePercent(profile);
+         if (chance <= 0) {
+            return null;
+         } else {
+            int hash = mixHash(worldX, worldZ, 1013904223);
+            if (!hasClusterCenter(hash, chance)) {
+               return null;
+            } else {
+               boolean kelp = shouldUseKelp(profile, waterDepth, hash);
+               BlockState blockState = kelp ? Blocks.KELP_PLANT.defaultBlockState() : Blocks.SEAGRASS.defaultBlockState();
+               int maxHeight = Math.min(4, Math.max(1, waterDepth - 1));
+               if (maxHeight <= 0) {
+                  return null;
+               } else {
+                  int height = 1 + (hash >>> 12 & 3);
+                  height = Math.min(height, maxHeight);
+                  return height <= 0 ? null : new TellusLodGenerator.WaterVegetationColumn(height, blockState);
+               }
+            }
+         }
+      }
+   }
+
+   private static int waterVegetationChancePercent(TellusLodGenerator.CanopyProfile profile) {
+      return profile.waterVegetationChance();
+   }
+
+   private static boolean shouldUseKelp(TellusLodGenerator.CanopyProfile profile, int waterDepth, int centerHash) {
+      if (profile.isRiver()) {
+         return false;
+      } else if (waterDepth < 6) {
+         return false;
+      } else {
+         int chance;
+         if (profile.isWarmOcean()) {
+            chance = 15;
+         } else if (profile.isLukewarmOcean() || profile.isDeepLukewarmOcean()) {
+            chance = 25;
+         } else if (profile.isOcean()) {
+            chance = 35;
+         } else {
+            chance = 0;
+         }
+
+         int roll = centerHash >>> 18 & 0xFF;
+         int threshold = chance * 255 / 100;
+         return roll < threshold;
+      }
+   }
+
+   private static int centerOffset(int hash, int gridSize) {
+      return Math.floorMod(hash, gridSize);
+   }
+
+   private static BlockState selectCanopyBlock(TellusLodGenerator.CanopyProfile profile, int worldX, int worldZ) {
+      if (profile.isWindsweptForest()) {
+         return Blocks.SPRUCE_LEAVES.defaultBlockState();
+      } else if (profile.isWoodedBadlands()) {
+         return Blocks.OAK_LEAVES.defaultBlockState();
+      } else if (profile.isWindsweptSavanna() || profile.isSavannaPlateau()) {
+         return Blocks.ACACIA_LEAVES.defaultBlockState();
+      } else if (profile.isSparseJungle() || profile.isBambooJungle()) {
+         return Blocks.JUNGLE_LEAVES.defaultBlockState();
+      } else if (profile.isMangrove()) {
+         return Blocks.MANGROVE_LEAVES.defaultBlockState();
+      } else if (profile.isDarkForest()) {
+         return Blocks.DARK_OAK_LEAVES.defaultBlockState();
+      } else if (profile.isCherryGrove()) {
+         return Blocks.CHERRY_LEAVES.defaultBlockState();
+      } else if (profile.isJungle()) {
+         return Blocks.JUNGLE_LEAVES.defaultBlockState();
+      } else if (profile.isTaiga()) {
+         return Blocks.SPRUCE_LEAVES.defaultBlockState();
+      } else if (profile.isSavanna()) {
+         return Blocks.ACACIA_LEAVES.defaultBlockState();
+      } else if (profile.isSwamp()) {
+         return Blocks.OAK_LEAVES.defaultBlockState();
+      } else if (profile.isForest()) {
+         int hash = mixHash(worldX, worldZ, 2135587861);
+         return (hash >>> 28 & 3) == 0 ? Blocks.BIRCH_LEAVES.defaultBlockState() : Blocks.OAK_LEAVES.defaultBlockState();
+      } else {
+         return null;
+      }
+   }
+
+   private static BlockState selectTrunkBlock(TellusLodGenerator.CanopyProfile profile, int worldX, int worldZ, int centerHash) {
+      if (profile.isWindsweptForest()) {
+         return Blocks.SPRUCE_LOG.defaultBlockState();
+      } else if (profile.isWoodedBadlands()) {
+         return Blocks.OAK_LOG.defaultBlockState();
+      } else if (profile.isWindsweptSavanna() || profile.isSavannaPlateau()) {
+         return Blocks.ACACIA_LOG.defaultBlockState();
+      } else if (profile.isSparseJungle() || profile.isBambooJungle()) {
+         return Blocks.JUNGLE_LOG.defaultBlockState();
+      } else if (profile.isMangrove()) {
+         return Blocks.MANGROVE_LOG.defaultBlockState();
+      } else if (profile.isDarkForest()) {
+         return Blocks.DARK_OAK_LOG.defaultBlockState();
+      } else if (profile.isCherryGrove()) {
+         return Blocks.CHERRY_LOG.defaultBlockState();
+      } else if (profile.isJungle()) {
+         return Blocks.JUNGLE_LOG.defaultBlockState();
+      } else if (profile.isTaiga()) {
+         return Blocks.SPRUCE_LOG.defaultBlockState();
+      } else if (profile.isSavanna()) {
+         return Blocks.ACACIA_LOG.defaultBlockState();
+      } else if (profile.isSwamp()) {
+         return Blocks.OAK_LOG.defaultBlockState();
+      } else if (profile.isForest()) {
+         int hash = mixHash(worldX, worldZ, 2135587861) ^ centerHash;
+         return (hash >>> 28 & 3) == 0 ? Blocks.BIRCH_LOG.defaultBlockState() : Blocks.OAK_LOG.defaultBlockState();
+      } else {
+         return Blocks.OAK_LOG.defaultBlockState();
+      }
+   }
+
+   private static int mixHash(int worldX, int worldZ, int seed) {
+      int h = worldX * 522133279 ^ worldZ * -1640531527 ^ seed * 668265261;
+      h ^= h >>> 15;
+      h *= -2048144789;
+      h ^= h >>> 13;
+      h *= -1028477387;
+      return h ^ h >>> 16;
+   }
+
+   private static boolean hasClusterCenter(int centerHash, int chancePercent) {
+      int roll = centerHash >>> 24 & 0xFF;
+      int threshold = chancePercent * 255 / 100;
+      return roll < threshold;
+   }
+
+   public EDhApiWorldGeneratorReturnType getReturnType() {
+      return EDhApiWorldGeneratorReturnType.API_DATA_SOURCES;
+   }
+
+   public boolean runApiValidation() {
+      return false;
+   }
+
+   public void close() {
+   }
+
+   private static final class CanopyColumn {
+      private final int trunkHeight;
+      private final int leafLift;
+      private final int leavesHeight;
+      private final BlockState leavesBlock;
+      private final BlockState trunkBlock;
+
+      private CanopyColumn(int trunkHeight, int leafLift, int leavesHeight, BlockState leavesBlock, BlockState trunkBlock) {
+         this.trunkHeight = trunkHeight;
+         this.leafLift = leafLift;
+         this.leavesHeight = leavesHeight;
+         this.leavesBlock = leavesBlock;
+         this.trunkBlock = trunkBlock;
+      }
+   }
+
+   private record CanopyProfile(
+      boolean isMangrove,
+      boolean isDarkForest,
+      boolean isBambooJungle,
+      boolean isSparseJungle,
+      boolean isWindsweptForest,
+      boolean isWoodedBadlands,
+      boolean isWindsweptSavanna,
+      boolean isSavannaPlateau,
+      boolean isCherryGrove,
+      boolean isSwamp,
+      boolean isJungle,
+      boolean isForest,
+      boolean isTaiga,
+      boolean isSavanna,
+      boolean isOcean,
+      boolean isRiver,
+      boolean isWarmOcean,
+      boolean isLukewarmOcean,
+      boolean isDeepLukewarmOcean,
+      int canopyBaseChance,
+      int canopyBaseRadius,
+      int canopyBaseHeight,
+      int canopyMaxHeight,
+      int waterVegetationChance
+   ) {
+      private boolean isTallCanopy() {
+         return this.isMangrove || this.isDarkForest || this.isJungle;
+      }
+
+      private boolean isSavannaFamily() {
+         return this.isSavanna || this.isWindsweptSavanna || this.isSavannaPlateau;
+      }
+   }
+
+   private record LodRoadMaskResult(
+      byte[] mask,
+      int[] bridgeDeckY,
+      int[] bridgeSupportShaftBottomY,
+      int[] bridgeSupportShaftTopY,
+      int[] bridgeSupportCapBottomY,
+      int[] bridgeSupportCapTopY,
+      int[] roadLightBaseY,
+      byte[] roadLightFenceCount,
+      boolean hadCacheMisses
+   ) {
+   }
+
+   private record LodBuildingMaskResult(TellusLodGenerator.LodBuildingColumn[] columns, int[] flattenedSurface, boolean hadCacheMisses) {
+   }
+
+   private static final class LodBuildingGroupScratch {
+      private final IntArrayList groundSamples = new IntArrayList();
+      private final IntArrayList fallbackSamples = new IntArrayList();
+      private int baseY = Integer.MIN_VALUE;
+
+      private IntArrayList groundSamples() {
+         return this.groundSamples;
+      }
+
+      private IntArrayList fallbackSamples() {
+         return this.fallbackSamples;
+      }
+
+      private int baseY() {
+         return this.baseY;
+      }
+
+      private void setBaseY(int baseY) {
+         this.baseY = baseY;
+      }
+   }
+
+   private record LodRasterizedBuildingFeature(
+      OsmBuildingFeature feature, String groupId, int lodSize, int minGridX, int minGridZ, int width, int height, boolean[] occupiedMask, int[] occupiedCells
+   ) {
+   }
+
+   private record SampledRoadStation(double worldX, double worldZ, double tangentX, double tangentZ) {
+   }
+
+   private static final class LodBuildingColumn {
+      private int[] starts = new int[2];
+      private int[] ends = new int[2];
+      private BlockState[] blockStates = new BlockState[2];
+      private byte[] emittedLights = new byte[2];
+      private int size;
+
+      private boolean isEmpty() {
+         return this.size == 0;
+      }
+
+      private int size() {
+         return this.size;
+      }
+
+      private int startY(int index) {
+         return this.starts[index];
+      }
+
+      private int endY(int index) {
+         return this.ends[index];
+      }
+
+      private BlockState blockState(int index) {
+         return this.blockStates[index];
+      }
+
+      private byte emittedLight(int index) {
+         return this.emittedLights[index];
+      }
+
+      private boolean intersectsSpan(int minY, int maxY) {
+         for (int i = 0; i < this.size; i++) {
+            if (this.ends[i] >= minY && this.starts[i] <= maxY) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+
+      private void addSpan(int startY, int endY, BlockState blockState, byte emittedLight) {
+         if (blockState == null || endY < startY) {
+            return;
+         }
+
+         int mergedStart = startY;
+         int mergedEnd = endY;
+         int insertAt = this.size;
+
+         for (int i = 0; i < this.size; i++) {
+            if (mergedEnd + 1 < this.starts[i]) {
+               insertAt = i;
+               break;
+            }
+
+            if (this.blockStates[i] == blockState
+               && this.emittedLights[i] == emittedLight
+               && mergedStart <= this.ends[i] + 1
+               && mergedEnd + 1 >= this.starts[i]) {
+               mergedStart = Math.min(mergedStart, this.starts[i]);
+               mergedEnd = Math.max(mergedEnd, this.ends[i]);
+               this.removeAt(i--);
+               insertAt = i + 1;
+            }
+         }
+
+         this.ensureCapacity(this.size + 1);
+         if (insertAt < this.size) {
+            System.arraycopy(this.starts, insertAt, this.starts, insertAt + 1, this.size - insertAt);
+            System.arraycopy(this.ends, insertAt, this.ends, insertAt + 1, this.size - insertAt);
+            System.arraycopy(this.blockStates, insertAt, this.blockStates, insertAt + 1, this.size - insertAt);
+            System.arraycopy(this.emittedLights, insertAt, this.emittedLights, insertAt + 1, this.size - insertAt);
+         }
+
+         this.starts[insertAt] = mergedStart;
+         this.ends[insertAt] = mergedEnd;
+         this.blockStates[insertAt] = blockState;
+         this.emittedLights[insertAt] = emittedLight;
+         this.size++;
+      }
+
+      private void removeAt(int index) {
+         if (index >= 0 && index < this.size) {
+            if (index + 1 < this.size) {
+               System.arraycopy(this.starts, index + 1, this.starts, index, this.size - index - 1);
+               System.arraycopy(this.ends, index + 1, this.ends, index, this.size - index - 1);
+               System.arraycopy(this.blockStates, index + 1, this.blockStates, index, this.size - index - 1);
+               System.arraycopy(this.emittedLights, index + 1, this.emittedLights, index, this.size - index - 1);
+            }
+
+            this.size--;
+         }
+      }
+
+      private void ensureCapacity(int capacity) {
+         if (capacity > this.starts.length) {
+            int newCapacity = Math.max(capacity, this.starts.length << 1);
+            this.starts = Arrays.copyOf(this.starts, newCapacity);
+            this.ends = Arrays.copyOf(this.ends, newCapacity);
+            this.blockStates = Arrays.copyOf(this.blockStates, newCapacity);
+            this.emittedLights = Arrays.copyOf(this.emittedLights, newCapacity);
+         }
+      }
+   }
+
+   private record SurfaceWrapperPair(IDhApiBlockStateWrapper top, IDhApiBlockStateWrapper filler) {
+   }
+
+   private record ChunkPrefetchKey(
+      int chunkX,
+      int chunkZ,
+      boolean includeRoadsPrefetch,
+      boolean includeBuildingsPrefetch,
+      boolean includeDetailedWaterPrefetch,
+      double previewResolutionMeters
+   ) {
+   }
+
+   private static final class LodSurfaceResolveProfiler implements EarthChunkGenerator.LodSurfaceProfiler {
+      private final LinkedHashMap<String, Long> phaseNanos = new LinkedHashMap<>();
+
+      @Override
+      public void addPhase(String phase, long nanos) {
+         this.phaseNanos.merge(phase, Math.max(0L, nanos), Long::sum);
+      }
+
+      private void flushTo(TellusLodGenerator.LodTimingTrace trace) {
+         for (Map.Entry<String, Long> entry : this.phaseNanos.entrySet()) {
+            trace.addPhase("emit.surfaceResolve." + entry.getKey(), entry.getValue());
+         }
+      }
+   }
+
+   private static final class LodTimingTrace {
+      private final boolean enabled;
+      private final int chunkPosMinX;
+      private final int chunkPosMinZ;
+      private final int detailLevel;
+      private final int lodSizePoints;
+      private final int cellSize;
+      private final EDhApiDistantGeneratorMode generatorMode;
+      private final EarthGeneratorSettings.DistantHorizonsRenderMode renderMode;
+      private final long startNanos;
+      private final LinkedHashMap<String, String> notes = new LinkedHashMap<>();
+      private final LinkedHashMap<String, String> stats = new LinkedHashMap<>();
+      private final LinkedHashMap<String, Long> phaseNanos = new LinkedHashMap<>();
+
+      private LodTimingTrace(
+         int chunkPosMinX,
+         int chunkPosMinZ,
+         byte detailLevel,
+         int lodSizePoints,
+         int cellSize,
+         EDhApiDistantGeneratorMode generatorMode,
+         EarthGeneratorSettings.DistantHorizonsRenderMode renderMode
+      ) {
+         this.enabled = LOD_TIMING_LOGGING;
+         this.chunkPosMinX = chunkPosMinX;
+         this.chunkPosMinZ = chunkPosMinZ;
+         this.detailLevel = Byte.toUnsignedInt(detailLevel);
+         this.lodSizePoints = lodSizePoints;
+         this.cellSize = cellSize;
+         this.generatorMode = generatorMode;
+         this.renderMode = renderMode;
+         this.startNanos = this.enabled ? System.nanoTime() : 0L;
+      }
+
+      private boolean isEnabled() {
+         return this.enabled;
+      }
+
+      private void note(String key, Object value) {
+         if (this.enabled) {
+            this.notes.put(key, String.valueOf(value));
+         }
+      }
+
+      private void addPhase(String phase, long nanos) {
+         if (this.enabled) {
+            this.phaseNanos.merge(phase, Math.max(0L, nanos), Long::sum);
+         }
+      }
+
+      private void stat(String key, Object value) {
+         if (this.enabled) {
+            this.stats.put(key, String.valueOf(value));
+         }
+      }
+
+      private void logSuccess() {
+         if (this.enabled) {
+            LOGGER.info(this.summary("success"));
+         }
+      }
+
+      private void logCancelled() {
+         if (this.enabled) {
+            LOGGER.info(this.summary("cancelled"));
+         }
+      }
+
+      private void logFailure(Throwable throwable) {
+         if (this.enabled) {
+            LOGGER.warn(this.summary("failed"), throwable);
+         }
+      }
+
+      private String summary(String status) {
+         StringBuilder builder = new StringBuilder(256);
+         builder.append("DH LOD timing status=").append(status);
+         builder.append(" chunk=[").append(this.chunkPosMinX).append(", ").append(this.chunkPosMinZ).append(']');
+         builder.append(" detail=").append(this.detailLevel);
+         builder.append(" width=").append(this.lodSizePoints);
+         builder.append(" cell=").append(this.cellSize);
+         builder.append(" genMode=").append(this.generatorMode);
+         builder.append(" render=").append(this.renderMode.id());
+         builder.append(" total=").append(formatMillis(System.nanoTime() - this.startNanos));
+         if (!this.notes.isEmpty()) {
+            builder.append(" notes={");
+            boolean first = true;
+            for (Map.Entry<String, String> entry : this.notes.entrySet()) {
+               if (!first) {
+                  builder.append(", ");
+               }
+
+               builder.append(entry.getKey()).append('=').append(entry.getValue());
+               first = false;
+            }
+
+            builder.append('}');
+         }
+
+         if (!this.phaseNanos.isEmpty()) {
+            builder.append(" phases={");
+            boolean first = true;
+            for (Map.Entry<String, Long> entry : this.phaseNanos.entrySet()) {
+               if (!first) {
+                  builder.append(", ");
+               }
+
+               builder.append(entry.getKey()).append('=').append(formatMillis(entry.getValue()));
+               first = false;
+            }
+
+            builder.append('}');
+         }
+
+         if (!this.stats.isEmpty()) {
+            builder.append(" stats={");
+            boolean first = true;
+            for (Map.Entry<String, String> entry : this.stats.entrySet()) {
+               if (!first) {
+                  builder.append(", ");
+               }
+
+               builder.append(entry.getKey()).append('=').append(entry.getValue());
+               first = false;
+            }
+
+            builder.append('}');
+         }
+
+         return builder.toString();
+      }
+
+      private static String formatMillis(long nanos) {
+         return String.format(Locale.ROOT, "%.3fms", (double)nanos / 1000000.0);
+      }
+   }
+
+   private static final class WaterVegetationColumn {
+      private final int height;
+      private final BlockState blockState;
+
+      private WaterVegetationColumn(int height, BlockState blockState) {
+         this.height = height;
+         this.blockState = blockState;
+      }
+   }
+
+   private static class WrapperCache {
+      private final IDhApiLevelWrapper levelWrapper;
+      private final IDhApiBlockStateWrapper airBlock;
+      private final IDhApiBiomeWrapper defaultBiome;
+      private final Map<BlockState, IDhApiBlockStateWrapper> blockStates = new IdentityHashMap<>();
+      private final Map<Holder<Biome>, IDhApiBiomeWrapper> biomes = new HashMap<>();
+
+      private WrapperCache(IDhApiLevelWrapper levelWrapper) {
+         this.levelWrapper = levelWrapper;
+         this.airBlock = Delayed.wrapperFactory.getAirBlockStateWrapper();
+         this.defaultBiome = this.lookupBiomeById(Biomes.PLAINS);
+      }
+
+      public IDhApiBlockStateWrapper airBlock() {
+         return this.airBlock;
+      }
+
+      public IDhApiBlockStateWrapper getBlockState(BlockState blockState) {
+         return this.blockStates.computeIfAbsent(blockState, this::lookupBlockState);
+      }
+
+      private IDhApiBlockStateWrapper lookupBlockState(BlockState blockState) {
+         try {
+            return Delayed.wrapperFactory.getBlockStateWrapper(new BlockState[]{blockState}, this.levelWrapper);
+         } catch (ClassCastException var3) {
+            throw new IllegalStateException(var3);
+         }
+      }
+
+      public IDhApiBiomeWrapper getBiome(Holder<Biome> biome) {
+         return this.biomes.computeIfAbsent(biome, this::lookupBiome);
+      }
+
+      private IDhApiBiomeWrapper lookupBiome(Holder<Biome> biome) {
+         IDhApiBiomeWrapper result = biome.unwrapKey().map(this::lookupBiomeById).orElse(null);
+         return result != null ? result : Objects.requireNonNull(this.defaultBiome, "No default biome available");
+      }
+
+      private IDhApiBiomeWrapper lookupBiomeById(ResourceKey<Biome> biome) {
+         try {
+            return Delayed.wrapperFactory.getBiomeWrapper(biome.location().toString(), this.levelWrapper);
+         } catch (IOException var3) {
+            TellusLodGenerator.LOGGER.warn("Could not find biome with id {}, will not use for LODs", biome.location());
+            return null;
+         }
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/integration/voxy/TellusVoxyPregenManager.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/integration/voxy/TellusVoxyPregenManager.java
@@ -1,0 +1,514 @@
+package com.yucareux.tellus.integration.voxy;
+
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
+import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
+
+public final class TellusVoxyPregenManager {
+   private static final long TICK_NANOS = 50000000L;
+   private static final long SOFT_OVERLOAD_TICK_NANOS = 55000000L;
+   private static final long HARD_OVERLOAD_TICK_NANOS = 70000000L;
+   private static final int MAX_QUEUE_SIZE = 50000;
+   private static final int IN_FLIGHT_MULTIPLIER = 4;
+   private static final int ABSOLUTE_MAX_IN_FLIGHT = 256;
+   private static final int COMPLETED_CACHE_MAX = 200000;
+   private static final int TELEPORT_REPRIORITIZE_DISTANCE_CHUNKS = 64;
+   private static final int MOVEMENT_REPRIORITIZE_DISTANCE_CHUNKS = 16;
+   private static final int REPRIORITIZE_IN_FLIGHT_KEEP_RADIUS_CHUNKS = 16;
+   private static final int REPRIORITIZE_RADIUS_PADDING_CHUNKS = 8;
+   private static final int PRIORITY_RADIUS_CHUNKS = 2;
+   private static final int STALE_QUEUE_PRUNE_TRIGGER = 10000;
+   private final LongArrayFIFOQueue queue = new LongArrayFIFOQueue();
+   private final LongOpenHashSet queued = new LongOpenHashSet();
+   private final LongArrayFIFOQueue priorityQueue = new LongArrayFIFOQueue();
+   private final LongOpenHashSet priorityQueued = new LongOpenHashSet();
+   private final LongLinkedOpenHashSet completedChunks = new LongLinkedOpenHashSet();
+   private final Map<UUID, TellusVoxyPregenManager.PlayerPregenState> playerStates = new HashMap<>();
+   private final Set<Long> inFlight = ConcurrentHashMap.newKeySet();
+   
+   private volatile Boolean enabledOverride;
+   
+   private volatile Integer maxRadiusOverride;
+   
+   private volatile Integer chunksPerTickOverride;
+   private volatile int lastConfiguredVoxyRadiusChunks;
+   private volatile int lastEffectiveRadiusChunks;
+
+   public void onServerTick(MinecraftServer server) {
+      ServerLevel level = server.getLevel(Level.OVERWORLD);
+      if (level == null) {
+         this.clearQueueAndPlayerState();
+         this.lastConfiguredVoxyRadiusChunks = 0;
+         this.lastEffectiveRadiusChunks = 0;
+      } else if (level.getChunkSource().getGenerator() instanceof EarthChunkGenerator earthGenerator) {
+         EarthGeneratorSettings var11 = earthGenerator.settings();
+         if (!this.effectiveEnabled(var11)) {
+            this.clearQueueAndPlayerState();
+            this.lastConfiguredVoxyRadiusChunks = 0;
+            this.lastEffectiveRadiusChunks = 0;
+         } else if (!VoxyBridge.isVoxyLoaded()) {
+            this.clearQueueAndPlayerState();
+            this.lastConfiguredVoxyRadiusChunks = 0;
+            this.lastEffectiveRadiusChunks = 0;
+         } else {
+            int configuredVoxyRadius = Math.max(0, VoxyBridge.configuredChunkRadius());
+            this.lastConfiguredVoxyRadiusChunks = configuredVoxyRadius;
+            int targetRadius = Math.min(configuredVoxyRadius, this.effectiveMaxRadius(var11));
+            this.lastEffectiveRadiusChunks = targetRadius;
+            if (targetRadius <= 0) {
+               this.clearQueueAndPlayerState();
+            } else {
+               List<ServerPlayer> players = overworldPlayers(server, level);
+               if (players.isEmpty()) {
+                  this.clearQueueAndPlayerState();
+               } else {
+                  boolean movedPlayers = this.enqueueAroundPlayers(players, targetRadius);
+                  if (movedPlayers) {
+                     this.refreshPriorityQueue(players, targetRadius);
+                     if (this.queue.size() >= STALE_QUEUE_PRUNE_TRIGGER) {
+                        this.pruneNormalQueue(players, targetRadius + REPRIORITIZE_RADIUS_PADDING_CHUNKS);
+                     }
+                  }
+
+                  long averageTickNanos = server.getAverageTickTimeNanos();
+                  this.processQueue(server, level.getChunkSource(), this.effectiveChunksPerTick(var11), averageTickNanos);
+               }
+            }
+         }
+      } else {
+         this.clearQueueAndPlayerState();
+         this.lastConfiguredVoxyRadiusChunks = 0;
+         this.lastEffectiveRadiusChunks = 0;
+      }
+   }
+
+   public void shutdown() {
+      this.clearQueueAndPlayerState();
+      this.inFlight.clear();
+      this.clearOverrides();
+      this.lastConfiguredVoxyRadiusChunks = 0;
+      this.lastEffectiveRadiusChunks = 0;
+   }
+
+   public void clearOverrides() {
+      this.enabledOverride = null;
+      this.maxRadiusOverride = null;
+      this.chunksPerTickOverride = null;
+   }
+
+   public void setEnabledOverride( Boolean enabled) {
+      this.enabledOverride = enabled;
+   }
+
+   public void setMaxRadiusOverride( Integer maxRadius) {
+      this.maxRadiusOverride = maxRadius;
+   }
+
+   public void setChunksPerTickOverride( Integer chunksPerTick) {
+      this.chunksPerTickOverride = chunksPerTick;
+   }
+
+   public boolean effectiveEnabled(EarthGeneratorSettings settings) {
+      Boolean override = this.enabledOverride;
+      return override != null ? override : settings.voxyChunkPregenEnabled();
+   }
+
+   public int effectiveMaxRadius(EarthGeneratorSettings settings) {
+      Integer override = this.maxRadiusOverride;
+      return Math.max(0, override != null ? override : settings.voxyChunkPregenMaxRadius());
+   }
+
+   public int effectiveChunksPerTick(EarthGeneratorSettings settings) {
+      Integer override = this.chunksPerTickOverride;
+      return Math.max(1, override != null ? override : settings.voxyChunkPregenChunksPerTick());
+   }
+
+   
+   public Boolean enabledOverride() {
+      return this.enabledOverride;
+   }
+
+   
+   public Integer maxRadiusOverride() {
+      return this.maxRadiusOverride;
+   }
+
+   
+   public Integer chunksPerTickOverride() {
+      return this.chunksPerTickOverride;
+   }
+
+   public int queuedChunkCount() {
+      return this.queue.size() + this.priorityQueue.size();
+   }
+
+   public int inFlightChunkCount() {
+      return this.inFlight.size();
+   }
+
+   public int lastConfiguredVoxyRadiusChunks() {
+      return this.lastConfiguredVoxyRadiusChunks;
+   }
+
+   public int lastEffectiveRadiusChunks() {
+      return this.lastEffectiveRadiusChunks;
+   }
+
+   private static List<ServerPlayer> overworldPlayers(MinecraftServer server, ServerLevel level) {
+      List<ServerPlayer> players = new ArrayList<>();
+
+      for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+         if (player.level() == level) {
+            players.add(player);
+         }
+      }
+
+      return players;
+   }
+
+   private boolean enqueueAroundPlayers(List<ServerPlayer> players, int radius) {
+      Set<UUID> active = new HashSet<>();
+      boolean reprioritize = false;
+      boolean movedPlayers = false;
+
+      for (ServerPlayer player : players) {
+         active.add(player.getUUID());
+         TellusVoxyPregenManager.PlayerPregenState state = this.playerStates
+            .computeIfAbsent(player.getUUID(), ignored -> new TellusVoxyPregenManager.PlayerPregenState());
+         ChunkPos center = player.chunkPosition();
+         if (state.centerX != center.x || state.centerZ != center.z) {
+            movedPlayers = true;
+            if (state.centerX != Integer.MIN_VALUE && state.centerZ != Integer.MIN_VALUE) {
+               int jumpDistance = chebyshevChunkDistance(state.centerX, state.centerZ, center.x, center.z);
+               boolean requiresReprioritize = jumpDistance >= TELEPORT_REPRIORITIZE_DISTANCE_CHUNKS;
+               if (!requiresReprioritize) {
+                  if (state.anchorX == Integer.MIN_VALUE || state.anchorZ == Integer.MIN_VALUE) {
+                     state.anchorX = state.centerX;
+                     state.anchorZ = state.centerZ;
+                  }
+
+                  int driftFromAnchor = chebyshevChunkDistance(state.anchorX, state.anchorZ, center.x, center.z);
+                  requiresReprioritize = driftFromAnchor >= MOVEMENT_REPRIORITIZE_DISTANCE_CHUNKS;
+               }
+
+               if (requiresReprioritize) {
+                  reprioritize = true;
+                  state.nextRing = 0;
+                  state.anchorX = center.x;
+                  state.anchorZ = center.z;
+               } else {
+                  state.nextRing = Math.max(0, state.nextRing - jumpDistance);
+               }
+
+               state.centerX = center.x;
+               state.centerZ = center.z;
+            } else {
+               state.centerX = center.x;
+               state.centerZ = center.z;
+               state.anchorX = center.x;
+               state.anchorZ = center.z;
+               state.nextRing = 0;
+            }
+         }
+      }
+
+      this.playerStates.entrySet().removeIf(entry -> !active.contains(entry.getKey()));
+      if (reprioritize) {
+         this.reprioritizeForCurrentPlayers(players, radius);
+      }
+
+      for (ServerPlayer playerx : players) {
+         TellusVoxyPregenManager.PlayerPregenState state = this.playerStates.get(playerx.getUUID());
+         if (state != null && state.nextRing <= radius && this.queue.size() < MAX_QUEUE_SIZE) {
+            this.enqueueRing(state.centerX, state.centerZ, state.nextRing);
+            state.nextRing++;
+         }
+      }
+
+      return movedPlayers;
+   }
+
+   private void reprioritizeForCurrentPlayers(List<ServerPlayer> players, int radius) {
+      this.queue.clear();
+      this.queued.clear();
+      int keepRadius = Math.min(radius + REPRIORITIZE_RADIUS_PADDING_CHUNKS, REPRIORITIZE_IN_FLIGHT_KEEP_RADIUS_CHUNKS);
+      this.releaseFarInFlight(players, keepRadius);
+      this.priorityQueue.clear();
+      this.priorityQueued.clear();
+
+      for (ServerPlayer player : players) {
+         ChunkPos pos = player.chunkPosition();
+         this.enqueueChunk(pos.x, pos.z);
+         this.enqueuePriorityChunk(pos.x, pos.z);
+      }
+   }
+
+   private void refreshPriorityQueue(List<ServerPlayer> players, int radius) {
+      int localRadius = Math.min(PRIORITY_RADIUS_CHUNKS, radius);
+      this.prunePriorityQueue(players, localRadius + PRIORITY_RADIUS_CHUNKS);
+
+      for (ServerPlayer player : players) {
+         ChunkPos center = player.chunkPosition();
+
+         for (int ring = 0; ring <= localRadius; ring++) {
+            this.enqueuePriorityRing(center.x, center.z, ring);
+         }
+      }
+   }
+
+   private void prunePriorityQueue(List<ServerPlayer> players, int keepRadius) {
+      if (!this.priorityQueue.isEmpty()) {
+         int size = this.priorityQueue.size();
+         LongArrayFIFOQueue retained = new LongArrayFIFOQueue(size);
+         this.priorityQueued.clear();
+
+         for (int i = 0; i < size; i++) {
+            long key = this.priorityQueue.dequeueLong();
+            if (isNearAnyPlayer(players, key, keepRadius) && this.priorityQueued.add(key)) {
+               retained.enqueue(key);
+            }
+         }
+
+         this.priorityQueue.clear();
+
+         while (!retained.isEmpty()) {
+            this.priorityQueue.enqueue(retained.dequeueLong());
+         }
+      }
+   }
+
+   private void pruneNormalQueue(List<ServerPlayer> players, int keepRadius) {
+      if (!this.queue.isEmpty()) {
+         int size = this.queue.size();
+         LongArrayFIFOQueue retained = new LongArrayFIFOQueue(size);
+
+         for (int i = 0; i < size; i++) {
+            long key = this.queue.dequeueLong();
+            if (this.queued.contains(key)) {
+               if (!isNearAnyPlayer(players, key, keepRadius)) {
+                  this.queued.remove(key);
+               } else {
+                  retained.enqueue(key);
+               }
+            }
+         }
+
+         this.queue.clear();
+
+         while (!retained.isEmpty()) {
+            long key = retained.dequeueLong();
+            if (this.queued.contains(key)) {
+               this.queue.enqueue(key);
+            }
+         }
+      }
+   }
+
+   private void releaseFarInFlight(List<ServerPlayer> players, int keepRadius) {
+      for (long key : this.inFlight) {
+         if (!isNearAnyPlayer(players, key, keepRadius)) {
+            this.inFlight.remove(key);
+         }
+      }
+   }
+
+   private static boolean isNearAnyPlayer(List<ServerPlayer> players, long chunkKey, int radius) {
+      int chunkX = ChunkPos.getX(chunkKey);
+      int chunkZ = ChunkPos.getZ(chunkKey);
+
+      for (ServerPlayer player : players) {
+         ChunkPos center = player.chunkPosition();
+         if (chebyshevChunkDistance(center.x, center.z, chunkX, chunkZ) <= radius) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private static int chebyshevChunkDistance(int xA, int zA, int xB, int zB) {
+      long dx = Math.abs((long)xA - xB);
+      long dz = Math.abs((long)zA - zB);
+      return (int)Math.min(2147483647L, Math.max(dx, dz));
+   }
+
+   private void enqueueRing(int centerX, int centerZ, int ring) {
+      if (ring <= 0) {
+         this.enqueueChunk(centerX, centerZ);
+      } else {
+         int minX = centerX - ring;
+         int maxX = centerX + ring;
+         int minZ = centerZ - ring;
+         int maxZ = centerZ + ring;
+
+         for (int x = minX; x <= maxX; x++) {
+            this.enqueueChunk(x, minZ);
+            if (maxZ != minZ) {
+               this.enqueueChunk(x, maxZ);
+            }
+         }
+
+         for (int z = minZ + 1; z < maxZ; z++) {
+            this.enqueueChunk(minX, z);
+            if (maxX != minX) {
+               this.enqueueChunk(maxX, z);
+            }
+         }
+      }
+   }
+
+   private void enqueueChunk(int chunkX, int chunkZ) {
+      long key = ChunkPos.asLong(chunkX, chunkZ);
+      if (!this.completedChunks.contains(key)) {
+         if (this.queued.add(key)) {
+            this.queue.enqueue(key);
+         }
+      }
+   }
+
+   private void enqueuePriorityRing(int centerX, int centerZ, int ring) {
+      if (ring <= 0) {
+         this.enqueuePriorityChunk(centerX, centerZ);
+      } else {
+         int minX = centerX - ring;
+         int maxX = centerX + ring;
+         int minZ = centerZ - ring;
+         int maxZ = centerZ + ring;
+
+         for (int x = minX; x <= maxX; x++) {
+            this.enqueuePriorityChunk(x, minZ);
+            if (maxZ != minZ) {
+               this.enqueuePriorityChunk(x, maxZ);
+            }
+         }
+
+         for (int z = minZ + 1; z < maxZ; z++) {
+            this.enqueuePriorityChunk(minX, z);
+            if (maxX != minX) {
+               this.enqueuePriorityChunk(maxX, z);
+            }
+         }
+      }
+   }
+
+   private void enqueuePriorityChunk(int chunkX, int chunkZ) {
+      long key = ChunkPos.asLong(chunkX, chunkZ);
+      if (!this.completedChunks.contains(key)) {
+         if (this.priorityQueued.add(key)) {
+            this.priorityQueue.enqueue(key);
+         }
+      }
+   }
+
+   private void processQueue(MinecraftServer server, ServerChunkCache source, int chunksPerTick, long averageTickNanos) {
+      int launchBudget = this.effectiveLaunchBudget(chunksPerTick, averageTickNanos);
+      if (launchBudget > 0) {
+         int maxInFlight = Math.min(ABSOLUTE_MAX_IN_FLIGHT, Math.max(launchBudget + 1, launchBudget * IN_FLIGHT_MULTIPLIER));
+         int launched = 0;
+
+         while (launched < launchBudget) {
+            if (this.inFlight.size() >= maxInFlight) {
+               return;
+            }
+
+            Long polled = this.pollNextChunk();
+            if (polled == null) {
+               return;
+            }
+
+            long key = polled;
+            if (!this.inFlight.contains(key) && this.inFlight.add(key)) {
+               int chunkX = ChunkPos.getX(key);
+               int chunkZ = ChunkPos.getZ(key);
+               source.getChunkFuture(chunkX, chunkZ, ChunkStatus.FULL, true).whenComplete((result, error) -> {
+                  this.inFlight.remove(key);
+                  if (error == null && result != null && result.isSuccess()) {
+                     result.ifSuccess(chunk -> this.ingestIfLevelChunk(server, chunk, key));
+                  }
+               });
+               launched++;
+            }
+         }
+      }
+   }
+
+   private int effectiveLaunchBudget(int chunksPerTick, long averageTickNanos) {
+      int base = Math.max(1, chunksPerTick);
+      if (averageTickNanos >= HARD_OVERLOAD_TICK_NANOS) {
+         return 0;
+      } else if (averageTickNanos >= SOFT_OVERLOAD_TICK_NANOS) {
+         return 1;
+      } else if (averageTickNanos >= TICK_NANOS) {
+         return Math.max(1, base / 2);
+      } else {
+         return averageTickNanos < TICK_NANOS - 10000000L ? Math.min(base + Math.max(1, base / 2), ABSOLUTE_MAX_IN_FLIGHT) : base;
+      }
+   }
+
+   
+   private Long pollNextChunk() {
+      if (!this.priorityQueue.isEmpty()) {
+         long key = this.priorityQueue.dequeueLong();
+         this.priorityQueued.remove(key);
+         this.queued.remove(key);
+         return key;
+      } else {
+         while (!this.queue.isEmpty()) {
+            long key = this.queue.dequeueLong();
+            if (this.queued.remove(key)) {
+               return key;
+            }
+         }
+
+         return null;
+      }
+   }
+
+   private void ingestIfLevelChunk(MinecraftServer server, ChunkAccess chunk, long chunkKey) {
+      if (chunk instanceof LevelChunk levelChunk) {
+         this.recordCompletedChunk(chunkKey);
+         VoxyBridge.tryIngestChunkAsync(server, levelChunk);
+      }
+   }
+
+   private void recordCompletedChunk(long chunkKey) {
+      if (this.completedChunks.addAndMoveToLast(chunkKey) && this.completedChunks.size() > COMPLETED_CACHE_MAX) {
+         this.completedChunks.removeFirstLong();
+      }
+   }
+
+   private void clearQueueAndPlayerState() {
+      this.queue.clear();
+      this.queued.clear();
+      this.priorityQueue.clear();
+      this.priorityQueued.clear();
+      this.playerStates.clear();
+   }
+
+   private static final class PlayerPregenState {
+      private int centerX = Integer.MIN_VALUE;
+      private int centerZ = Integer.MIN_VALUE;
+      private int anchorX = Integer.MIN_VALUE;
+      private int anchorZ = Integer.MIN_VALUE;
+      private int nextRing;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/integration/voxy/VoxyBridge.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/integration/voxy/VoxyBridge.java
@@ -1,0 +1,158 @@
+package com.yucareux.tellus.integration.voxy;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.yucareux.tellus.Tellus;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLPaths;
+
+final class VoxyBridge {
+   private static final String VOXY_MOD_ID = "voxy";
+   private static final String VOXY_CONFIG_FILE = "voxy-config.json";
+   private static final int DEFAULT_SECTION_RENDER_DISTANCE = 16;
+   private static final int VOXY_CHUNKS_PER_SECTION = 32;
+   private static final int MIN_SECTION_RENDER_DISTANCE = 2;
+   private static final int MAX_SECTION_RENDER_DISTANCE = 64;
+   private static final long CONFIG_REFRESH_MS = 2000L;
+   private static final Object CONFIG_LOCK = new Object();
+   private static final AtomicBoolean LOGGED_CONFIG_ERROR = new AtomicBoolean(false);
+   private static volatile int cachedSectionRenderDistance = 16;
+   private static volatile long cachedConfigModifiedMs = Long.MIN_VALUE;
+   private static volatile long nextConfigRefreshMs = 0L;
+   private static final Object INGEST_LOCK = new Object();
+   private static final AtomicBoolean LOGGED_INGEST_ERROR = new AtomicBoolean(false);
+
+   private static volatile Method ingestMethod;
+   private static volatile boolean ingestMethodResolved;
+
+   private VoxyBridge() {
+   }
+
+   static boolean isVoxyLoaded() {
+      return ModList.get().isLoaded(VOXY_MOD_ID);
+   }
+
+   static int configuredChunkRadius() {
+      int sectionRenderDistance = configuredSectionRenderDistance();
+      return sectionRenderDistance * VOXY_CHUNKS_PER_SECTION;
+   }
+
+   private static int configuredSectionRenderDistance() {
+      if (!isVoxyLoaded()) {
+         return 0;
+      } else {
+         long now = System.currentTimeMillis();
+         if (now < nextConfigRefreshMs) {
+            return cachedSectionRenderDistance;
+         } else {
+            synchronized (CONFIG_LOCK) {
+               if (now < nextConfigRefreshMs) {
+                  return cachedSectionRenderDistance;
+               } else {
+                  refreshConfig(now);
+                  return cachedSectionRenderDistance;
+               }
+            }
+         }
+      }
+   }
+
+   private static void refreshConfig(long now) {
+      nextConfigRefreshMs = now + CONFIG_REFRESH_MS;
+      Path path = configPath();
+      if (!Files.exists(path)) {
+         cachedSectionRenderDistance = DEFAULT_SECTION_RENDER_DISTANCE;
+         cachedConfigModifiedMs = Long.MIN_VALUE;
+      } else {
+         try {
+            long modifiedMs = Files.getLastModifiedTime(path).toMillis();
+            if (cachedConfigModifiedMs == modifiedMs) {
+               return;
+            }
+
+            cachedConfigModifiedMs = modifiedMs;
+            cachedSectionRenderDistance = readSectionRenderDistance(path);
+            LOGGED_CONFIG_ERROR.set(false);
+         } catch (IOException var5) {
+            cachedSectionRenderDistance = DEFAULT_SECTION_RENDER_DISTANCE;
+            if (LOGGED_CONFIG_ERROR.compareAndSet(false, true)) {
+               Tellus.LOGGER.warn("Failed to read Voxy config from {}", path, var5);
+            }
+         }
+      }
+   }
+
+   private static int readSectionRenderDistance(Path path) throws IOException {
+      try {
+         byte var3;
+         try (Reader reader = Files.newBufferedReader(path)) {
+            JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+            if (root != null && root.has("section_render_distance")) {
+               return Mth.clamp(root.get("section_render_distance").getAsInt(), MIN_SECTION_RENDER_DISTANCE, MAX_SECTION_RENDER_DISTANCE);
+            }
+
+            var3 = DEFAULT_SECTION_RENDER_DISTANCE;
+         }
+
+         return var3;
+      } catch (RuntimeException var6) {
+         throw new IOException("Invalid Voxy config structure", var6);
+      }
+   }
+
+   private static Path configPath() {
+      return FMLPaths.CONFIGDIR.get().resolve(VOXY_CONFIG_FILE);
+   }
+
+   static void tryIngestChunkAsync(MinecraftServer server, LevelChunk chunk) {
+      if (isVoxyLoaded()) {
+         server.execute(() -> tryIngestChunkOnServerThread(chunk));
+      }
+   }
+
+   private static void tryIngestChunkOnServerThread(LevelChunk chunk) {
+      Method method = resolveIngestMethod();
+      if (method != null) {
+         try {
+            method.invoke(null, chunk);
+            LOGGED_INGEST_ERROR.set(false);
+         } catch (RuntimeException | ReflectiveOperationException var3) {
+            if (LOGGED_INGEST_ERROR.compareAndSet(false, true)) {
+               Tellus.LOGGER.warn("Failed to invoke Voxy chunk ingest bridge", var3);
+            }
+         }
+      }
+   }
+
+   private static Method resolveIngestMethod() {
+      if (ingestMethodResolved) {
+         return ingestMethod;
+      } else {
+         synchronized (INGEST_LOCK) {
+            if (ingestMethodResolved) {
+               return ingestMethod;
+            } else {
+               try {
+                  Class<?> serviceClass = Class.forName("me.cortex.voxy.common.world.service.VoxelIngestService");
+                  ingestMethod = serviceClass.getMethod("tryAutoIngestChunk", LevelChunk.class);
+               } catch (ReflectiveOperationException var3) {
+                  Tellus.LOGGER.debug("Voxy ingest bridge unavailable", var3);
+                  ingestMethod = null;
+               }
+
+               ingestMethodResolved = true;
+               return ingestMethod;
+            }
+         }
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/mixin/client/LevelLoadingScreenMixin.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/mixin/client/LevelLoadingScreenMixin.java
@@ -1,0 +1,104 @@
+package com.yucareux.tellus.mixin.client;
+
+import com.yucareux.tellus.client.LoadingTerrainScreenTiming;
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.LevelLoadingScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.FormattedCharSequence;
+import net.minecraft.world.level.Level;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@OnlyIn(Dist.CLIENT)
+@Mixin({LevelLoadingScreen.class})
+public abstract class LevelLoadingScreenMixin {
+   private static final int TEXT_COLOR = -1710619;
+   private static final int TEXT_PADDING = 20;
+   private static final int LINE_SPACING = 2;
+   private static final int MAX_TEXT_WIDTH = 420;
+   private static final int LOADING_WIDGET_HALF_HEIGHT = 42;
+   private static final int LOADING_WIDGET_TEXT_GAP = 16;
+   private static final List<Component> CONTRIBUTIONS = List.of(
+      Component.literal("Land cover: © ESA WorldCover project / Contains modified Copernicus Sentinel data (2021) processed by ESA WorldCover consortium."),
+      Component.literal("Climate zones: Köppen–Geiger climate classification (Beck et al., 2018) — CC BY 4.0."),
+      Component.literal("Elevation: swissALTI3D / Terrain Tiles / AHN / CANElevation / USGS 3DEP / Copernicus DEM / ArcticDEM/REMA — see Data Sources for required DEM attributions."),
+      Component.literal("Weather: Weather data by Open-Meteo.com (https://open-meteo.com/)")
+   );
+   @Inject(
+      method = {"render"},
+      at = {@At("HEAD")}
+   )
+   private void tellus$trackLoadingTerrainScreen(GuiGraphics graphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+      LoadingTerrainScreenTiming.onScreenRender((LevelLoadingScreen)(Object)this, "level_loading");
+   }
+
+   @Inject(
+      method = {"render"},
+      at = {@At("TAIL")}
+   )
+   private void tellus$renderContributions(GuiGraphics graphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+      if (!tellus$isLoadingTellusWorld()) {
+         return;
+      }
+
+      Font font = Minecraft.getInstance().font;
+      int width = Minecraft.getInstance().getWindow().getGuiScaledWidth();
+      int height = Minecraft.getInstance().getWindow().getGuiScaledHeight();
+      int availableWidth = Math.max(TEXT_PADDING * 2, width - TEXT_PADDING * 2);
+      int wrapWidth = Math.min(MAX_TEXT_WIDTH, availableWidth);
+      List<FormattedCharSequence> lines = new ArrayList<>();
+
+      for (Component line : CONTRIBUTIONS) {
+         for (FormattedCharSequence wrapped : font.split(line, wrapWidth)) {
+            lines.add(Objects.requireNonNull(wrapped, "wrappedLine"));
+         }
+      }
+
+      if (!lines.isEmpty()) {
+         int totalHeight = lines.size() * font.lineHeight + (lines.size() - 1) * LINE_SPACING;
+         int centerX = width / 2;
+         int y = tellus$getTextY(height, totalHeight);
+
+         for (FormattedCharSequence line : lines) {
+            int lineWidth = font.width(line);
+            int x = centerX - lineWidth / 2;
+            graphics.drawString(font, line, x, y, TEXT_COLOR, true);
+            y += font.lineHeight + LINE_SPACING;
+         }
+      }
+   }
+
+   private static int tellus$getTextY(int height, int totalHeight) {
+      int centerY = height / 2;
+      int bottomY = height - totalHeight - TEXT_PADDING;
+      int belowLoadingWidgetY = centerY + LOADING_WIDGET_HALF_HEIGHT + LOADING_WIDGET_TEXT_GAP;
+      if (belowLoadingWidgetY <= bottomY) {
+         return belowLoadingWidgetY;
+      }
+
+      int aboveLoadingWidgetY = centerY - LOADING_WIDGET_HALF_HEIGHT - LOADING_WIDGET_TEXT_GAP - totalHeight;
+      return Math.max(TEXT_PADDING, Math.min(aboveLoadingWidgetY, bottomY));
+   }
+
+   private static boolean tellus$isLoadingTellusWorld() {
+      MinecraftServer server = Minecraft.getInstance().getSingleplayerServer();
+      if (server == null) {
+         return false;
+      }
+
+      ServerLevel overworld = server.getLevel(Level.OVERWORLD);
+      return overworld != null && overworld.getChunkSource().getGenerator() instanceof EarthChunkGenerator;
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/mixin/client/MinecraftScreenMixin.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/mixin/client/MinecraftScreenMixin.java
@@ -1,0 +1,27 @@
+package com.yucareux.tellus.mixin.client;
+
+import com.yucareux.tellus.client.LoadingTerrainScreenTiming;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@OnlyIn(Dist.CLIENT)
+@Mixin({Minecraft.class})
+public abstract class MinecraftScreenMixin {
+   @Shadow
+   public Screen screen;
+
+   @Inject(
+      method = {"setScreen"},
+      at = {@At("HEAD")}
+   )
+   private void tellus$trackLoadingTerrainScreen(Screen newScreen, CallbackInfo ci) {
+      LoadingTerrainScreenTiming.onScreenChange(this.screen, newScreen);
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/mixin/client/PresetEditorMixin.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/mixin/client/PresetEditorMixin.java
@@ -1,0 +1,33 @@
+package com.yucareux.tellus.mixin.client;
+
+import com.yucareux.tellus.client.screen.EarthCustomizeScreen;
+import com.yucareux.tellus.worldgen.TellusWorldPresets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import net.minecraft.client.gui.screens.worldselection.PresetEditor;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@OnlyIn(Dist.CLIENT)
+@Mixin({PresetEditor.class})
+public interface PresetEditorMixin {
+   @Redirect(
+      method = {"<clinit>"},
+      at = @At(
+         value = "INVOKE",
+         target = "Ljava/util/Map;of(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/Map;"
+      )
+   )
+   private static Map<Object, Object> tellus$addEarthEditor(Object key1, Object value1, Object key2, Object value2) {
+      Map<Object, Object> editors = new HashMap<>();
+      PresetEditor earthEditor = EarthCustomizeScreen::new;
+      editors.put(key1, value1);
+      editors.put(key2, value2);
+      editors.put(Optional.of(TellusWorldPresets.EARTH), earthEditor);
+      return Map.copyOf(editors);
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/cover/TellusLandCoverSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/cover/TellusLandCoverSource.java
@@ -1,0 +1,1232 @@
+package com.yucareux.tellus.world.data.cover;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class TellusLandCoverSource implements TellusCacheHandle {
+   private static final double MIN_LAT = -60.0;
+   private static final double MAX_LAT = 84.0;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final int TILE_DEGREES = 3;
+   private static final int SNOW_ICE_CLASS = 70;
+   private static final int WATER_CLASS = 80;
+   private static final int MANGROVES_CLASS = 95;
+   private static final int BUILT_UP_CLASS = 50;
+   private static final int NO_DATA_CLASS = 0;
+   private static final int MAX_CACHE_TILES = intProperty("tellus.landcover.cacheTiles", 64);
+   private static final double RESOLUTION_METERS = 10.0;
+   private static final int TILE_CACHE_ENTRIES = intProperty("tellus.landcover.tileCacheEntries", 32);
+   private static final int SMOOTH_RADIUS_PIXELS = 1;
+   private static final ThreadLocal<TellusLandCoverSource.CoverSmoothScratch> COVER_SMOOTH_SCRATCH = ThreadLocal.withInitial(
+      TellusLandCoverSource.CoverSmoothScratch::new
+   );
+   private static final ThreadLocal<TellusLandCoverSource.CoverBlendScratch> COVER_BLEND_SCRATCH = ThreadLocal.withInitial(
+      TellusLandCoverSource.CoverBlendScratch::new
+   );
+   private static final String ENDPOINT = "https://esa-worldcover.s3.eu-central-1.amazonaws.com/v200/2021/map";
+   private static final String TILE_PATTERN = "ESA_WorldCover_10m_2021_v200_%s_Map.tif";
+   private final Path cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/worldcover2021");
+   private final LoadingCache<TellusLandCoverSource.TileKey, TellusLandCoverSource.GeoTiffTile> cache = CacheBuilder.newBuilder()
+      .maximumSize(MAX_CACHE_TILES)
+      .removalListener(notification -> {
+         TellusLandCoverSource.GeoTiffTile tile = (TellusLandCoverSource.GeoTiffTile)notification.getValue();
+         if (tile != null) {
+            tile.close();
+         }
+      })
+      .build(new CacheLoader<TellusLandCoverSource.TileKey, TellusLandCoverSource.GeoTiffTile>() {
+         public TellusLandCoverSource.GeoTiffTile load(TellusLandCoverSource.TileKey key) throws Exception {
+            return TellusLandCoverSource.this.loadTile(key);
+         }
+      });
+
+   public TellusLandCoverSource() {
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isSnowIce(double blockX, double blockZ, double worldScale) {
+      return this.sampleCoverClass(blockX, blockZ, worldScale) == SNOW_ICE_CLASS;
+   }
+
+   public int sampleCoverClass(double blockX, double blockZ, double worldScale) {
+      return this.sampleCoverClass(blockX, blockZ, worldScale, worldScale);
+   }
+
+   public int sampleCoverClass(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      return this.sampleCoverClass(blockX, blockZ, worldScale, previewResolutionMeters, false);
+   }
+
+   public int sampleCoverClassLocalOnly(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      return this.sampleCoverClass(blockX, blockZ, worldScale, previewResolutionMeters, true);
+   }
+
+   public int sampleCoverClassMemoryOnly(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      if (worldScale <= 0.0) {
+         return Integer.MIN_VALUE;
+      } else {
+         int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleCoverClassAtLonLatMemoryOnly(lon, lat);
+      }
+   }
+
+   private int sampleCoverClass(double blockX, double blockZ, double worldScale, double previewResolutionMeters, boolean localOnly) {
+      if (worldScale <= 0.0) {
+         return 0;
+      } else {
+         int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return localOnly ? this.sampleCoverClassAtLonLatLocalOnly(lon, lat) : this.sampleCoverClassAtLonLat(lon, lat);
+      }
+   }
+
+   public int sampleSmoothedCoverClass(double blockX, double blockZ, double worldScale) {
+      return this.sampleSmoothedCoverClass(blockX, blockZ, worldScale, worldScale);
+   }
+
+   public int sampleSmoothedCoverClass(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      if (worldScale <= 0.0) {
+         return 0;
+      } else {
+         int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleSmoothedCoverClassAtLonLat(lon, lat, SMOOTH_RADIUS_PIXELS);
+      }
+   }
+
+   public int sampleVisualCoverClass(double blockX, double blockZ, double worldScale) {
+      return this.sampleVisualCoverClass(blockX, blockZ, worldScale, worldScale);
+   }
+
+   public int sampleVisualCoverClass(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      return this.sampleVisualCoverClass(blockX, blockZ, worldScale, previewResolutionMeters, false);
+   }
+
+   public int sampleVisualCoverClassLocalOnly(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      return this.sampleVisualCoverClass(blockX, blockZ, worldScale, previewResolutionMeters, true);
+   }
+
+   public int sampleVisualCoverClassMemoryOnly(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      if (worldScale <= 0.0) {
+         return Integer.MIN_VALUE;
+      } else {
+         int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleVisualCoverClassAtLonLatMemoryOnly(
+            lon, lat, blockX, blockZ, effectiveSampleResolutionMeters(worldScale, previewResolutionMeters)
+         );
+      }
+   }
+
+   private int sampleVisualCoverClass(double blockX, double blockZ, double worldScale, double previewResolutionMeters, boolean localOnly) {
+      if (worldScale <= 0.0) {
+         return 0;
+      } else {
+         int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return localOnly
+            ? this.sampleVisualCoverClassAtLonLatLocalOnly(lon, lat, blockX, blockZ, effectiveSampleResolutionMeters(worldScale, previewResolutionMeters))
+            : this.sampleVisualCoverClassAtLonLat(lon, lat, blockX, blockZ, effectiveSampleResolutionMeters(worldScale, previewResolutionMeters));
+      }
+   }
+
+   private int sampleCoverClassAtLonLat(double lon, double lat) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return NO_DATA_CLASS;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTile(key);
+         return tile.sample(lon, lat);
+      }
+   }
+
+   private int sampleCoverClassAtLonLatLocalOnly(double lon, double lat) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return NO_DATA_CLASS;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTileLocalOnly(key);
+         return tile.sample(lon, lat);
+      }
+   }
+
+   private int sampleCoverClassAtLonLatMemoryOnly(double lon, double lat) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return Integer.MIN_VALUE;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTileMemoryOnly(key);
+         return tile == null ? Integer.MIN_VALUE : tile.sample(lon, lat);
+      }
+   }
+
+   private int sampleSmoothedCoverClassAtLonLat(double lon, double lat, int radiusPixels) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return NO_DATA_CLASS;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTile(key);
+         TellusLandCoverSource.Pixel center = tile.toPixel(lon, lat);
+         if (center == null) {
+            return NO_DATA_CLASS;
+         } else {
+            int centerValue = tile.sampleValue(center.x(), center.y());
+            if (radiusPixels > 0 && centerValue != WATER_CLASS && centerValue != NO_DATA_CLASS) {
+               TellusLandCoverSource.CoverSmoothScratch scratch = COVER_SMOOTH_SCRATCH.get();
+               scratch.reset();
+               if (tile.isNeighborhoodInBounds(center.x(), center.y(), radiusPixels)) {
+                  for (int dy = -radiusPixels; dy <= radiusPixels; dy++) {
+                     int py = center.y() + dy;
+
+                     for (int dx = -radiusPixels; dx <= radiusPixels; dx++) {
+                        int px = center.x() + dx;
+                        int value = tile.sampleValue(px, py);
+                        if (value != WATER_CLASS && value != NO_DATA_CLASS) {
+                           scratch.add(value);
+                        }
+                     }
+                  }
+               } else {
+                  for (int dy = -radiusPixels; dy <= radiusPixels; dy++) {
+                     int py = center.y() + dy;
+
+                     for (int dxx = -radiusPixels; dxx <= radiusPixels; dxx++) {
+                        int px = center.x() + dxx;
+                        int value = this.sampleValueAcrossTiles(tile, px, py);
+                        if (value != WATER_CLASS && value != NO_DATA_CLASS) {
+                           scratch.add(value);
+                        }
+                     }
+                  }
+               }
+
+               return scratch.pickMajority(centerValue);
+            } else {
+               return centerValue;
+            }
+         }
+      }
+   }
+
+   private int sampleVisualCoverClassAtLonLat(double lon, double lat, double blockX, double blockZ, double effectiveResolutionMeters) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return NO_DATA_CLASS;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTile(key);
+         TellusLandCoverSource.ContinuousPixel center = tile.toContinuousPixel(lon, lat);
+         if (center == null) {
+            return NO_DATA_CLASS;
+         } else {
+            int centerPixelX = Mth.floor(center.x());
+            int centerPixelY = Mth.floor(center.y());
+            int centerValue = tile.sampleValue(centerPixelX, centerPixelY);
+            if (effectiveResolutionMeters >= RESOLUTION_METERS || isHardRawCoverClass(centerValue)) {
+               return centerValue;
+            } else {
+               double transitionStrength = Mth.clamp((RESOLUTION_METERS - effectiveResolutionMeters) / 9.0, 0.0, 1.0);
+               if (!(transitionStrength > 0.0)) {
+                  return centerValue;
+               } else {
+                  double blendX = center.x() - 0.5;
+                  double blendY = center.y() - 0.5;
+                  int x0 = Mth.floor(blendX);
+                  int y0 = Mth.floor(blendY);
+                  int x1 = x0 + 1;
+                  int y1 = y0 + 1;
+                  double fx = blendX - x0;
+                  double fy = blendY - y0;
+                  int value00 = this.sampleValueAcrossTiles(tile, x0, y0);
+                  int value10 = this.sampleValueAcrossTiles(tile, x1, y0);
+                  int value01 = this.sampleValueAcrossTiles(tile, x0, y1);
+                  int value11 = this.sampleValueAcrossTiles(tile, x1, y1);
+                  if (isHardRawCoverClass(value00) || isHardRawCoverClass(value10) || isHardRawCoverClass(value01) || isHardRawCoverClass(value11)) {
+                     return centerValue;
+                  } else {
+                     TellusLandCoverSource.CoverBlendScratch scratch = COVER_BLEND_SCRATCH.get();
+                     scratch.reset();
+                     double inverseFx = 1.0 - fx;
+                     double inverseFy = 1.0 - fy;
+                     scratch.add(centerValue, 1.0 - transitionStrength);
+                     scratch.add(value00, inverseFx * inverseFy * transitionStrength);
+                     scratch.add(value10, fx * inverseFy * transitionStrength);
+                     scratch.add(value01, inverseFx * fy * transitionStrength);
+                     scratch.add(value11, fx * fy * transitionStrength);
+                     return scratch.pickWeighted(
+                        centerValue, hashToUnitDouble(Mth.floor(blockX), Mth.floor(blockZ), 9154887495218319081L)
+                     );
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private int sampleVisualCoverClassAtLonLatLocalOnly(double lon, double lat, double blockX, double blockZ, double effectiveResolutionMeters) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return NO_DATA_CLASS;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTileLocalOnly(key);
+         TellusLandCoverSource.ContinuousPixel center = tile.toContinuousPixel(lon, lat);
+         if (center == null) {
+            return NO_DATA_CLASS;
+         } else {
+            int centerPixelX = Mth.floor(center.x());
+            int centerPixelY = Mth.floor(center.y());
+            int centerValue = tile.sampleValue(centerPixelX, centerPixelY);
+            if (effectiveResolutionMeters >= RESOLUTION_METERS || isHardRawCoverClass(centerValue)) {
+               return centerValue;
+            } else {
+               double transitionStrength = Mth.clamp((RESOLUTION_METERS - effectiveResolutionMeters) / 9.0, 0.0, 1.0);
+               if (!(transitionStrength > 0.0)) {
+                  return centerValue;
+               } else {
+                  double blendX = center.x() - 0.5;
+                  double blendY = center.y() - 0.5;
+                  int x0 = Mth.floor(blendX);
+                  int y0 = Mth.floor(blendY);
+                  int x1 = x0 + 1;
+                  int y1 = y0 + 1;
+                  double fx = blendX - x0;
+                  double fy = blendY - y0;
+                  int value00 = this.sampleValueAcrossTilesLocalOnly(tile, x0, y0);
+                  int value10 = this.sampleValueAcrossTilesLocalOnly(tile, x1, y0);
+                  int value01 = this.sampleValueAcrossTilesLocalOnly(tile, x0, y1);
+                  int value11 = this.sampleValueAcrossTilesLocalOnly(tile, x1, y1);
+                  if (isHardRawCoverClass(value00) || isHardRawCoverClass(value10) || isHardRawCoverClass(value01) || isHardRawCoverClass(value11)) {
+                     return centerValue;
+                  } else {
+                     TellusLandCoverSource.CoverBlendScratch scratch = COVER_BLEND_SCRATCH.get();
+                     scratch.reset();
+                     double inverseFx = 1.0 - fx;
+                     double inverseFy = 1.0 - fy;
+                     scratch.add(centerValue, 1.0 - transitionStrength);
+                     scratch.add(value00, inverseFx * inverseFy * transitionStrength);
+                     scratch.add(value10, fx * inverseFy * transitionStrength);
+                     scratch.add(value01, inverseFx * fy * transitionStrength);
+                     scratch.add(value11, fx * fy * transitionStrength);
+                     return scratch.pickWeighted(
+                        centerValue, hashToUnitDouble(Mth.floor(blockX), Mth.floor(blockZ), 9154887495218319081L)
+                     );
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private int sampleVisualCoverClassAtLonLatMemoryOnly(double lon, double lat, double blockX, double blockZ, double effectiveResolutionMeters) {
+      TellusLandCoverSource.TileKey key = tileKeyForLonLat(lon, lat);
+      if (key == null) {
+         return Integer.MIN_VALUE;
+      } else {
+         TellusLandCoverSource.GeoTiffTile tile = this.getTileMemoryOnly(key);
+         if (tile == null) {
+            return Integer.MIN_VALUE;
+         } else {
+            TellusLandCoverSource.ContinuousPixel center = tile.toContinuousPixel(lon, lat);
+            if (center == null) {
+               return Integer.MIN_VALUE;
+            } else {
+               int centerPixelX = Mth.floor(center.x());
+               int centerPixelY = Mth.floor(center.y());
+               int centerValue = tile.sampleValue(centerPixelX, centerPixelY);
+               if (effectiveResolutionMeters >= RESOLUTION_METERS || isHardRawCoverClass(centerValue)) {
+                  return centerValue;
+               } else {
+                  double transitionStrength = Mth.clamp((RESOLUTION_METERS - effectiveResolutionMeters) / 9.0, 0.0, 1.0);
+                  if (!(transitionStrength > 0.0)) {
+                     return centerValue;
+                  } else {
+                     double blendX = center.x() - 0.5;
+                     double blendY = center.y() - 0.5;
+                     int x0 = Mth.floor(blendX);
+                     int y0 = Mth.floor(blendY);
+                     int x1 = x0 + 1;
+                     int y1 = y0 + 1;
+                     double fx = blendX - x0;
+                     double fy = blendY - y0;
+                     int value00 = this.sampleValueAcrossTilesMemoryOnly(tile, x0, y0);
+                     int value10 = this.sampleValueAcrossTilesMemoryOnly(tile, x1, y0);
+                     int value01 = this.sampleValueAcrossTilesMemoryOnly(tile, x0, y1);
+                     int value11 = this.sampleValueAcrossTilesMemoryOnly(tile, x1, y1);
+                     if (value00 == Integer.MIN_VALUE || value10 == Integer.MIN_VALUE || value01 == Integer.MIN_VALUE || value11 == Integer.MIN_VALUE) {
+                        return Integer.MIN_VALUE;
+                     } else if (isHardRawCoverClass(value00)
+                        || isHardRawCoverClass(value10)
+                        || isHardRawCoverClass(value01)
+                        || isHardRawCoverClass(value11)) {
+                        return centerValue;
+                     } else {
+                        TellusLandCoverSource.CoverBlendScratch scratch = COVER_BLEND_SCRATCH.get();
+                        scratch.reset();
+                        double inverseFx = 1.0 - fx;
+                        double inverseFy = 1.0 - fy;
+                        scratch.add(centerValue, 1.0 - transitionStrength);
+                        scratch.add(value00, inverseFx * inverseFy * transitionStrength);
+                        scratch.add(value10, fx * inverseFy * transitionStrength);
+                        scratch.add(value01, inverseFx * fy * transitionStrength);
+                        scratch.add(value11, fx * fy * transitionStrength);
+                        return scratch.pickWeighted(centerValue, hashToUnitDouble(Mth.floor(blockX), Mth.floor(blockZ), 9154887495218319081L));
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private int sampleValueAcrossTiles(TellusLandCoverSource.GeoTiffTile tile, int pixelX, int pixelY) {
+      if (tile.isInside(pixelX, pixelY)) {
+         return tile.sampleValue(pixelX, pixelY);
+      } else {
+         double neighborLon = tile.lonForPixel(pixelX);
+         double neighborLat = tile.latForPixel(pixelY);
+         return this.sampleCoverClassAtLonLat(neighborLon, neighborLat);
+      }
+   }
+
+   private int sampleValueAcrossTilesLocalOnly(TellusLandCoverSource.GeoTiffTile tile, int pixelX, int pixelY) {
+      if (tile.isInside(pixelX, pixelY)) {
+         return tile.sampleValue(pixelX, pixelY);
+      } else {
+         double neighborLon = tile.lonForPixel(pixelX);
+         double neighborLat = tile.latForPixel(pixelY);
+         return this.sampleCoverClassAtLonLatLocalOnly(neighborLon, neighborLat);
+      }
+   }
+
+   private int sampleValueAcrossTilesMemoryOnly(TellusLandCoverSource.GeoTiffTile tile, int pixelX, int pixelY) {
+      if (tile.isInside(pixelX, pixelY)) {
+         return tile.sampleValue(pixelX, pixelY);
+      } else {
+         double neighborLon = tile.lonForPixel(pixelX);
+         double neighborLat = tile.latForPixel(pixelY);
+         return this.sampleCoverClassAtLonLatMemoryOnly(neighborLon, neighborLat);
+      }
+   }
+
+   private static boolean isHardRawCoverClass(int coverClass) {
+      return coverClass == NO_DATA_CLASS || coverClass == WATER_CLASS || coverClass == MANGROVES_CLASS || coverClass == BUILT_UP_CLASS;
+   }
+
+   private static double hashToUnitDouble(long x, long z, long salt) {
+      long seed = x * 3129871L ^ z * 116129781L ^ salt;
+      seed = seed * seed * 42317861L + seed * 11L;
+      return ((seed >>> 11) & (1L << 53) - 1L) * 1.1102230246251565E-16;
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, worldScale);
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius, double previewResolutionMeters) {
+      TellusLandCoverSource.TileKey center = tileKeyForBlock(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (center != null) {
+         int clampedRadius = Math.max(0, radius);
+
+         for (int dz = -clampedRadius; dz <= clampedRadius; dz++) {
+            int lat = center.lat() + dz * TILE_DEGREES;
+            if (!(lat < MIN_LAT) && !(lat > MAX_LAT)) {
+               for (int dx = -clampedRadius; dx <= clampedRadius; dx++) {
+                  int lon = center.lon() + dx * TILE_DEGREES;
+                  if (!(lon < MIN_LON) && !(lon > MAX_LON)) {
+                     this.prefetchTile(new TellusLandCoverSource.TileKey(lat, lon));
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private static int downsampleStep(double worldScale, double resolutionMeters, double previewResolutionMeters) {
+      if (!(worldScale > 0.0)) {
+         return 1;
+      } else if (!(effectiveSampleResolutionMeters(worldScale, previewResolutionMeters) >= resolutionMeters)) {
+         return 1;
+      } else {
+         return Math.max(1, Mth.floor(resolutionMeters / worldScale));
+      }
+   }
+
+   private static double downsampleBlock(double blockCoord, int step) {
+      if (step <= 1) {
+         return blockCoord;
+      } else {
+         int block = Mth.floor(blockCoord);
+         int snapped = Math.floorDiv(block, step) * step;
+         return snapped + step * 0.5;
+      }
+   }
+
+   private static TellusLandCoverSource.TileKey tileKeyForBlock(double blockX, double blockZ, double worldScale, double previewResolutionMeters) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return tileKeyForLonLat(lon, lat);
+      }
+   }
+
+   private static double effectiveSampleResolutionMeters(double worldScale, double previewResolutionMeters) {
+      return Double.isFinite(previewResolutionMeters) && previewResolutionMeters > 0.0 ? Math.max(worldScale, previewResolutionMeters) : worldScale;
+   }
+
+   private static TellusLandCoverSource.TileKey tileKeyForLonLat(double lon, double lat) {
+      if (!(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON)) {
+         int tileLat = (int)Math.floor(lat / TILE_DEGREES) * TILE_DEGREES;
+         int tileLon = (int)Math.floor(lon / TILE_DEGREES) * TILE_DEGREES;
+         return new TellusLandCoverSource.TileKey(tileLat, tileLon);
+      } else {
+         return null;
+      }
+   }
+
+   private void prefetchTile( TellusLandCoverSource.TileKey key) {
+      if (this.cache.getIfPresent(key) == null) {
+         try {
+            this.cache.get(key);
+         } catch (Exception var3) {
+            if (isInterruptedLoad(var3)) {
+               Thread.currentThread().interrupt();
+               return;
+            }
+
+            Tellus.LOGGER.debug("Failed to prefetch land cover tile {}", key, var3);
+         }
+      }
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException var4) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private TellusLandCoverSource.GeoTiffTile getTile(TellusLandCoverSource.TileKey key) {
+      try {
+         return (TellusLandCoverSource.GeoTiffTile)this.cache.get(key);
+      } catch (Exception var3) {
+         if (isInterruptedLoad(var3)) {
+            Thread.currentThread().interrupt();
+            return TellusLandCoverSource.GeoTiffTile.MISSING;
+         }
+
+         Tellus.LOGGER.warn("Failed to load land cover tile {}", key, var3);
+         return TellusLandCoverSource.GeoTiffTile.MISSING;
+      }
+   }
+
+   private TellusLandCoverSource.GeoTiffTile getTileLocalOnly(TellusLandCoverSource.TileKey key) {
+      TellusLandCoverSource.GeoTiffTile cached = (TellusLandCoverSource.GeoTiffTile)this.cache.getIfPresent(key);
+      if (cached != null) {
+         return cached;
+      } else {
+         Path cachePath = this.cacheRoot.resolve(key.fileName());
+         if (!Files.exists(cachePath)) {
+            return TellusLandCoverSource.GeoTiffTile.MISSING;
+         } else {
+            try {
+               TellusLandCoverSource.GeoTiffTile opened = TellusLandCoverSource.GeoTiffTile.open(cachePath);
+               TellusLandCoverSource.GeoTiffTile raced = (TellusLandCoverSource.GeoTiffTile)this.cache.asMap().putIfAbsent(key, opened);
+               if (raced != null) {
+                  opened.close();
+                  return raced;
+               } else {
+                  return opened;
+               }
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached land cover tile {}", key, error);
+               return TellusLandCoverSource.GeoTiffTile.MISSING;
+            }
+         }
+      }
+   }
+
+   private TellusLandCoverSource.GeoTiffTile getTileMemoryOnly(TellusLandCoverSource.TileKey key) {
+      TellusLandCoverSource.GeoTiffTile cached = (TellusLandCoverSource.GeoTiffTile)this.cache.getIfPresent(key);
+      return cached == null || cached == TellusLandCoverSource.GeoTiffTile.MISSING ? null : cached;
+   }
+
+   private static boolean isInterruptedLoad(Throwable throwable) {
+      if (Thread.currentThread().isInterrupted()) {
+         return true;
+      } else {
+         for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof ClosedByInterruptException || current instanceof InterruptedException || current instanceof InterruptedIOException) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+   }
+
+   private TellusLandCoverSource.GeoTiffTile loadTile(TellusLandCoverSource.TileKey key) throws IOException {
+      Path cachePath = this.cacheRoot.resolve(key.fileName());
+      if (Files.exists(cachePath)) {
+         return TellusLandCoverSource.GeoTiffTile.open(cachePath);
+      } else {
+         byte[] data = this.downloadTile(key);
+         if (data == null) {
+            return TellusLandCoverSource.GeoTiffTile.MISSING;
+         } else {
+            this.cacheTile(cachePath, data);
+            return TellusLandCoverSource.GeoTiffTile.open(cachePath);
+         }
+      }
+   }
+
+   private byte[] downloadTile(TellusLandCoverSource.TileKey key) throws IOException {
+      URI uri = URI.create(String.format("%s/%s", ENDPOINT, key.fileName()));
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      try {
+         connection.setConnectTimeout(8000);
+         connection.setReadTimeout(8000);
+         connection.setRequestProperty("User-Agent", "Tellus/1.0 (Minecraft Mod)");
+         if (connection.getResponseCode() == 404) {
+            return null;
+         } else {
+            DownloadProgressReporter.requestStarted(connection.getContentLengthLong());
+
+            byte[] var5;
+            try (InputStream input = connection.getInputStream()) {
+               var5 = DownloadProgressReporter.readAllBytesWithProgress(input);
+            } finally {
+               DownloadProgressReporter.requestFinished();
+            }
+
+            return var5;
+         }
+      } finally {
+         connection.disconnect();
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] data) {
+      try {
+         Files.createDirectories(cachePath.getParent());
+         Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+         Files.write(tempPath, data);
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException var4) {
+         Tellus.LOGGER.warn("Failed to cache land cover tile {}", cachePath, var4);
+      }
+   }
+
+   private static final class CoverSmoothScratch {
+      private final int[] counts = new int[256];
+      private final int[] used = new int[256];
+      private int usedCount;
+
+      private void reset() {
+         for (int i = 0; i < this.usedCount; i++) {
+            this.counts[this.used[i]] = 0;
+         }
+
+         this.usedCount = 0;
+      }
+
+      private void add(int value) {
+         if (this.counts[value] == 0) {
+            this.used[this.usedCount++] = value;
+         }
+
+         this.counts[value]++;
+      }
+
+      private int pickMajority(int centerValue) {
+         if (this.usedCount == 0) {
+            return centerValue;
+         } else {
+            int bestValue = centerValue;
+            int bestCount = -1;
+
+            for (int i = 0; i < this.usedCount; i++) {
+               int value = this.used[i];
+               int count = this.counts[value];
+               if (count > bestCount || count == bestCount && value == centerValue) {
+                  bestCount = count;
+                  bestValue = value;
+               }
+            }
+
+            return bestValue;
+         }
+      }
+   }
+
+   private static final class CoverBlendScratch {
+      private final double[] weights = new double[256];
+      private final int[] used = new int[256];
+      private int usedCount;
+
+      private void reset() {
+         for (int i = 0; i < this.usedCount; i++) {
+            this.weights[this.used[i]] = 0.0;
+         }
+
+         this.usedCount = 0;
+      }
+
+      private void add(int value, double weight) {
+         if (weight > 0.0) {
+            if (!(this.weights[value] > 0.0)) {
+               this.used[this.usedCount++] = value;
+            }
+
+            this.weights[value] += weight;
+         }
+      }
+
+      private int pickWeighted(int fallbackValue, double threshold) {
+         if (this.usedCount == 0) {
+            return fallbackValue;
+         } else {
+            double total = 0.0;
+
+            for (int i = 0; i < this.usedCount; i++) {
+               total += this.weights[this.used[i]];
+            }
+
+            if (!(total > 0.0)) {
+               return fallbackValue;
+            } else {
+               double target = Mth.clamp(threshold, 0.0, 0.9999999999999999) * total;
+               double cumulative = 0.0;
+               int lastValue = fallbackValue;
+
+               for (int i = 0; i < this.usedCount; i++) {
+                  int value = this.used[i];
+                  lastValue = value;
+                  cumulative += this.weights[value];
+                  if (target < cumulative || i + 1 == this.usedCount) {
+                     return value;
+                  }
+               }
+
+               return lastValue;
+            }
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.LAND_COVER;
+   }
+
+   @Override
+   public void clearCache() {
+      this.cache.invalidateAll();
+      this.cache.cleanUp();
+   }
+
+   private static final class GeoTiffTile {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_MODEL_PIXEL_SCALE = 33550;
+      private static final int TAG_MODEL_TIEPOINT = 33922;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private static final TellusLandCoverSource.GeoTiffTile MISSING = new TellusLandCoverSource.GeoTiffTile();
+      private final Path path;
+      private final FileChannel channel;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final double pixelScaleX;
+      private final double pixelScaleY;
+      private final double tieLon;
+      private final double tieLat;
+      private final Map<Integer, byte[]> tileCache;
+
+      private GeoTiffTile() {
+         this.path = null;
+         this.channel = null;
+         this.width = 0;
+         this.height = 0;
+         this.tileWidth = 0;
+         this.tileHeight = 0;
+         this.tilesPerRow = 0;
+         this.tileOffsets = null;
+         this.tileByteCounts = null;
+         this.pixelScaleX = 0.0;
+         this.pixelScaleY = 0.0;
+         this.tieLon = 0.0;
+         this.tieLat = 0.0;
+         this.tileCache = Map.of();
+      }
+
+      private GeoTiffTile(
+         Path path,
+         FileChannel channel,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         double pixelScaleX,
+         double pixelScaleY,
+         double tieLon,
+         double tieLat
+      ) {
+         this.path = path;
+         this.channel = channel;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.pixelScaleX = pixelScaleX;
+         this.pixelScaleY = pixelScaleY;
+         this.tieLon = tieLon;
+         this.tieLat = tieLat;
+         this.tileCache = new LinkedHashMap<Integer, byte[]>(TellusLandCoverSource.TILE_CACHE_ENTRIES, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, byte[]> eldest) {
+               return this.size() > TellusLandCoverSource.TILE_CACHE_ENTRIES;
+            }
+         };
+      }
+
+      static TellusLandCoverSource.GeoTiffTile open(Path path) throws IOException {
+         FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
+
+         try {
+            return readFromChannel(path, channel);
+         } catch (IOException var3) {
+            channel.close();
+            throw var3;
+         }
+      }
+
+      int sample(double lon, double lat) {
+         TellusLandCoverSource.Pixel pixel = this.toPixel(lon, lat);
+         return pixel == null ? 0 : this.sampleValue(pixel.x, pixel.y);
+      }
+
+      TellusLandCoverSource.ContinuousPixel toContinuousPixel(double lon, double lat) {
+         if (this == MISSING) {
+            return null;
+         } else {
+            double pixelX = (lon - this.tieLon) / this.pixelScaleX;
+            double pixelY = (this.tieLat - lat) / this.pixelScaleY;
+            return pixelX >= 0.0 && pixelY >= 0.0 && pixelX < this.width && pixelY < this.height
+               ? new TellusLandCoverSource.ContinuousPixel(pixelX, pixelY)
+               : null;
+         }
+      }
+
+      TellusLandCoverSource.Pixel toPixel(double lon, double lat) {
+         if (this == MISSING) {
+            return null;
+         } else {
+            int pixelX = (int)Math.floor((lon - this.tieLon) / this.pixelScaleX);
+            int pixelY = (int)Math.floor((this.tieLat - lat) / this.pixelScaleY);
+            return pixelX >= 0 && pixelY >= 0 && pixelX < this.width && pixelY < this.height ? new TellusLandCoverSource.Pixel(pixelX, pixelY) : null;
+         }
+      }
+
+      int sampleValue(int pixelX, int pixelY) {
+         if (this != MISSING && pixelX >= 0 && pixelY >= 0 && pixelX < this.width && pixelY < this.height) {
+            int tileX = pixelX / this.tileWidth;
+            int tileY = pixelY / this.tileHeight;
+            int tileIndex = tileY * this.tilesPerRow + tileX;
+
+            byte[] tile;
+            try {
+               tile = this.getTile(tileIndex);
+            } catch (ClosedByInterruptException var9) {
+               Thread.currentThread().interrupt();
+               return 0;
+            } catch (IOException var10) {
+               Tellus.LOGGER.warn("Failed to read land cover tile {} in {}", new Object[]{tileIndex, this.path, var10});
+               return 0;
+            }
+
+            int localX = pixelX - tileX * this.tileWidth;
+            int localY = pixelY - tileY * this.tileHeight;
+            return Byte.toUnsignedInt(tile[localX + localY * this.tileWidth]);
+         } else {
+            return 0;
+         }
+      }
+
+      boolean isInside(int pixelX, int pixelY) {
+         return pixelX >= 0 && pixelY >= 0 && pixelX < this.width && pixelY < this.height;
+      }
+
+      boolean isNeighborhoodInBounds(int pixelX, int pixelY, int radius) {
+         return pixelX - radius >= 0 && pixelY - radius >= 0 && pixelX + radius < this.width && pixelY + radius < this.height;
+      }
+
+      double lonForPixel(int pixelX) {
+         return this.tieLon + (pixelX + 0.5) * this.pixelScaleX;
+      }
+
+      double latForPixel(int pixelY) {
+         return this.tieLat - (pixelY + 0.5) * this.pixelScaleY;
+      }
+
+      void close() {
+         if (this.channel != null) {
+            synchronized (this.tileCache) {
+               this.tileCache.clear();
+            }
+
+            try {
+               this.channel.close();
+            } catch (IOException var2) {
+               Tellus.LOGGER.warn("Failed to close land cover tile {}", this.path, var2);
+            }
+         }
+      }
+
+      private byte[] getTile(int tileIndex) throws IOException {
+         synchronized (this.tileCache) {
+            byte[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         byte[] tile = this.readTile(tileIndex);
+         synchronized (this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private byte[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = new byte[length];
+
+         try {
+            readFully(this.channel, compressed, offset);
+         } catch (ClosedChannelException var12) {
+            if (this.path == null) {
+               throw var12;
+            }
+
+            try (FileChannel reopened = FileChannel.open(this.path, StandardOpenOption.READ)) {
+               readFully(reopened, compressed, offset);
+            }
+         }
+
+         return inflate(compressed, this.tileWidth * this.tileHeight);
+      }
+
+      private static TellusLandCoverSource.GeoTiffTile readFromChannel(Path path, FileChannel channel) throws IOException {
+         ByteBuffer header = ByteBuffer.allocate(8);
+         readFully(channel, header, 0L);
+         header.flip();
+         short order = header.getShort();
+
+         ByteOrder byteOrder = switch (order) {
+            case 18761 -> ByteOrder.LITTLE_ENDIAN;
+            case 19789 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid TIFF byte order");
+         };
+         header.order(byteOrder);
+         short magic = header.getShort();
+         if (magic != 42) {
+            throw new IOException("Invalid TIFF magic");
+         } else {
+            int ifdOffset = header.getInt();
+            ByteBuffer countBuffer = ByteBuffer.allocate(2).order(byteOrder);
+            readFully(channel, countBuffer, ifdOffset);
+            countBuffer.flip();
+            int entryCount = Short.toUnsignedInt(countBuffer.getShort());
+            ByteBuffer entries = ByteBuffer.allocate(entryCount * 12).order(byteOrder);
+            readFully(channel, entries, ifdOffset + 2L);
+            entries.flip();
+            int width = -1;
+            int height = -1;
+            int tileWidth = -1;
+            int tileHeight = -1;
+            int compression = -1;
+            long[] tileOffsets = null;
+            int[] tileByteCounts = null;
+            double[] pixelScale = null;
+            double[] tiepoint = null;
+
+            for (int i = 0; i < entryCount; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               int count = entries.getInt();
+               int value = entries.getInt();
+               switch (tag) {
+                  case TAG_IMAGE_WIDTH:
+                     width = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_IMAGE_HEIGHT:
+                     height = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_COMPRESSION:
+                     compression = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_TILE_WIDTH:
+                     tileWidth = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_TILE_HEIGHT:
+                     tileHeight = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_TILE_OFFSETS:
+                     tileOffsets = readLongArray(channel, value, count, byteOrder);
+                     break;
+                  case TAG_TILE_BYTE_COUNTS:
+                     tileByteCounts = readIntArray(channel, value, count, byteOrder);
+                     break;
+                  case TAG_MODEL_PIXEL_SCALE:
+                     pixelScale = readDoubleArray(channel, value, count, byteOrder);
+                     break;
+                  case TAG_MODEL_TIEPOINT:
+                     tiepoint = readDoubleArray(channel, value, count, byteOrder);
+               }
+            }
+
+            if (compression != COMPRESSION_DEFLATE) {
+               throw new IOException("Unsupported TIFF compression " + compression);
+            } else if (width <= 0 || height <= 0 || tileWidth <= 0 || tileHeight <= 0) {
+               throw new IOException("Missing TIFF size tags");
+            } else if (tileOffsets == null || tileByteCounts == null) {
+               throw new IOException("Missing TIFF tile offsets");
+            } else if (pixelScale != null && pixelScale.length >= 2 && tiepoint != null && tiepoint.length >= 5) {
+               return new TellusLandCoverSource.GeoTiffTile(
+                  path, channel, width, height, tileWidth, tileHeight, tileOffsets, tileByteCounts, pixelScale[0], pixelScale[1], tiepoint[3], tiepoint[4]
+               );
+            } else {
+               throw new IOException("Missing TIFF georeference tags");
+            }
+         }
+      }
+
+      private static int readIntValue(int type, int count, int value, ByteOrder order) throws IOException {
+         if (count != 1) {
+            throw new IOException("Expected single TIFF value");
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(4).order(order);
+            buffer.putInt(value);
+            buffer.flip();
+            if (type == TYPE_SHORT) {
+               return Short.toUnsignedInt(buffer.getShort());
+            } else if (type == TYPE_LONG) {
+               return buffer.getInt();
+            } else {
+               throw new IOException("Unsupported TIFF value type " + type);
+            }
+         }
+      }
+
+      private static long[] readLongArray(FileChannel channel, long offset, int count, ByteOrder order) throws IOException {
+         if (count <= 0) {
+            return new long[0];
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(count * 4).order(order);
+            readFully(channel, buffer, offset);
+            buffer.flip();
+            long[] values = new long[count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = Integer.toUnsignedLong(buffer.getInt());
+            }
+
+            return values;
+         }
+      }
+
+      private static int[] readIntArray(FileChannel channel, long offset, int count, ByteOrder order) throws IOException {
+         if (count <= 0) {
+            return new int[0];
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(count * 4).order(order);
+            readFully(channel, buffer, offset);
+            buffer.flip();
+            int[] values = new int[count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getInt();
+            }
+
+            return values;
+         }
+      }
+
+      private static double[] readDoubleArray(FileChannel channel, long offset, int count, ByteOrder order) throws IOException {
+         if (count <= 0) {
+            return new double[0];
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(count * 8).order(order);
+            readFully(channel, buffer, offset);
+            buffer.flip();
+            double[] values = new double[count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getDouble();
+            }
+
+            return values;
+         }
+      }
+
+      private static void readFully(FileChannel channel, ByteBuffer buffer, long offset) throws IOException {
+         long position = offset;
+
+         while (buffer.hasRemaining()) {
+            int read = channel.read(buffer, position);
+            if (read < 0) {
+               throw new EOFException("Unexpected end of file");
+            }
+
+            position += read;
+         }
+      }
+
+      private static void readFully(FileChannel channel, byte[] dest, long offset) throws IOException {
+         readFully(channel, ByteBuffer.wrap(dest), offset);
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         byte[] var8;
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            }
+
+            var8 = output;
+         }
+
+         return var8;
+      }
+   }
+
+   private record Pixel(int x, int y) {
+   }
+
+   private record ContinuousPixel(double x, double y) {
+   }
+
+   private record TileKey(int lat, int lon) {
+      String fileName() {
+         return String.format(Locale.ROOT, TILE_PATTERN, formatLatLon(this.lat, this.lon));
+      }
+
+      private static String formatLatLon(int lat, int lon) {
+         char latPrefix = (char)(lat >= 0 ? 78 : 83);
+         char lonPrefix = (char)(lon >= 0 ? 69 : 87);
+         int latAbs = Math.abs(lat);
+         int lonAbs = Math.abs(lon);
+         return String.format(Locale.ROOT, "%c%02d%c%03d", latPrefix, latAbs, lonPrefix, lonAbs);
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/AhnElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/AhnElevationSource.java
@@ -1,0 +1,1087 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class AhnElevationSource implements TellusCacheHandle {
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final int MAX_FILE_CACHE = intProperty("tellus.ahn.cacheFiles", 8);
+   private static final int MAX_TILE_CACHE = intProperty("tellus.ahn.cacheTiles", 16);
+   private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("tellus.ahn.enabled", "true"));
+   private static final double DEFAULT_NO_DATA = -9999.0;
+   private static final double REF_LAT = 52.15517440;
+   private static final double REF_LON = 5.38720621;
+   private final Path cacheRoot;
+   private final AhnCoverageIndex coverageIndex = AhnCoverageIndex.create();
+   private final LoadingCache<AhnCoverageIndex.TileReference, AhnElevationSource.TileFile> fileCache;
+
+   public AhnElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-ahn/dtm_05m");
+      this.fileCache = CacheBuilder.newBuilder().maximumSize(MAX_FILE_CACHE).build(new CacheLoader<AhnCoverageIndex.TileReference, AhnElevationSource.TileFile>() {
+         public AhnElevationSource.TileFile load(AhnCoverageIndex.TileReference key) throws Exception {
+            return AhnElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isLikelyInCoverage(double lat, double lon) {
+      if (!this.canUse()) {
+         return false;
+      } else {
+         AhnElevationSource.Projection projection = project(lat, lon);
+         return projection != null && this.coverageIndex.find(projection.x(), projection.y()) != null;
+      }
+   }
+
+   public AhnElevationSource.Sample sample(double blockX, double blockZ, double worldScale) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return AhnElevationSource.Sample.none();
+      } else {
+         AhnElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? AhnElevationSource.Sample.none() : this.sample(latLon.lat(), latLon.lon());
+      }
+   }
+
+   public AhnElevationSource.Sample sampleLocalOnly(double blockX, double blockZ, double worldScale) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return AhnElevationSource.Sample.none();
+      } else {
+         AhnElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? AhnElevationSource.Sample.none() : this.sampleLocalOnly(latLon.lat(), latLon.lon());
+      }
+   }
+
+   public AhnElevationSource.Sample sample(double lat, double lon) {
+      if (!this.canUse()) {
+         return AhnElevationSource.Sample.none();
+      } else {
+         AhnElevationSource.Projection projection = project(lat, lon);
+         if (projection == null) {
+            return AhnElevationSource.Sample.none();
+         } else {
+            AhnCoverageIndex.TileReference tileRef = this.coverageIndex.find(projection.x(), projection.y());
+            if (tileRef == null) {
+               return AhnElevationSource.Sample.none();
+            } else {
+               AhnElevationSource.TileFile tile = this.getTile(tileRef);
+               if (tile == null) {
+                  return AhnElevationSource.Sample.none();
+               } else {
+                  double value = tile.sampleProjected(projection.x(), projection.y());
+                  return Double.isFinite(value)
+                     ? new AhnElevationSource.Sample(value, TellusElevationSource.DemUsage.AHN, tile.effectiveResolutionMeters())
+                     : AhnElevationSource.Sample.none();
+               }
+            }
+         }
+      }
+   }
+
+   private AhnElevationSource.Sample sampleLocalOnly(double lat, double lon) {
+      if (!this.canUse()) {
+         return AhnElevationSource.Sample.none();
+      } else {
+         AhnElevationSource.Projection projection = project(lat, lon);
+         if (projection == null) {
+            return AhnElevationSource.Sample.none();
+         } else {
+            AhnCoverageIndex.TileReference tileRef = this.coverageIndex.find(projection.x(), projection.y());
+            if (tileRef == null) {
+               return AhnElevationSource.Sample.none();
+            } else {
+               AhnElevationSource.TileFile tile = this.getTileLocalOnly(tileRef);
+               if (tile == null) {
+                  return AhnElevationSource.Sample.none();
+               } else {
+                  double value = tile.sampleProjected(projection.x(), projection.y());
+                  return Double.isFinite(value)
+                     ? new AhnElevationSource.Sample(value, TellusElevationSource.DemUsage.AHN, tile.effectiveResolutionMeters())
+                     : AhnElevationSource.Sample.none();
+               }
+            }
+         }
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      if (!(worldScale <= 0.0) && radius > 0 && this.canUse()) {
+         LinkedHashSet<AhnCoverageIndex.TileReference> refs = new LinkedHashSet<>();
+         double blockRadius = Math.max(1, radius) * 256.0;
+
+         for (int dz = -1; dz <= 1; dz++) {
+            for (int dx = -1; dx <= 1; dx++) {
+               AhnElevationSource.LatLon latLon = toLatLon(blockX + dx * blockRadius, blockZ + dz * blockRadius, worldScale);
+               if (latLon != null) {
+                  AhnElevationSource.Projection projection = project(latLon.lat(), latLon.lon());
+                  if (projection != null) {
+                     AhnCoverageIndex.TileReference ref = this.coverageIndex.find(projection.x(), projection.y());
+                     if (ref != null) {
+                        refs.add(ref);
+                     }
+                  }
+               }
+            }
+         }
+
+         for (AhnCoverageIndex.TileReference ref : refs) {
+            this.prefetchTile(ref);
+         }
+      }
+   }
+
+   private boolean canUse() {
+      return ENABLED && this.coverageIndex.available();
+   }
+
+   private void prefetchTile(AhnCoverageIndex.TileReference tileRef) {
+      if (this.fileCache.getIfPresent(tileRef) == null) {
+         try {
+            this.fileCache.get(tileRef);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch AHN tile {}", tileRef.id(), error);
+         }
+      }
+   }
+
+   private AhnElevationSource.TileFile getTile(AhnCoverageIndex.TileReference tileRef) {
+      try {
+         return this.fileCache.get(tileRef);
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load AHN tile {}", tileRef.id(), error);
+         return null;
+      }
+   }
+
+   private AhnElevationSource.TileFile getTileLocalOnly(AhnCoverageIndex.TileReference tileRef) {
+      AhnElevationSource.TileFile cached = this.fileCache.getIfPresent(tileRef);
+      if (cached != null) {
+         return cached;
+      } else {
+         Path cacheDir = this.cacheRoot.resolve(tileRef.cacheDirectory());
+         if (!Files.isDirectory(cacheDir)) {
+            return null;
+         } else {
+            try {
+               AhnElevationSource.TileFile opened = AhnElevationSource.TileFile.openLocalOnly(tileRef, cacheDir);
+               AhnElevationSource.TileFile raced = this.fileCache.asMap().putIfAbsent(tileRef, opened);
+               return raced != null ? raced : opened;
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached AHN tile {}", tileRef.id(), error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private AhnElevationSource.TileFile loadTile(AhnCoverageIndex.TileReference tileRef) throws Exception {
+      return AhnElevationSource.TileFile.open(tileRef, this.cacheRoot.resolve(tileRef.cacheDirectory()));
+   }
+
+   private static AhnElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0 ? new AhnElevationSource.LatLon(lat, lon) : null;
+   }
+
+   private static AhnElevationSource.Projection project(double latDeg, double lonDeg) {
+      if (!(latDeg >= 50.0) || !(latDeg <= 55.0) || !(lonDeg >= 2.0) || !(lonDeg <= 8.0)) {
+         return null;
+      } else {
+         double dLat = 0.36 * (latDeg - REF_LAT);
+         double dLon = 0.36 * (lonDeg - REF_LON);
+         double x = 155000.0
+            - 0.705 * dLat
+            + 190094.945 * dLon
+            - 11832.228 * dLat * dLon
+            - 114.221 * dLat * dLat * dLon
+            - 32.391 * dLon * dLon * dLon
+            - 2.340 * dLat * dLat * dLon * dLon
+            - 0.608 * dLat * dLon * dLon * dLon
+            - 0.008 * dLat * dLat * dLon * dLon * dLon;
+         double y = 463000.0
+            + 309056.544 * dLat
+            + 0.433 * dLon
+            + 3638.893 * dLon * dLon
+            + 73.077 * dLat * dLat
+            - 157.984 * dLat * dLon * dLon
+            + 59.788 * dLat * dLat * dLat
+            - 6.439 * dLat * dLat * dLon
+            - 0.032 * dLat * dLon * dLon
+            + 0.092 * dLon * dLon * dLon * dLon
+            - 0.054 * dLat * dLat * dLat * dLat;
+         return new AhnElevationSource.Projection(x, y);
+      }
+   }
+
+   private static HttpURLConnection openConnection(URI uri, String rangeHeader) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+      if (rangeHeader != null) {
+         connection.setRequestProperty("Range", rangeHeader);
+      }
+
+      return connection;
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.AHN;
+   }
+
+   @Override
+   public void clearCache() {
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record Projection(double x, double y) {
+   }
+
+   public record Sample(double elevation, TellusElevationSource.DemUsage usage, double resolutionMeters) {
+      private static AhnElevationSource.Sample none() {
+         return new AhnElevationSource.Sample(Double.NaN, null, Double.NaN);
+      }
+
+      public boolean usable() {
+         return this.usage != null && Double.isFinite(this.elevation);
+      }
+   }
+
+   private static final class CachedRangeReader {
+      private final AhnCoverageIndex.TileReference tileRef;
+      private final Path cacheDir;
+      private final boolean localOnly;
+
+      private CachedRangeReader(AhnCoverageIndex.TileReference tileRef, Path cacheDir) {
+         this(tileRef, cacheDir, false);
+      }
+
+      private CachedRangeReader(AhnCoverageIndex.TileReference tileRef, Path cacheDir, boolean localOnly) {
+         this.tileRef = Objects.requireNonNull(tileRef, "tileRef");
+         this.cacheDir = Objects.requireNonNull(cacheDir, "cacheDir");
+         this.localOnly = localOnly;
+      }
+
+      private byte[] read(long offset, int length) throws IOException {
+         if (length <= 0) {
+            return new byte[0];
+         } else {
+            Path cachePath = this.cacheDir.resolve(offset + "-" + length + ".bin");
+            byte[] cached = this.readCachedRange(cachePath, length);
+            if (cached != null) {
+               return cached;
+            } else {
+               if (this.localOnly) {
+                  throw new EOFException("AHN range not cached for " + this.tileRef.id());
+               }
+
+               byte[] data = this.readRemoteRange(offset, length);
+               this.writeCachedRange(cachePath, data);
+               return data;
+            }
+         }
+      }
+
+      private byte[] readCachedRange(Path cachePath, int expectedLength) throws IOException {
+         if (!Files.exists(cachePath)) {
+            return null;
+         } else {
+            byte[] data = Files.readAllBytes(cachePath);
+            if (data.length == expectedLength) {
+               return data;
+            } else {
+               Files.deleteIfExists(cachePath);
+               return null;
+            }
+         }
+      }
+
+      private byte[] readRemoteRange(long offset, int length) throws IOException {
+         String rangeHeader = "bytes=" + offset + "-" + (offset + length - 1L);
+         HttpURLConnection connection = AhnElevationSource.openConnection(URI.create(this.tileRef.url()), rangeHeader);
+
+         try {
+            int status = connection.getResponseCode();
+            if (status != 200 && status != 206) {
+               throw new IOException("Unexpected AHN HTTP status " + status + " for " + this.tileRef.id());
+            } else {
+               DownloadProgressReporter.requestStarted((long)length);
+               try (InputStream input = connection.getInputStream()) {
+                  byte[] data = DownloadProgressReporter.readAllBytesWithProgress(input);
+                  if (data.length != length) {
+                     throw new EOFException("Unexpected AHN range length " + data.length + " for " + this.tileRef.id());
+                  } else {
+                     return data;
+                  }
+               }
+            }
+         } finally {
+            DownloadProgressReporter.requestFinished();
+            connection.disconnect();
+         }
+      }
+
+      private void writeCachedRange(Path cachePath, byte[] data) {
+         try {
+            Files.createDirectories(cachePath.getParent());
+            Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+            Files.write(tempPath, data);
+            Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to cache AHN range {}", cachePath, error);
+         }
+      }
+   }
+
+   private static final class TileFile {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_BITS_PER_SAMPLE = 258;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_STRIP_OFFSETS = 273;
+      private static final int TAG_SAMPLES_PER_PIXEL = 277;
+      private static final int TAG_ROWS_PER_STRIP = 278;
+      private static final int TAG_STRIP_BYTE_COUNTS = 279;
+      private static final int TAG_PREDICTOR = 317;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_SAMPLE_FORMAT = 339;
+      private static final int TAG_MODEL_PIXEL_SCALE = 33550;
+      private static final int TAG_MODEL_TIEPOINT = 33922;
+      private static final int TAG_GDAL_NODATA = 42113;
+      private static final int TYPE_BYTE = 1;
+      private static final int TYPE_ASCII = 2;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int TYPE_DOUBLE = 12;
+      private static final int TYPE_LONG8 = 16;
+      private static final int COMPRESSION_NONE = 1;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private final String tileId;
+      private final AhnElevationSource.CachedRangeReader reader;
+      private final ByteOrder order;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final int predictor;
+      private final int bytesPerSample;
+      private final int samplesPerPixel;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final double originX;
+      private final double originY;
+      private final double pixelSizeX;
+      private final double pixelSizeY;
+      private final float noData;
+      private final Map<Integer, float[]> tileCache;
+
+      private TileFile(
+         String tileId,
+         AhnElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         int predictor,
+         int bytesPerSample,
+         int samplesPerPixel,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         double originX,
+         double originY,
+         double pixelSizeX,
+         double pixelSizeY,
+         float noData
+      ) {
+         this.tileId = tileId;
+         this.reader = reader;
+         this.order = order;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.compression = compression;
+         this.predictor = predictor;
+         this.bytesPerSample = bytesPerSample;
+         this.samplesPerPixel = samplesPerPixel;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.originX = originX;
+         this.originY = originY;
+         this.pixelSizeX = pixelSizeX;
+         this.pixelSizeY = pixelSizeY;
+         this.noData = noData;
+         this.tileCache = new LinkedHashMap<Integer, float[]>(MAX_TILE_CACHE, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, float[]> eldest) {
+               return this.size() > MAX_TILE_CACHE;
+            }
+         };
+      }
+
+      private double sampleProjected(double x, double y) {
+         double globalX = (x - this.originX) / this.pixelSizeX;
+         double globalY = (this.originY - y) / this.pixelSizeY;
+         if (globalX < -1.0 || globalY < -1.0 || globalX > this.width || globalY > this.height) {
+            return Double.NaN;
+         } else {
+            int maxPixelX = this.width - 1;
+            int maxPixelY = this.height - 1;
+            double clampedX = Mth.clamp(globalX, 0.0, maxPixelX);
+            double clampedY = Mth.clamp(globalY, 0.0, maxPixelY);
+            int x0 = Mth.floor(clampedX);
+            int y0 = Mth.floor(clampedY);
+            int x1 = Math.min(x0 + 1, maxPixelX);
+            int y1 = Math.min(y0 + 1, maxPixelY);
+            double dx = clampedX - x0;
+            double dy = clampedY - y0;
+            float v00 = this.sampleValue(x0, y0);
+            float v10 = this.sampleValue(x1, y0);
+            float v01 = this.sampleValue(x0, y1);
+            float v11 = this.sampleValue(x1, y1);
+            return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+         }
+      }
+
+      private double effectiveResolutionMeters() {
+         return (Math.abs(this.pixelSizeX) + Math.abs(this.pixelSizeY)) * 0.5;
+      }
+
+      private float sampleValue(int pixelX, int pixelY) {
+         int clampedX = Mth.clamp(pixelX, 0, this.width - 1);
+         int clampedY = Mth.clamp(pixelY, 0, this.height - 1);
+         int tileX = clampedX / this.tileWidth;
+         int tileY = clampedY / this.tileHeight;
+         int tileIndex = tileY * this.tilesPerRow + tileX;
+
+         try {
+            float[] tile = this.getTile(tileIndex);
+            int localX = clampedX - tileX * this.tileWidth;
+            int localY = clampedY - tileY * this.tileHeight;
+            return tile[localX + localY * this.tileWidth];
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to read AHN tile {} block from {}", tileIndex, this.tileId, error);
+            return Float.NaN;
+         }
+      }
+
+      private float[] getTile(int tileIndex) throws IOException {
+         synchronized(this.tileCache) {
+            float[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         float[] tile = this.readTile(tileIndex);
+         synchronized(this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private float[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = this.reader.read(offset, length);
+         int expectedSize = this.tileWidth * this.tileHeight * this.bytesPerSample * this.samplesPerPixel;
+         if (this.samplesPerPixel != 1) {
+            throw new IOException("Unsupported AHN TIFF samples per pixel " + this.samplesPerPixel);
+         } else {
+            byte[] raw = switch (this.compression) {
+               case COMPRESSION_NONE -> compressed;
+               case COMPRESSION_LZW -> decompressLzw(compressed, expectedSize);
+               case COMPRESSION_DEFLATE -> inflate(compressed, expectedSize);
+               default -> throw new IOException("Unsupported AHN TIFF compression " + this.compression);
+            };
+            if (raw.length != expectedSize) {
+               throw new IOException("Unexpected AHN tile length " + raw.length + " for " + this.tileId);
+            } else {
+               if (this.predictor == 3) {
+                  applyFloatingPointPredictor(raw, this.tileWidth, this.tileHeight, this.bytesPerSample, this.samplesPerPixel, this.order);
+               } else if (this.predictor != 1) {
+                  throw new IOException("Unsupported AHN TIFF predictor " + this.predictor);
+               }
+
+               float[] values = new float[this.tileWidth * this.tileHeight];
+               ByteBuffer buffer = ByteBuffer.wrap(raw).order(this.order);
+
+               for (int i = 0; i < values.length; i++) {
+                  float value = buffer.getFloat();
+                  values[i] = value <= this.noData + 1.0F ? Float.NaN : value;
+               }
+
+               return values;
+            }
+         }
+      }
+
+      private static AhnElevationSource.TileFile open(AhnCoverageIndex.TileReference tileRef, Path cacheDir) throws IOException {
+         return open(tileRef, cacheDir, false);
+      }
+
+      private static AhnElevationSource.TileFile openLocalOnly(AhnCoverageIndex.TileReference tileRef, Path cacheDir) throws IOException {
+         return open(tileRef, cacheDir, true);
+      }
+
+      private static AhnElevationSource.TileFile open(AhnCoverageIndex.TileReference tileRef, Path cacheDir, boolean localOnly) throws IOException {
+         AhnElevationSource.CachedRangeReader reader = new AhnElevationSource.CachedRangeReader(tileRef, cacheDir, localOnly);
+         byte[] header = reader.read(0L, 32);
+         ByteOrder order = switch (header[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid AHN TIFF byte order for " + tileRef.id());
+         };
+         ByteBuffer headerBuf = ByteBuffer.wrap(header).order(order);
+         headerBuf.getShort();
+         short magic = headerBuf.getShort();
+         if (magic == 42) {
+            return openStandardTiff(tileRef, reader, order, headerBuf);
+         } else if (magic == 43) {
+            return openBigTiff(tileRef, reader, order, headerBuf);
+         } else {
+            throw new IOException("Unsupported AHN TIFF magic " + magic + " for " + tileRef.id());
+         }
+      }
+
+      private static AhnElevationSource.TileFile openStandardTiff(
+         AhnCoverageIndex.TileReference tileRef, AhnElevationSource.CachedRangeReader reader, ByteOrder order, ByteBuffer headerBuf
+      ) throws IOException {
+         long ifdOffset = Integer.toUnsignedLong(headerBuf.getInt());
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return buildTileFile(tileRef, reader, order, false, entryCount, entries);
+      }
+
+      private static AhnElevationSource.TileFile openBigTiff(
+         AhnCoverageIndex.TileReference tileRef, AhnElevationSource.CachedRangeReader reader, ByteOrder order, ByteBuffer headerBuf
+      ) throws IOException {
+         short offsetSize = headerBuf.getShort();
+         headerBuf.getShort();
+         if (offsetSize != 8) {
+            throw new IOException("Unsupported AHN BigTIFF offset size " + offsetSize + " for " + tileRef.id());
+         } else {
+            long ifdOffset = headerBuf.getLong();
+            long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+            if (entryCount < 0L || entryCount > 1000000L) {
+               throw new IOException("Invalid AHN BigTIFF entry count " + entryCount + " for " + tileRef.id());
+            } else {
+               byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+               ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+               return buildTileFile(tileRef, reader, order, true, entryCount, entries);
+            }
+         }
+      }
+
+      private static AhnElevationSource.TileFile buildTileFile(
+         AhnCoverageIndex.TileReference tileRef,
+         AhnElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         int tileWidth = -1;
+         int tileHeight = -1;
+         int compression = -1;
+         int predictor = 1;
+         int bitsPerSample = -1;
+         int sampleFormat = -1;
+         int samplesPerPixel = 1;
+         long[] tileOffsets = null;
+         int[] tileByteCounts = null;
+         int rowsPerStrip = -1;
+         long[] stripOffsets = null;
+         int[] stripByteCounts = null;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+         float noData = (float)DEFAULT_NO_DATA;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_BITS_PER_SAMPLE -> bitsPerSample = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_COMPRESSION -> compression = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_OFFSETS -> stripOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLES_PER_PIXEL -> samplesPerPixel = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_ROWS_PER_STRIP -> rowsPerStrip = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_BYTE_COUNTS -> stripByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_PREDICTOR -> predictor = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_WIDTH -> tileWidth = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_HEIGHT -> tileHeight = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_OFFSETS -> tileOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_BYTE_COUNTS -> tileByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLE_FORMAT -> sampleFormat = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_GDAL_NODATA -> noData = parseNoData(readAscii(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize));
+            }
+         }
+
+         if (width <= 0 || height <= 0) {
+            throw new IOException("Missing AHN TIFF size tags for " + tileRef.id());
+         } else {
+            if ((tileOffsets == null || tileByteCounts == null) && stripOffsets != null && stripByteCounts != null && rowsPerStrip > 0) {
+               tileWidth = width;
+               tileHeight = rowsPerStrip;
+               tileOffsets = stripOffsets;
+               tileByteCounts = stripByteCounts;
+            }
+
+            if (tileWidth <= 0 || tileHeight <= 0) {
+               throw new IOException("Missing AHN TIFF tile geometry for " + tileRef.id());
+            } else if (tileOffsets == null || tileByteCounts == null) {
+               throw new IOException("Missing AHN TIFF tile offsets for " + tileRef.id());
+            } else if (bitsPerSample != 32 || sampleFormat != 3) {
+               throw new IOException("Unsupported AHN TIFF sample format " + sampleFormat + " bits " + bitsPerSample);
+            } else if (pixelScale != null && pixelScale.length >= 2 && tiePoints != null && tiePoints.length >= 6) {
+               double pixelSizeX = pixelScale[0];
+               double pixelSizeY = pixelScale[1];
+               double originX = tiePoints[3] - tiePoints[0] * pixelSizeX;
+               double originY = tiePoints[4] + tiePoints[1] * pixelSizeY;
+               return new AhnElevationSource.TileFile(
+                  tileRef.id(),
+                  reader,
+                  order,
+                  width,
+                  height,
+                  tileWidth,
+                  tileHeight,
+                  compression,
+                  predictor,
+                  4,
+                  samplesPerPixel,
+                  tileOffsets,
+                  tileByteCounts,
+                  originX,
+                  originY,
+                  pixelSizeX,
+                  pixelSizeY,
+                  noData
+               );
+            } else {
+               throw new IOException("Missing AHN TIFF georeferencing tags for " + tileRef.id());
+            }
+         }
+      }
+
+      private static int readIntValue(
+         AhnElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count != 1L) {
+            throw new IOException("Expected single TIFF value");
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            return switch (type) {
+               case TYPE_BYTE -> buffer.get() & 255;
+               case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+               case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+               case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+               default -> throw new IOException("Unsupported TIFF value type " + type);
+            };
+         }
+      }
+
+      private static long[] readLongArray(
+         AhnElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new long[0];
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            long[] values = new long[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = switch (type) {
+                  case TYPE_BYTE -> buffer.get() & 255;
+                  case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+                  case TYPE_LONG -> Integer.toUnsignedLong(buffer.getInt());
+                  case TYPE_LONG8 -> buffer.getLong();
+                  default -> throw new IOException("Unsupported TIFF array type " + type);
+               };
+            }
+
+            return values;
+         }
+      }
+
+      private static int[] readIntArray(
+         AhnElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         long[] values = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+         int[] output = new int[values.length];
+
+         for (int i = 0; i < values.length; i++) {
+            if (values[i] > 2147483647L) {
+               throw new IOException("TIFF byte count too large " + values[i]);
+            }
+
+            output[i] = (int)values[i];
+         }
+
+         return output;
+      }
+
+      private static double[] readDoubleArray(
+         AhnElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new double[0];
+         } else if (type != TYPE_DOUBLE) {
+            throw new IOException("Unsupported TIFF double array type " + type);
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            double[] values = new double[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getDouble();
+            }
+
+            return values;
+         }
+      }
+
+      private static String readAscii(
+         AhnElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return "";
+         } else if (type != TYPE_ASCII) {
+            throw new IOException("Unsupported TIFF ASCII type " + type);
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            int length = (int)Math.min(count, data.length);
+
+            while (length > 0 && data[length - 1] == 0) {
+               length--;
+            }
+
+            return new String(data, 0, length, StandardCharsets.US_ASCII);
+         }
+      }
+
+      private static byte[] readFieldData(
+         AhnElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         int size = typeSize(type);
+         if (size <= 0) {
+            throw new IOException("Unsupported TIFF field type " + type);
+         } else {
+            long byteSize = count * size;
+            if (byteSize <= inlineSize) {
+               byte[] data = new byte[(int)byteSize];
+               System.arraycopy(inlineBytes, 0, data, 0, (int)byteSize);
+               return data;
+            } else if (byteSize > Integer.MAX_VALUE) {
+               throw new IOException("TIFF field too large");
+            } else {
+               return reader.read(valueOrOffset, (int)byteSize);
+            }
+         }
+      }
+
+      private static float parseNoData(String value) {
+         if (value == null || value.isBlank()) {
+            return (float)DEFAULT_NO_DATA;
+         } else {
+            try {
+               return Float.parseFloat(value.trim());
+            } catch (NumberFormatException error) {
+               return (float)DEFAULT_NO_DATA;
+            }
+         }
+      }
+
+      private static int typeSize(int type) {
+         return switch (type) {
+            case TYPE_BYTE, TYPE_ASCII -> 1;
+            case TYPE_SHORT -> 2;
+            case TYPE_LONG -> 4;
+            case TYPE_DOUBLE, TYPE_LONG8 -> 8;
+            default -> 0;
+         };
+      }
+
+      private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+         double w00 = (1.0 - dx) * (1.0 - dy);
+         double w10 = dx * (1.0 - dy);
+         double w01 = (1.0 - dx) * dy;
+         double w11 = dx * dy;
+         double sum = 0.0;
+         double weight = 0.0;
+         if (Float.isFinite(v00)) {
+            sum += v00 * w00;
+            weight += w00;
+         }
+
+         if (Float.isFinite(v10)) {
+            sum += v10 * w10;
+            weight += w10;
+         }
+
+         if (Float.isFinite(v01)) {
+            sum += v01 * w01;
+            weight += w01;
+         }
+
+         if (Float.isFinite(v11)) {
+            sum += v11 * w11;
+            weight += w11;
+         }
+
+         return weight <= 0.0 ? Double.NaN : sum / weight;
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            } else {
+               return output;
+            }
+         }
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[][] table = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            table[i] = new byte[]{(byte)i};
+         }
+
+         int clearCode = 256;
+         int endCode = 257;
+         int codeSize = 9;
+         int nextCode = 258;
+         byte[] output = new byte[expectedSize];
+         int outPos = 0;
+         AhnElevationSource.TileFile.LzwBitReader reader = new AhnElevationSource.TileFile.LzwBitReader(compressed);
+         byte[] previous = null;
+
+         while (true) {
+            int code = reader.read(codeSize);
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 0; i < 256; i++) {
+                  table[i] = new byte[]{(byte)i};
+               }
+
+               for (int i = 256; i < table.length; i++) {
+                  table[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else {
+               if (code == endCode) {
+                  break;
+               }
+
+               byte[] entry;
+               if (code < nextCode && table[code] != null) {
+                  entry = table[code];
+               } else {
+                  if (code != nextCode || previous == null) {
+                     throw new IOException("Invalid LZW code " + code);
+                  }
+
+                  entry = concat(previous, previous[0]);
+               }
+
+               if (outPos + entry.length > output.length) {
+                  throw new IOException("Unexpected LZW output size");
+               }
+
+               System.arraycopy(entry, 0, output, outPos, entry.length);
+               outPos += entry.length;
+               if (previous != null && nextCode < table.length) {
+                  table[nextCode++] = concat(previous, entry[0]);
+                  int threshold = (1 << codeSize) - 1;
+                  if (nextCode == threshold && codeSize < 12) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+               if (outPos == output.length) {
+                  break;
+               }
+            }
+         }
+
+         if (outPos != output.length) {
+            throw new IOException("Unexpected LZW output length " + outPos);
+         } else {
+            return output;
+         }
+      }
+
+      private static void applyFloatingPointPredictor(byte[] data, int width, int height, int bytesPerSample, int samplesPerPixel, ByteOrder order)
+         throws IOException {
+         int rowBytes = width * bytesPerSample * samplesPerPixel;
+         if (rowBytes > 0) {
+            if (samplesPerPixel > 0 && rowBytes % (bytesPerSample * samplesPerPixel) == 0) {
+               int wordCount = rowBytes / bytesPerSample;
+               byte[] tmp = new byte[rowBytes];
+
+               for (int row = 0; row < height; row++) {
+                  int rowStart = row * rowBytes;
+                  int count = rowBytes;
+
+                  for (int offset = rowStart; count > samplesPerPixel; count -= samplesPerPixel) {
+                     for (int i = 0; i < samplesPerPixel; i++) {
+                        int target = offset + samplesPerPixel;
+                        int value = (data[target] & 255) + (data[offset] & 255);
+                        data[target] = (byte)value;
+                        offset++;
+                     }
+                  }
+
+                  System.arraycopy(data, rowStart, tmp, 0, rowBytes);
+
+                  for (int word = 0; word < wordCount; word++) {
+                     int base = rowStart + word * bytesPerSample;
+
+                     for (int byteIndex = 0; byteIndex < bytesPerSample; byteIndex++) {
+                        int sourceIndex = order == ByteOrder.BIG_ENDIAN ? byteIndex * wordCount + word : (bytesPerSample - byteIndex - 1) * wordCount + word;
+                        data[base + byteIndex] = tmp[sourceIndex];
+                     }
+                  }
+               }
+            } else {
+               throw new IOException("Invalid floating point predictor stride");
+            }
+         }
+      }
+
+      private static byte[] concat(byte[] prefix, byte suffix) {
+         byte[] combined = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, combined, 0, prefix.length);
+         combined[prefix.length] = suffix;
+         return combined;
+      }
+
+      private static final class LzwBitReader {
+         private final byte[] data;
+         private int bitPos;
+
+         private LzwBitReader(byte[] data) {
+            this.data = data;
+         }
+
+         private int read(int width) {
+            if (this.bitPos + width > this.data.length * 8) {
+               return -1;
+            } else {
+               int value = 0;
+
+               for (int bit = 0; bit < width; bit++) {
+                  int byteIndex = (this.bitPos + bit) >> 3;
+                  int bitIndex = this.bitPos + bit & 7;
+                  value |= ((this.data[byteIndex] & 255) >> bitIndex & 1) << bit;
+               }
+
+               this.bitPos += width;
+               return value;
+            }
+         }
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/ArcticDemElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/ArcticDemElevationSource.java
@@ -1,0 +1,1483 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public class ArcticDemElevationSource implements TellusCacheHandle {
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final double BUCKET_SIZE_METERS = 100000.0;
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final double NO_DATA = -9999.0;
+   private static final boolean DEBUG_DEM = Boolean.getBoolean("tellus.debug.dem");
+   private static final double DEBUG_SAMPLE_LAT = doubleProperty("tellus.debug.dem.sampleLat", Double.NaN);
+   private static final double DEBUG_SAMPLE_LON = doubleProperty("tellus.debug.dem.sampleLon", Double.NaN);
+   private static final double DEBUG_SAMPLE_EPS = doubleProperty("tellus.debug.dem.sampleEps", 1.0E-4);
+   private static final double PROJ_A = 6378137.0;
+   private static final double PROJ_E = 0.081819190843;
+   private final ArcticDemElevationSource.Dataset dataset;
+   private final Path cacheRoot;
+   private final LoadingCache<ArcticDemElevationSource.Tier, ArcticDemElevationSource.TileIndex> indexCache;
+   private final LoadingCache<String, ArcticDemElevationSource.TileFile> fileCache;
+   private final ThreadLocal<ArcticDemElevationSource.TileLookup> lookupCache = ThreadLocal.withInitial(ArcticDemElevationSource.TileLookup::new);
+   private final boolean enabled;
+   private final int maxTileCache;
+   private final long failureCooldownMs;
+   private volatile long suspendedUntilMs;
+   private final AtomicInteger debugMask = new AtomicInteger();
+   private final AtomicInteger debugSampleMask = new AtomicInteger();
+   private volatile ArcticDemElevationSource.Tier lastLoggedTier;
+
+   public ArcticDemElevationSource() {
+      this(ArcticDemElevationSource.Dataset.ARCTIC);
+   }
+
+   ArcticDemElevationSource(ArcticDemElevationSource.Dataset dataset) {
+      this.dataset = dataset;
+      this.enabled = Boolean.parseBoolean(System.getProperty(dataset.enabledPropertyKey(), "true"));
+      int maxFileCache = intProperty(dataset.cacheFilesPropertyKey(), 8);
+      this.maxTileCache = intProperty(dataset.cacheTilesPropertyKey(), 16);
+      this.failureCooldownMs = longProperty(dataset.retryPropertyKey(), 60000L);
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve(dataset.cacheRelativePath());
+      this.indexCache = CacheBuilder.newBuilder()
+         .maximumSize(ArcticDemElevationSource.Tier.values().length)
+         .build(new CacheLoader<ArcticDemElevationSource.Tier, ArcticDemElevationSource.TileIndex>() {
+            public ArcticDemElevationSource.TileIndex load(ArcticDemElevationSource.Tier tier) throws Exception {
+               return ArcticDemElevationSource.TileIndex.load(tier, ArcticDemElevationSource.this.cacheRoot, dataset.baseUrl());
+            }
+         });
+      this.fileCache = CacheBuilder.newBuilder().maximumSize(maxFileCache).build(new CacheLoader<String, ArcticDemElevationSource.TileFile>() {
+         public ArcticDemElevationSource.TileFile load(String url) throws Exception {
+            return ArcticDemElevationSource.TileFile.open(url, ArcticDemElevationSource.this.maxTileCache, dataset.displayName());
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public double sampleElevationMeters(double blockX, double blockZ, double worldScale) {
+      if (this.enabled && !this.isSuspended()) {
+         if (worldScale <= 0.0) {
+            return Double.NaN;
+         } else {
+            ArcticDemElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+            double lat = latLon.lat();
+            double lon = latLon.lon();
+            if (!this.isInCoverage(lat, lon)) {
+               this.debugOnce(
+                  ArcticDemElevationSource.DebugReason.OUT_OF_BOUNDS, "{} out of coverage at lat={}, lon={}.", this.dataset.displayName(), lat, lon
+               );
+               return Double.NaN;
+            } else {
+               ArcticDemElevationSource.Tier tier = ArcticDemElevationSource.Tier.forScale(worldScale);
+               this.debugTier(tier, worldScale);
+               ArcticDemElevationSource.TileIndex index = this.getIndex(tier);
+               if (index == null) {
+                  this.debugOnce(ArcticDemElevationSource.DebugReason.INDEX_FAILED, "{} index unavailable; falling back to Terrarium.", this.dataset.displayName());
+                  return Double.NaN;
+               } else {
+                  ArcticDemElevationSource.Projection projection = this.project(lat, lon);
+                  if (projection == null) {
+                     this.debugOnce(
+                        ArcticDemElevationSource.DebugReason.PROJECTION_FAILED, "{} projection failed for lat={}, lon={}.", this.dataset.displayName(), lat, lon
+                     );
+                     return Double.NaN;
+                  } else {
+                     ArcticDemElevationSource.TileLookup lookup = this.lookupCache.get();
+                     ArcticDemElevationSource.TileEntry tile = lookup.get(tier, projection.x, projection.y);
+                     if (tile == null) {
+                        tile = index.findTile(projection.x, projection.y);
+                        lookup.update(tier, tile);
+                     }
+
+                     if (tile == null) {
+                        this.debugOnce(
+                           ArcticDemElevationSource.DebugReason.TILE_NOT_FOUND,
+                           "{} tile not found for x={}, y={}, tier={}.",
+                           this.dataset.displayName(),
+                           projection.x,
+                           projection.y,
+                           tier.id
+                        );
+                        return Double.NaN;
+                     } else {
+                        ArcticDemElevationSource.TileFile tileFile = this.getTileFile(tile.url);
+                        if (tileFile == null) {
+                           this.debugOnce(ArcticDemElevationSource.DebugReason.TILEFILE_FAILED, "{} tile load failed for {}.", this.dataset.displayName(), tile.url);
+                           return Double.NaN;
+                        } else {
+                           boolean probeSample = this.shouldDebugSample(lat, lon);
+                           double value;
+                           if (probeSample && this.debugSampleMask.compareAndSet(0, 1)) {
+                              ArcticDemElevationSource.TileFile.SampleResult result = tileFile.sampleWithDebug(
+                                 tile, projection.x, projection.y, index.pixelSize
+                              );
+                              value = result.value();
+                              if (DEBUG_DEM && result.debug() != null) {
+                                 ArcticDemElevationSource.TileFile.SampleDebug debug = result.debug();
+                                 Tellus.LOGGER
+                                    .info(
+                                       "{} probe lat={}, lon={}, tier={}, tile={}, local=({},{}) px=({},{})->({},{}), v00={}, v10={}, v01={}, v11={}, value={}",
+                                       new Object[]{
+                                          this.dataset.displayName(),
+                                          String.format("%.5f", lat),
+                                          String.format("%.5f", lon),
+                                          tier.id,
+                                          tile.url,
+                                          String.format("%.2f", debug.localX()),
+                                          String.format("%.2f", debug.localY()),
+                                          debug.x0(),
+                                          debug.y0(),
+                                          debug.x1(),
+                                          debug.y1(),
+                                          Float.isFinite(debug.v00()) ? String.format("%.2f", debug.v00()) : "NaN",
+                                          Float.isFinite(debug.v10()) ? String.format("%.2f", debug.v10()) : "NaN",
+                                          Float.isFinite(debug.v01()) ? String.format("%.2f", debug.v01()) : "NaN",
+                                          Float.isFinite(debug.v11()) ? String.format("%.2f", debug.v11()) : "NaN",
+                                          Double.isFinite(result.value()) ? String.format("%.2f", result.value()) : "NaN"
+                                       }
+                                    );
+                              }
+                           } else {
+                              value = tileFile.sample(tile, projection.x, projection.y, index.pixelSize);
+                           }
+
+                           if (tileFile.hasFailure()) {
+                              this.suspend();
+                           }
+
+                           if (!Double.isNaN(value) && !(value <= NO_DATA + 1.0)) {
+                              this.debugOnce(ArcticDemElevationSource.DebugReason.SUCCESS, "{} active (tier {}, tile {}).", this.dataset.displayName(), tier.id, tile.url);
+                              return value;
+                           } else {
+                              this.debugOnce(ArcticDemElevationSource.DebugReason.NO_DATA, "{} returned no-data for {}.", this.dataset.displayName(), tile.url);
+                              return Double.NaN;
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      } else {
+         if (!this.enabled) {
+            this.debugOnce(
+               ArcticDemElevationSource.DebugReason.DISABLED, "{} disabled ({}=false).", this.dataset.displayName(), this.dataset.enabledPropertyKey()
+            );
+         } else {
+            this.debugOnce(ArcticDemElevationSource.DebugReason.SUSPENDED, "{} suspended; falling back to Terrarium.", this.dataset.displayName());
+         }
+
+         return Double.NaN;
+      }
+   }
+
+   public double sampleElevationMetersLocalOnly(double blockX, double blockZ, double worldScale) {
+      if (this.enabled && !this.isSuspended()) {
+         if (worldScale <= 0.0) {
+            return Double.NaN;
+         } else {
+            ArcticDemElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+            double lat = latLon.lat();
+            double lon = latLon.lon();
+            if (!this.isInCoverage(lat, lon)) {
+               return Double.NaN;
+            } else {
+               ArcticDemElevationSource.Tier tier = ArcticDemElevationSource.Tier.forScale(worldScale);
+               ArcticDemElevationSource.TileIndex index = this.getIndexLocalOnly(tier);
+               if (index == null) {
+                  return Double.NaN;
+               } else {
+                  ArcticDemElevationSource.Projection projection = this.project(lat, lon);
+                  if (projection == null) {
+                     return Double.NaN;
+                  } else {
+                     ArcticDemElevationSource.TileLookup lookup = this.lookupCache.get();
+                     ArcticDemElevationSource.TileEntry tile = lookup.get(tier, projection.x, projection.y);
+                     if (tile == null) {
+                        tile = index.findTile(projection.x, projection.y);
+                        lookup.update(tier, tile);
+                     }
+
+                     if (tile == null) {
+                        return Double.NaN;
+                     } else {
+                        ArcticDemElevationSource.TileFile tileFile = this.getTileFileLocalOnly(tile.url);
+                        if (tileFile == null) {
+                           return Double.NaN;
+                        } else {
+                           double value = tileFile.sample(tile, projection.x, projection.y, index.pixelSize);
+                           return !Double.isNaN(value) && !(value <= NO_DATA + 1.0) ? value : Double.NaN;
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      } else {
+         return Double.NaN;
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      if (this.enabled && !this.isSuspended()) {
+         if (!(worldScale <= 0.0) && radius > 0) {
+            ArcticDemElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+            double lat = latLon.lat();
+            double lon = latLon.lon();
+            if (this.isInCoverage(lat, lon)) {
+               ArcticDemElevationSource.Tier tier = ArcticDemElevationSource.Tier.forScale(worldScale);
+               ArcticDemElevationSource.TileIndex index = this.getIndex(tier);
+               if (index != null) {
+                  ArcticDemElevationSource.Projection projection = this.project(lat, lon);
+                  if (projection != null) {
+                     double span = index.tileSpanMeters;
+                     int clampedRadius = Math.max(1, radius);
+
+                     for (int dz = -clampedRadius; dz <= clampedRadius; dz++) {
+                        for (int dx = -clampedRadius; dx <= clampedRadius; dx++) {
+                           double x = projection.x + dx * span;
+                           double y = projection.y + dz * span;
+                           ArcticDemElevationSource.TileEntry tile = index.findTile(x, y);
+                           if (tile != null) {
+                              try {
+                                 this.fileCache.get(tile.url);
+                              } catch (ExecutionException var27) {
+                                 Tellus.LOGGER.debug("Failed to prefetch {} tile {}", this.dataset.displayName(), tile.url, var27);
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private static ArcticDemElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return new ArcticDemElevationSource.LatLon(lat, lon);
+   }
+
+   private boolean isInCoverage(double lat, double lon) {
+      return lat >= this.dataset.minLat() && lat <= this.dataset.maxLat() && lon >= MIN_LON && lon <= MAX_LON;
+   }
+
+   private ArcticDemElevationSource.TileIndex getIndex(ArcticDemElevationSource.Tier tier) {
+      try {
+         return (ArcticDemElevationSource.TileIndex)this.indexCache.get(tier);
+      } catch (ExecutionException var3) {
+         Tellus.LOGGER.warn("Failed to load {} index for {}", this.dataset.displayName(), tier.id, var3);
+         this.suspend();
+         return null;
+      }
+   }
+
+   private ArcticDemElevationSource.TileIndex getIndexLocalOnly(ArcticDemElevationSource.Tier tier) {
+      return (ArcticDemElevationSource.TileIndex)this.indexCache.getIfPresent(tier);
+   }
+
+   private ArcticDemElevationSource.TileFile getTileFile(String url) {
+      try {
+         return (ArcticDemElevationSource.TileFile)this.fileCache.get(url);
+      } catch (ExecutionException var3) {
+         Tellus.LOGGER.debug("Failed to load {} tile {}", this.dataset.displayName(), url, var3);
+         this.suspend();
+         return null;
+      }
+   }
+
+   private ArcticDemElevationSource.TileFile getTileFileLocalOnly(String url) {
+      return (ArcticDemElevationSource.TileFile)this.fileCache.getIfPresent(url);
+   }
+
+   private boolean isSuspended() {
+      return System.currentTimeMillis() < this.suspendedUntilMs;
+   }
+
+   private void suspend() {
+      this.suspendedUntilMs = Math.max(this.suspendedUntilMs, System.currentTimeMillis() + this.failureCooldownMs);
+   }
+
+   private void debugOnce(ArcticDemElevationSource.DebugReason reason, String message, Object... args) {
+      if (DEBUG_DEM) {
+         int bit = 1 << reason.ordinal();
+
+         int previous;
+         do {
+            previous = this.debugMask.get();
+            if ((previous & bit) != 0) {
+               return;
+            }
+         } while (!this.debugMask.compareAndSet(previous, previous | bit));
+
+         Tellus.LOGGER.info(message, args);
+      }
+   }
+
+   private void debugTier(ArcticDemElevationSource.Tier tier, double worldScale) {
+      if (DEBUG_DEM) {
+         if (tier != this.lastLoggedTier) {
+            this.lastLoggedTier = tier;
+            Tellus.LOGGER.info("{} tier set to {} (worldScale {}).", this.dataset.displayName(), tier.id, String.format("%.2f", worldScale));
+         }
+      }
+   }
+
+   private boolean shouldDebugSample(double lat, double lon) {
+      if (!DEBUG_DEM) {
+         return false;
+      } else {
+         return Double.isFinite(DEBUG_SAMPLE_LAT) && Double.isFinite(DEBUG_SAMPLE_LON)
+            ? Math.abs(lat - DEBUG_SAMPLE_LAT) <= DEBUG_SAMPLE_EPS && Math.abs(lon - DEBUG_SAMPLE_LON) <= DEBUG_SAMPLE_EPS
+            : false;
+      }
+   }
+
+   private ArcticDemElevationSource.Projection project(double latDeg, double lonDeg) {
+      return this.dataset.projection().project(latDeg, lonDeg);
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException var4) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static long longProperty(String key, long defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1L, Long.parseLong(value));
+         } catch (NumberFormatException var5) {
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return this.dataset.cacheDomain();
+   }
+
+   @Override
+   public void clearCache() {
+      this.indexCache.invalidateAll();
+      this.indexCache.cleanUp();
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+      this.lookupCache.remove();
+      this.lastLoggedTier = null;
+      this.suspendedUntilMs = 0L;
+   }
+
+   private static double doubleProperty(String key, double defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Double.parseDouble(value);
+         } catch (NumberFormatException var5) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static HttpURLConnection openConnection(URI uri) throws IOException {
+      return openConnection(uri, null);
+   }
+
+   private static HttpURLConnection openConnection(URI uri, String rangeHeader) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+      if (rangeHeader != null) {
+         connection.setRequestProperty("Range", rangeHeader);
+      }
+
+      return connection;
+   }
+
+   private static long bucketKey(int bx, int by) {
+      return (long)bx << 32 ^ by & 4294967295L;
+   }
+
+   static enum Dataset {
+      ARCTIC(
+         "ArcticDEM",
+         "arcticdem",
+         "https://pgc-opendata-dems.s3.us-west-2.amazonaws.com/arcticdem/mosaics/v4.1",
+         "tellus/cache/elevation-arcticdem/v4.1",
+         TellusCacheDomain.ARCTICDEM,
+         50.593818479,
+         83.988230361,
+         ArcticDemElevationSource.PolarProjection.NORTH_3413
+      ),
+      REMA(
+         "REMA",
+         "rema",
+         "https://pgc-opendata-dems.s3.us-west-2.amazonaws.com/rema/mosaics/v2.0",
+         "tellus/cache/elevation-rema/v2.0",
+         TellusCacheDomain.REMA,
+         -90.0,
+         -60.0,
+         ArcticDemElevationSource.PolarProjection.SOUTH_3031
+      );
+
+      private final String displayName;
+      private final String propertyId;
+      private final String baseUrl;
+      private final String cacheRelativePath;
+      private final TellusCacheDomain cacheDomain;
+      private final double minLat;
+      private final double maxLat;
+      private final ArcticDemElevationSource.PolarProjection projection;
+
+      private Dataset(
+         String displayName,
+         String propertyId,
+         String baseUrl,
+         String cacheRelativePath,
+         TellusCacheDomain cacheDomain,
+         double minLat,
+         double maxLat,
+         ArcticDemElevationSource.PolarProjection projection
+      ) {
+         this.displayName = displayName;
+         this.propertyId = propertyId;
+         this.baseUrl = baseUrl;
+         this.cacheRelativePath = cacheRelativePath;
+         this.cacheDomain = cacheDomain;
+         this.minLat = minLat;
+         this.maxLat = maxLat;
+         this.projection = projection;
+      }
+
+      private String displayName() {
+         return this.displayName;
+      }
+
+      private String baseUrl() {
+         return this.baseUrl;
+      }
+
+      private String cacheRelativePath() {
+         return this.cacheRelativePath;
+      }
+
+      private TellusCacheDomain cacheDomain() {
+         return this.cacheDomain;
+      }
+
+      private double minLat() {
+         return this.minLat;
+      }
+
+      private double maxLat() {
+         return this.maxLat;
+      }
+
+      private ArcticDemElevationSource.PolarProjection projection() {
+         return this.projection;
+      }
+
+      private String enabledPropertyKey() {
+         return "tellus." + this.propertyId + ".enabled";
+      }
+
+      private String cacheFilesPropertyKey() {
+         return "tellus." + this.propertyId + ".cacheFiles";
+      }
+
+      private String cacheTilesPropertyKey() {
+         return "tellus." + this.propertyId + ".cacheTiles";
+      }
+
+      private String retryPropertyKey() {
+         return "tellus." + this.propertyId + ".retryMs";
+      }
+   }
+
+   private static enum PolarProjection {
+      NORTH_3413(true, 70.0, -45.0),
+      SOUTH_3031(false, -71.0, 0.0);
+
+      private final boolean north;
+      private final double lon0;
+      private final double tC;
+      private final double mC;
+
+      private PolarProjection(boolean north, double latTsDeg, double lon0Deg) {
+         this.north = north;
+         this.lon0 = Math.toRadians(lon0Deg);
+         double latTs = Math.toRadians(Math.abs(latTsDeg));
+         double sinTs = Math.sin(latTs);
+         this.tC = Math.tan((Math.PI / 4) - latTs / 2.0) / Math.pow((1.0 - PROJ_E * sinTs) / (1.0 + PROJ_E * sinTs), PROJ_E / 2.0);
+         this.mC = Math.cos(latTs) / Math.sqrt(1.0 - PROJ_E * PROJ_E * sinTs * sinTs);
+      }
+
+      private ArcticDemElevationSource.Projection project(double latDeg, double lonDeg) {
+         if (this.north ? latDeg <= 0.0 : latDeg >= 0.0) {
+            return null;
+         } else {
+            double lat = Math.toRadians(Math.abs(latDeg));
+            double lon = Math.toRadians(lonDeg);
+            double sinLat = Math.sin(lat);
+            double t = Math.tan((Math.PI / 4) - lat / 2.0) / Math.pow((1.0 - PROJ_E * sinLat) / (1.0 + PROJ_E * sinLat), PROJ_E / 2.0);
+            double rho = PROJ_A * this.mC * t / this.tC;
+            double x = rho * Math.sin(lon - this.lon0);
+            double y = this.north ? -rho * Math.cos(lon - this.lon0) : rho * Math.cos(lon - this.lon0);
+            return new ArcticDemElevationSource.Projection(x, y);
+         }
+      }
+   }
+
+   private static enum DebugReason {
+      DISABLED,
+      SUSPENDED,
+      OUT_OF_BOUNDS,
+      INDEX_FAILED,
+      PROJECTION_FAILED,
+      TILE_NOT_FOUND,
+      TILEFILE_FAILED,
+      NO_DATA,
+      SUCCESS;
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record Projection(double x, double y) {
+   }
+
+   private static final class RangeReader {
+      private final String url;
+
+      private RangeReader(String url) {
+         this.url = url;
+      }
+
+      private byte[] read(long offset, int length) throws IOException {
+         if (length <= 0) {
+            return new byte[0];
+         } else {
+            String rangeHeader = "bytes=" + offset + "-" + (offset + length - 1L);
+            HttpURLConnection connection = ArcticDemElevationSource.openConnection(URI.create(this.url), rangeHeader);
+            try {
+               int status = connection.getResponseCode();
+               if (status == 416) {
+                  throw new EOFException("Range not satisfiable for " + this.url);
+               } else if (status != 206 && status != 200) {
+                  throw new IOException("Unexpected HTTP status " + status + " for " + this.url);
+               } else {
+                  DownloadProgressReporter.requestStarted((long)length);
+                  byte[] var9;
+                  try (InputStream input = connection.getInputStream()) {
+                     byte[] data = DownloadProgressReporter.readAllBytesWithProgress(input);
+                     if (data.length != length) {
+                        throw new EOFException("Unexpected range length " + data.length + " for " + this.url);
+                     }
+
+                     var9 = data;
+                  }
+
+                  return var9;
+               }
+            } finally {
+               DownloadProgressReporter.requestFinished();
+               connection.disconnect();
+            }
+         }
+      }
+   }
+
+   private static enum Tier {
+      TWO_M("2m", 2.0),
+      TEN_M("10m", 10.0),
+      THIRTY_TWO_M("32m", 32.0);
+
+      private final String id;
+      private final double meters;
+
+      private Tier(String id, double meters) {
+         this.id = id;
+         this.meters = meters;
+      }
+
+      private static ArcticDemElevationSource.Tier forScale(double worldScale) {
+         if (worldScale >= THIRTY_TWO_M.meters) {
+            return THIRTY_TWO_M;
+         } else {
+            return worldScale >= TEN_M.meters ? TEN_M : TWO_M;
+         }
+      }
+   }
+
+   private record TileEntry(String url, double xMin, double yMin, double xMax, double yMax) {
+      private boolean contains(double x, double y) {
+         return x >= this.xMin && x <= this.xMax && y >= this.yMin && y <= this.yMax;
+      }
+
+      private double widthMeters() {
+         return this.xMax - this.xMin;
+      }
+   }
+
+   private static final class TileFile {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_BITS_PER_SAMPLE = 258;
+      private static final int TAG_SAMPLE_FORMAT = 339;
+      private static final int TAG_PREDICTOR = 317;
+      private static final int TAG_SAMPLES_PER_PIXEL = 277;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int TYPE_DOUBLE = 12;
+      private static final int TYPE_LONG8 = 16;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private final String url;
+      private final ArcticDemElevationSource.RangeReader reader;
+      private final ByteOrder order;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final int predictor;
+      private final int bytesPerSample;
+      private final int samplesPerPixel;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final String sourceLabel;
+      private final Map<Integer, float[]> tileCache;
+      private volatile boolean failed;
+
+      private TileFile(
+         String url,
+         ArcticDemElevationSource.RangeReader reader,
+         ByteOrder order,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         int predictor,
+         int bytesPerSample,
+         int samplesPerPixel,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         String sourceLabel,
+         int maxTileCache
+      ) {
+         this.url = url;
+         this.reader = reader;
+         this.order = order;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.compression = compression;
+         this.predictor = predictor;
+         this.bytesPerSample = bytesPerSample;
+         this.samplesPerPixel = samplesPerPixel;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.sourceLabel = sourceLabel;
+         this.tileCache = new LinkedHashMap<Integer, float[]>(maxTileCache, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, float[]> eldest) {
+               return this.size() > maxTileCache;
+            }
+         };
+      }
+
+      private double sample(ArcticDemElevationSource.TileEntry tile, double x, double y, double pixelSize) {
+         if (this.failed) {
+            return Double.NaN;
+         } else {
+            double localX = (x - tile.xMin()) / pixelSize;
+            double localY = (tile.yMax() - y) / pixelSize;
+            return !this.isWithinImage(localX, localY) ? Double.NaN : this.sampleBilinear(localX, localY);
+         }
+      }
+
+      private ArcticDemElevationSource.TileFile.SampleResult sampleWithDebug(ArcticDemElevationSource.TileEntry tile, double x, double y, double pixelSize) {
+         if (this.failed) {
+            return new ArcticDemElevationSource.TileFile.SampleResult(Double.NaN, null);
+         } else {
+            double localX = (x - tile.xMin()) / pixelSize;
+            double localY = (tile.yMax() - y) / pixelSize;
+            if (!this.isWithinImage(localX, localY)) {
+               return new ArcticDemElevationSource.TileFile.SampleResult(Double.NaN, null);
+            } else {
+               int x0 = Mth.clamp(Mth.floor(localX), 0, this.width - 1);
+               int y0 = Mth.clamp(Mth.floor(localY), 0, this.height - 1);
+               int x1 = Math.min(x0 + 1, this.width - 1);
+               int y1 = Math.min(y0 + 1, this.height - 1);
+               float v00 = this.sampleValue(x0, y0);
+               float v10 = this.sampleValue(x1, y0);
+               float v01 = this.sampleValue(x0, y1);
+               float v11 = this.sampleValue(x1, y1);
+               double dx = localX - x0;
+               double dy = localY - y0;
+               double value = blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+               return new ArcticDemElevationSource.TileFile.SampleResult(
+                  value, new ArcticDemElevationSource.TileFile.SampleDebug(localX, localY, x0, y0, x1, y1, v00, v10, v01, v11)
+               );
+            }
+         }
+      }
+
+      private double sampleBilinear(double localX, double localY) {
+         int x0 = Mth.clamp(Mth.floor(localX), 0, this.width - 1);
+         int y0 = Mth.clamp(Mth.floor(localY), 0, this.height - 1);
+         int x1 = Math.min(x0 + 1, this.width - 1);
+         int y1 = Math.min(y0 + 1, this.height - 1);
+         float v00 = this.sampleValue(x0, y0);
+         float v10 = this.sampleValue(x1, y0);
+         float v01 = this.sampleValue(x0, y1);
+         float v11 = this.sampleValue(x1, y1);
+         double dx = localX - x0;
+         double dy = localY - y0;
+         return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+      }
+
+      private boolean isWithinImage(double localX, double localY) {
+         return localX >= 0.0 && localY >= 0.0 && localX < this.width && localY < this.height;
+      }
+
+      private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+         double w00 = (1.0 - dx) * (1.0 - dy);
+         double w10 = dx * (1.0 - dy);
+         double w01 = (1.0 - dx) * dy;
+         double w11 = dx * dy;
+         double sum = 0.0;
+         double weight = 0.0;
+         if (Float.isFinite(v00)) {
+            sum += v00 * w00;
+            weight += w00;
+         }
+
+         if (Float.isFinite(v10)) {
+            sum += v10 * w10;
+            weight += w10;
+         }
+
+         if (Float.isFinite(v01)) {
+            sum += v01 * w01;
+            weight += w01;
+         }
+
+         if (Float.isFinite(v11)) {
+            sum += v11 * w11;
+            weight += w11;
+         }
+
+         return weight <= 0.0 ? Double.NaN : sum / weight;
+      }
+
+      private float sampleValue(int pixelX, int pixelY) {
+         if (this.failed) {
+            return Float.NaN;
+         } else {
+            int tileX = pixelX / this.tileWidth;
+            int tileY = pixelY / this.tileHeight;
+            int tileIndex = tileY * this.tilesPerRow + tileX;
+
+            float[] tile;
+            try {
+               tile = this.getTile(tileIndex);
+            } catch (IOException var10) {
+               this.failed = true;
+               if (Thread.currentThread().isInterrupted()) {
+                  Thread.currentThread().interrupt();
+               }
+
+               Tellus.LOGGER.debug("Failed to read {} tile {} from {}", new Object[]{this.sourceLabel, tileIndex, this.url, var10});
+               return Float.NaN;
+            }
+
+            int localX = pixelX - tileX * this.tileWidth;
+            int localY = pixelY - tileY * this.tileHeight;
+            float value = tile[localX + localY * this.tileWidth];
+            return Float.isFinite(value) && !(value <= (float)(NO_DATA + 1.0)) ? value : Float.NaN;
+         }
+      }
+
+      private boolean hasFailure() {
+         return this.failed;
+      }
+
+      private float[] getTile(int tileIndex) throws IOException {
+         synchronized (this.tileCache) {
+            float[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         float[] tile = this.readTile(tileIndex);
+         synchronized (this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private float[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = this.reader.read(offset, length);
+         int expectedSize = this.tileWidth * this.tileHeight * this.bytesPerSample * this.samplesPerPixel;
+         if (this.samplesPerPixel != 1) {
+            throw new IOException("Unsupported TIFF samples per pixel " + this.samplesPerPixel);
+         } else {
+            byte[] raw = switch (this.compression) {
+               case COMPRESSION_LZW -> decompressLzw(compressed, expectedSize);
+               case COMPRESSION_DEFLATE -> inflate(compressed, expectedSize);
+               default -> throw new IOException("Unsupported TIFF compression " + this.compression);
+            };
+            if (this.predictor == 3) {
+               applyFloatingPointPredictor(raw, this.tileWidth, this.tileHeight, this.bytesPerSample, this.samplesPerPixel, this.order);
+            } else if (this.predictor != 1) {
+               throw new IOException("Unsupported TIFF predictor " + this.predictor);
+            }
+
+            float[] values = new float[this.tileWidth * this.tileHeight];
+            ByteBuffer buffer = ByteBuffer.wrap(raw).order(this.order);
+
+            for (int i = 0; i < values.length; i++) {
+               values[i] = buffer.getFloat();
+            }
+
+            return values;
+         }
+      }
+
+      private static ArcticDemElevationSource.TileFile open(String url, int maxTileCache, String sourceLabel) throws IOException {
+         ArcticDemElevationSource.RangeReader reader = new ArcticDemElevationSource.RangeReader(url);
+         byte[] header = reader.read(0L, 32);
+
+         ByteOrder order = switch (header[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid TIFF byte order");
+         };
+         ByteBuffer headerBuf = ByteBuffer.wrap(header).order(order);
+         headerBuf.getShort();
+         short magic = headerBuf.getShort();
+         if (magic != 43) {
+            throw new IOException("Expected BigTIFF magic");
+         } else {
+            headerBuf.getShort();
+            headerBuf.getShort();
+            long ifdOffset = headerBuf.getLong();
+            byte[] countBytes = reader.read(ifdOffset, 8);
+            long entryCount = ByteBuffer.wrap(countBytes).order(order).getLong();
+            if (entryCount > 0L && entryCount <= 1000000L) {
+               byte[] entryBytes = reader.read(ifdOffset + 8L, (int)entryCount * 20);
+               ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+               int width = -1;
+               int height = -1;
+               int tileWidth = -1;
+               int tileHeight = -1;
+               int compression = -1;
+               int predictor = 1;
+               int bitsPerSample = -1;
+               int sampleFormat = -1;
+               int samplesPerPixel = 1;
+               long[] tileOffsets = null;
+               int[] tileByteCounts = null;
+
+               for (int i = 0; i < entryCount; i++) {
+                  int tag = Short.toUnsignedInt(entries.getShort());
+                  int type = Short.toUnsignedInt(entries.getShort());
+                  long count = entries.getLong();
+                  long value = entries.getLong();
+                  switch (tag) {
+                     case TAG_IMAGE_WIDTH:
+                        width = readIntValue(type, count, value);
+                        break;
+                     case TAG_IMAGE_HEIGHT:
+                        height = readIntValue(type, count, value);
+                        break;
+                     case TAG_BITS_PER_SAMPLE:
+                        bitsPerSample = readIntValue(type, count, value);
+                        break;
+                     case TAG_COMPRESSION:
+                        compression = readIntValue(type, count, value);
+                        break;
+                     case TAG_SAMPLES_PER_PIXEL:
+                        samplesPerPixel = readIntValue(type, count, value);
+                        break;
+                     case TAG_PREDICTOR:
+                        predictor = readIntValue(type, count, value);
+                        break;
+                     case TAG_TILE_WIDTH:
+                        tileWidth = readIntValue(type, count, value);
+                        break;
+                     case TAG_TILE_HEIGHT:
+                        tileHeight = readIntValue(type, count, value);
+                        break;
+                     case TAG_TILE_OFFSETS:
+                        tileOffsets = readLongArray(reader, value, count, type, order);
+                        break;
+                     case TAG_TILE_BYTE_COUNTS:
+                        tileByteCounts = readIntArray(reader, value, count, type, order);
+                        break;
+                     case TAG_SAMPLE_FORMAT:
+                        sampleFormat = readIntValue(type, count, value);
+                  }
+               }
+
+               if (width <= 0 || height <= 0 || tileWidth <= 0 || tileHeight <= 0) {
+                  throw new IOException("Missing TIFF size tags");
+               } else if (tileOffsets == null || tileByteCounts == null) {
+                  throw new IOException("Missing TIFF tile offsets");
+               } else if (bitsPerSample == 32 && sampleFormat == 3) {
+                  return new ArcticDemElevationSource.TileFile(
+                     url,
+                     reader,
+                     order,
+                     width,
+                     height,
+                     tileWidth,
+                     tileHeight,
+                     compression,
+                     predictor,
+                     4,
+                     samplesPerPixel,
+                     tileOffsets,
+                     tileByteCounts,
+                     sourceLabel,
+                     maxTileCache
+                  );
+               } else {
+                  throw new IOException("Unsupported TIFF sample format " + sampleFormat + " bits " + bitsPerSample);
+               }
+            } else {
+               throw new IOException("Invalid BigTIFF entry count " + entryCount);
+            }
+         }
+      }
+
+      private static int readIntValue(int type, long count, long value) throws IOException {
+         if (count != 1L) {
+            throw new IOException("Expected single TIFF value");
+         } else if (type == TYPE_SHORT) {
+            return (int)(value & 65535L);
+         } else if (type == TYPE_LONG) {
+            return (int)(value & 4294967295L);
+         } else if (type == TYPE_LONG8) {
+            if (value > 2147483647L) {
+               throw new IOException("TIFF value out of range " + value);
+            } else {
+               return (int)value;
+            }
+         } else {
+            throw new IOException("Unsupported TIFF value type " + type);
+         }
+      }
+
+      private static long[] readLongArray(ArcticDemElevationSource.RangeReader reader, long offset, long count, int type, ByteOrder order) throws IOException {
+         if (count <= 0L) {
+            return new long[0];
+         } else {
+            int size = typeSize(type);
+            if (size <= 0) {
+               throw new IOException("Unsupported TIFF array type " + type);
+            } else {
+               long byteSize = count * size;
+               if (byteSize > 2147483647L) {
+                  throw new IOException("TIFF array too large");
+               } else {
+                  byte[] data = reader.read(offset, (int)byteSize);
+                  ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+                  long[] values = new long[(int)count];
+
+                  for (int i = 0; i < count; i++) {
+                     values[i] = switch (type) {
+                        case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+                        case TYPE_LONG -> Integer.toUnsignedLong(buffer.getInt());
+                        case TYPE_LONG8 -> buffer.getLong();
+                        default -> throw new IOException("Unsupported TIFF array type " + type);
+                     };
+                  }
+
+                  return values;
+               }
+            }
+         }
+      }
+
+      private static int[] readIntArray(ArcticDemElevationSource.RangeReader reader, long offset, long count, int type, ByteOrder order) throws IOException {
+         long[] values = readLongArray(reader, offset, count, type, order);
+         int[] output = new int[values.length];
+
+         for (int i = 0; i < values.length; i++) {
+            if (values[i] > 2147483647L) {
+               throw new IOException("TIFF byte count too large " + values[i]);
+            }
+
+            output[i] = (int)values[i];
+         }
+
+         return output;
+      }
+
+      private static int typeSize(int type) {
+         return switch (type) {
+            case TYPE_SHORT -> 2;
+            case TYPE_LONG -> 4;
+            case TYPE_DOUBLE, TYPE_LONG8 -> 8;
+            default -> 0;
+         };
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         byte[] var8;
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            }
+
+            var8 = output;
+         }
+
+         return var8;
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[][] table = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            table[i] = new byte[]{(byte)i};
+         }
+
+         int clearCode = 256;
+         int endCode = 257;
+         int codeSize = 9;
+         int nextCode = 258;
+         byte[] output = new byte[expectedSize];
+         int outPos = 0;
+         ArcticDemElevationSource.TileFile.LzwBitReader reader = new ArcticDemElevationSource.TileFile.LzwBitReader(compressed);
+         byte[] previous = null;
+
+         while (true) {
+            int code = reader.read(codeSize);
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 0; i < 256; i++) {
+                  table[i] = new byte[]{(byte)i};
+               }
+
+               for (int i = 256; i < table.length; i++) {
+                  table[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else {
+               if (code == endCode) {
+                  break;
+               }
+
+               byte[] entry;
+               if (code < nextCode && table[code] != null) {
+                  entry = table[code];
+               } else {
+                  if (code != nextCode || previous == null) {
+                     throw new IOException("Invalid LZW code " + code);
+                  }
+
+                  entry = concat(previous, previous[0]);
+               }
+
+               if (outPos + entry.length > output.length) {
+                  throw new IOException("Unexpected LZW output size");
+               }
+
+               System.arraycopy(entry, 0, output, outPos, entry.length);
+               outPos += entry.length;
+               if (previous != null && nextCode < table.length) {
+                  table[nextCode++] = concat(previous, entry[0]);
+                  int threshold = (1 << codeSize) - 1;
+                  if (nextCode == threshold && codeSize < 12) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+               if (outPos == output.length) {
+                  break;
+               }
+            }
+         }
+
+         if (outPos != output.length) {
+            throw new IOException("Unexpected LZW output length " + outPos);
+         } else {
+            return output;
+         }
+      }
+
+      private static void applyFloatingPointPredictor(byte[] data, int width, int height, int bytesPerSample, int samplesPerPixel, ByteOrder order) throws IOException {
+         int rowBytes = width * bytesPerSample * samplesPerPixel;
+         if (rowBytes > 0) {
+            if (samplesPerPixel > 0 && rowBytes % (bytesPerSample * samplesPerPixel) == 0) {
+               int wordCount = rowBytes / bytesPerSample;
+               byte[] tmp = new byte[rowBytes];
+
+               for (int row = 0; row < height; row++) {
+                  int rowStart = row * rowBytes;
+                  int count = rowBytes;
+
+                  for (int offset = rowStart; count > samplesPerPixel; count -= samplesPerPixel) {
+                     for (int i = 0; i < samplesPerPixel; i++) {
+                        int target = offset + samplesPerPixel;
+                        int value = (data[target] & 255) + (data[offset] & 255);
+                        data[target] = (byte)value;
+                        offset++;
+                     }
+                  }
+
+                  System.arraycopy(data, rowStart, tmp, 0, rowBytes);
+
+                  for (int word = 0; word < wordCount; word++) {
+                     int base = rowStart + word * bytesPerSample;
+
+                     for (int byteIndex = 0; byteIndex < bytesPerSample; byteIndex++) {
+                        int sourceIndex = order == ByteOrder.BIG_ENDIAN ? byteIndex * wordCount + word : (bytesPerSample - byteIndex - 1) * wordCount + word;
+                        data[base + byteIndex] = tmp[sourceIndex];
+                     }
+                  }
+               }
+            } else {
+               throw new IOException("Invalid floating point predictor stride");
+            }
+         }
+      }
+
+      private static byte[] concat(byte[] prefix, byte suffix) {
+         byte[] combined = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, combined, 0, prefix.length);
+         combined[prefix.length] = suffix;
+         return combined;
+      }
+
+      private static final class LzwBitReader {
+         private final byte[] data;
+         private int bitPos;
+
+         private LzwBitReader(byte[] data) {
+            this.data = data;
+         }
+
+         private int read(int bits) {
+            int totalBits = this.data.length * 8;
+            if (this.bitPos + bits > totalBits) {
+               return -1;
+            } else {
+               int result = 0;
+
+               for (int i = 0; i < bits; i++) {
+                  int byteIndex = (this.bitPos + i) / 8;
+                  int bitIndex = 7 - (this.bitPos + i) % 8;
+                  int bit = this.data[byteIndex] >> bitIndex & 1;
+                  result = result << 1 | bit;
+               }
+
+               this.bitPos += bits;
+               return result;
+            }
+         }
+      }
+
+      private record SampleDebug(double localX, double localY, int x0, int y0, int x1, int y1, float v00, float v10, float v01, float v11) {
+      }
+
+      private record SampleResult(double value, ArcticDemElevationSource.TileFile.SampleDebug debug) {
+      }
+   }
+
+   private static final class TileIndex {
+      private static final Pattern GEO_TRANSFORM_PATTERN = Pattern.compile("<GeoTransform>([^<]+)</GeoTransform>");
+      private static final Pattern TILE_PATTERN = Pattern.compile(
+         "<ComplexSource>\\s*<SourceFilename[^>]*>([^<]+)</SourceFilename>.*?<SourceProperties[^>]*RasterXSize=\\\"(\\d+)\\\" RasterYSize=\\\"(\\d+)\\\".*?>.*?<DstRect xOff=\\\"(\\d+)\\\" yOff=\\\"(\\d+)\\\" xSize=\\\"(\\d+)\\\" ySize=\\\"(\\d+)\\\"",
+         32
+      );
+      private final double pixelSize;
+      private final double minX;
+      private final double minY;
+      private final double maxX;
+      private final double maxY;
+      private final double tileSpanMeters;
+      private final Map<Long, List<ArcticDemElevationSource.TileEntry>> buckets;
+
+      private TileIndex(
+         double pixelSize,
+         double minX,
+         double minY,
+         double maxX,
+         double maxY,
+         double tileSpanMeters,
+         Map<Long, List<ArcticDemElevationSource.TileEntry>> buckets
+      ) {
+         this.pixelSize = pixelSize;
+         this.minX = minX;
+         this.minY = minY;
+         this.maxX = maxX;
+         this.maxY = maxY;
+         this.tileSpanMeters = tileSpanMeters;
+         this.buckets = buckets;
+      }
+
+      private ArcticDemElevationSource.TileEntry findTile(double x, double y) {
+         if (!(x < this.minX) && !(x > this.maxX) && !(y < this.minY) && !(y > this.maxY)) {
+            int bx = (int)Math.floor((x - this.minX) / BUCKET_SIZE_METERS);
+            int by = (int)Math.floor((y - this.minY) / BUCKET_SIZE_METERS);
+            long key = ArcticDemElevationSource.bucketKey(bx, by);
+            List<ArcticDemElevationSource.TileEntry> bucket = this.buckets.get(key);
+            if (bucket == null) {
+               return null;
+            } else {
+               for (ArcticDemElevationSource.TileEntry tile : bucket) {
+                  if (tile.contains(x, y)) {
+                     return tile;
+                  }
+               }
+
+               return null;
+            }
+         } else {
+            return null;
+         }
+      }
+
+      private static ArcticDemElevationSource.TileIndex load(ArcticDemElevationSource.Tier tier, Path cacheRoot, String baseUrl) throws IOException {
+         Path cachePath = cacheRoot.resolve(tier.id + "_dem_tiles.vrt");
+         String vrtText;
+         if (Files.exists(cachePath)) {
+            vrtText = new String(Files.readAllBytes(cachePath), StandardCharsets.UTF_8);
+         } else {
+            vrtText = downloadVrt(tier, cachePath, baseUrl);
+         }
+
+         Matcher geoMatcher = GEO_TRANSFORM_PATTERN.matcher(vrtText);
+         if (!geoMatcher.find()) {
+            throw new IOException("Missing GeoTransform in ArcticDEM VRT");
+         } else {
+            double[] transform = parseGeoTransform(geoMatcher.group(1));
+            double originX = transform[0];
+            double pixelSizeX = transform[1];
+            double originY = transform[3];
+            double pixelSizeY = transform[5];
+            List<ArcticDemElevationSource.TileEntry> tiles = new ArrayList<>();
+            double minX = Double.POSITIVE_INFINITY;
+            double minY = Double.POSITIVE_INFINITY;
+            double maxX = Double.NEGATIVE_INFINITY;
+            double maxY = Double.NEGATIVE_INFINITY;
+            Matcher tileMatcher = TILE_PATTERN.matcher(vrtText);
+
+            while (tileMatcher.find()) {
+               String src = tileMatcher.group(1);
+               long xOff = Long.parseLong(tileMatcher.group(4));
+               long yOff = Long.parseLong(tileMatcher.group(5));
+               int xSize = Integer.parseInt(tileMatcher.group(6));
+               int ySize = Integer.parseInt(tileMatcher.group(7));
+               double xMin = originX + xOff * pixelSizeX;
+               double yMax = originY + yOff * pixelSizeY;
+               double xMax = xMin + xSize * pixelSizeX;
+               double yMin = yMax + ySize * pixelSizeY;
+               String url = toHttpUrl(src);
+               ArcticDemElevationSource.TileEntry tile = new ArcticDemElevationSource.TileEntry(
+                  url, Math.min(xMin, xMax), Math.min(yMin, yMax), Math.max(xMin, xMax), Math.max(yMin, yMax)
+               );
+               tiles.add(tile);
+               minX = Math.min(minX, tile.xMin());
+               minY = Math.min(minY, tile.yMin());
+               maxX = Math.max(maxX, tile.xMax());
+               maxY = Math.max(maxY, tile.yMax());
+            }
+
+            if (tiles.isEmpty()) {
+               throw new IOException("No tiles found in ArcticDEM VRT");
+            } else {
+               double tileSpanMeters = medianTileSpan(tiles);
+               Map<Long, List<ArcticDemElevationSource.TileEntry>> buckets = buildBuckets(tiles, minX, minY);
+               return new ArcticDemElevationSource.TileIndex(Math.abs(pixelSizeX), minX, minY, maxX, maxY, tileSpanMeters, buckets);
+            }
+         }
+      }
+
+      private static Map<Long, List<ArcticDemElevationSource.TileEntry>> buildBuckets(List<ArcticDemElevationSource.TileEntry> tiles, double minX, double minY) {
+         Map<Long, List<ArcticDemElevationSource.TileEntry>> buckets = new LinkedHashMap<>();
+
+         for (ArcticDemElevationSource.TileEntry tile : tiles) {
+            int bx0 = (int)Math.floor((tile.xMin() - minX) / BUCKET_SIZE_METERS);
+            int bx1 = (int)Math.floor((tile.xMax() - minX) / BUCKET_SIZE_METERS);
+            int by0 = (int)Math.floor((tile.yMin() - minY) / BUCKET_SIZE_METERS);
+            int by1 = (int)Math.floor((tile.yMax() - minY) / BUCKET_SIZE_METERS);
+
+            for (int by = by0; by <= by1; by++) {
+               for (int bx = bx0; bx <= bx1; bx++) {
+                  long key = ArcticDemElevationSource.bucketKey(bx, by);
+                  buckets.computeIfAbsent(key, ignored -> new ArrayList<>()).add(tile);
+               }
+            }
+         }
+
+         return buckets;
+      }
+
+      private static double medianTileSpan(List<ArcticDemElevationSource.TileEntry> tiles) {
+         double[] spans = new double[tiles.size()];
+
+         for (int i = 0; i < tiles.size(); i++) {
+            spans[i] = tiles.get(i).widthMeters();
+         }
+
+         Arrays.sort(spans);
+         return spans[spans.length / 2];
+      }
+
+      private static double[] parseGeoTransform(String text) {
+         String[] parts = text.trim().split(",");
+         if (parts.length < 6) {
+            throw new IllegalArgumentException("Invalid GeoTransform");
+         } else {
+            double[] values = new double[6];
+
+            for (int i = 0; i < 6; i++) {
+               values[i] = Double.parseDouble(parts[i].trim());
+            }
+
+            return values;
+         }
+      }
+
+      private static String downloadVrt(ArcticDemElevationSource.Tier tier, Path cachePath, String baseUrl) throws IOException {
+         URI uri = URI.create(String.format("%s/%s_dem_tiles.vrt", baseUrl, tier.id));
+         HttpURLConnection connection = ArcticDemElevationSource.openConnection(uri);
+
+         byte[] data;
+         try {
+            DownloadProgressReporter.requestStarted(Math.max(0L, connection.getContentLengthLong()));
+            try (InputStream input = connection.getInputStream()) {
+               data = DownloadProgressReporter.readAllBytesWithProgress(input);
+            }
+         } finally {
+            DownloadProgressReporter.requestFinished();
+            connection.disconnect();
+         }
+
+         Files.createDirectories(cachePath.getParent());
+         Files.write(cachePath, data);
+         return new String(data, StandardCharsets.UTF_8);
+      }
+
+      private static String toHttpUrl(String sourceFilename) {
+         String trimmed = sourceFilename.trim();
+         String prefix = "/vsis3/";
+         if (trimmed.startsWith(prefix)) {
+            String path = trimmed.substring(prefix.length());
+            int slash = path.indexOf(47);
+            if (slash > 0) {
+               String bucket = path.substring(0, slash);
+               String key = path.substring(slash + 1);
+               return "https://" + bucket + ".s3.us-west-2.amazonaws.com/" + key;
+            }
+         }
+
+         return trimmed;
+      }
+   }
+
+   private static final class TileLookup {
+      private ArcticDemElevationSource.Tier tier;
+      private ArcticDemElevationSource.TileEntry tile;
+
+      private ArcticDemElevationSource.TileEntry get(ArcticDemElevationSource.Tier tier, double x, double y) {
+         if (this.tile != null && this.tier == tier) {
+            return this.tile.contains(x, y) ? this.tile : null;
+         } else {
+            return null;
+         }
+      }
+
+      private void update(ArcticDemElevationSource.Tier tier, ArcticDemElevationSource.TileEntry tile) {
+         this.tier = tier;
+         this.tile = tile;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/CanElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/CanElevationSource.java
@@ -1,0 +1,1435 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class CanElevationSource implements TellusCacheHandle {
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final int MAX_FILE_CACHE = intProperty("tellus.canelevation.cacheFiles", 8);
+   private static final int MAX_TILE_CACHE = intProperty("tellus.canelevation.cacheTiles", 16);
+   private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("tellus.canelevation.enabled", "true"));
+   private static final double DEFAULT_NO_DATA = -9999.0;
+   private static final double PROJ_A = 6378137.0;
+   private static final double PROJ_INV_F = 298.257222101;
+   private static final double PROJ_F = 1.0 / PROJ_INV_F;
+   private static final double PROJ_E2 = 2.0 * PROJ_F - PROJ_F * PROJ_F;
+   private static final double PROJ_E = Math.sqrt(PROJ_E2);
+   private static final double PROJ_LAT_0 = Math.toRadians(49.0);
+   private static final double PROJ_LON_0 = Math.toRadians(-95.0);
+   private static final double PROJ_LAT_1 = Math.toRadians(49.0);
+   private static final double PROJ_LAT_2 = Math.toRadians(77.0);
+   private static final double PROJ_M1 = m(PROJ_LAT_1);
+   private static final double PROJ_M2 = m(PROJ_LAT_2);
+   private static final double PROJ_T0 = t(PROJ_LAT_0);
+   private static final double PROJ_T1 = t(PROJ_LAT_1);
+   private static final double PROJ_T2 = t(PROJ_LAT_2);
+   private static final double PROJ_N = Math.abs(PROJ_LAT_1 - PROJ_LAT_2) < 1.0E-12
+      ? Math.sin(PROJ_LAT_1)
+      : (Math.log(PROJ_M1) - Math.log(PROJ_M2)) / (Math.log(PROJ_T1) - Math.log(PROJ_T2));
+   private static final double PROJ_F0 = PROJ_M1 / (PROJ_N * Math.pow(PROJ_T1, PROJ_N));
+   private static final double PROJ_RHO_0 = PROJ_A * PROJ_F0 * Math.pow(PROJ_T0, PROJ_N);
+   private final Path cacheRoot;
+   private final CanElevationCoverageIndex coverageIndex = CanElevationCoverageIndex.create();
+   private final LoadingCache<CanElevationSource.TileCacheKey, CanElevationSource.TileFile> fileCache;
+
+   public CanElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-canelevation");
+      this.fileCache = CacheBuilder.newBuilder().maximumSize(MAX_FILE_CACHE).build(new CacheLoader<CanElevationSource.TileCacheKey, CanElevationSource.TileFile>() {
+         public CanElevationSource.TileFile load(CanElevationSource.TileCacheKey key) throws Exception {
+            return CanElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isLikelyInCoverage(double lat, double lon) {
+      return ENABLED && this.coverageIndex.available() && this.coverageIndex.containsCanada(lat, lon);
+   }
+
+   public CanElevationSource.Sample sample(double blockX, double blockZ, double worldScale) {
+      return this.sample(blockX, blockZ, worldScale, Double.NaN);
+   }
+
+   public CanElevationSource.Sample sample(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return CanElevationSource.Sample.none();
+      } else {
+         CanElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? CanElevationSource.Sample.none() : this.sampleAtLatLon(latLon.lat(), latLon.lon(), targetResolutionMeters);
+      }
+   }
+
+   public CanElevationSource.Sample sampleLocalOnly(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return CanElevationSource.Sample.none();
+      } else {
+         CanElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? CanElevationSource.Sample.none() : this.sampleAtLatLonLocalOnly(latLon.lat(), latLon.lon(), targetResolutionMeters);
+      }
+   }
+
+   public CanElevationSource.Sample sample(double lat, double lon) {
+      return this.sampleAtLatLon(lat, lon, Double.NaN);
+   }
+
+   private CanElevationSource.Sample sampleAtLatLon(double lat, double lon, double targetResolutionMeters) {
+      if (!this.canUse() || !this.coverageIndex.containsCanada(lat, lon)) {
+         return CanElevationSource.Sample.none();
+      } else {
+         CanElevationCoverageIndex.TileReference highResTile = this.coverageIndex.findHighResTile(lat, lon);
+         if (highResTile != null) {
+            CanElevationSource.Sample highResSample = this.sample(
+               highResTile,
+               lat,
+               lon,
+               TellusElevationSource.DemUsage.CANELEVATION_2M,
+               targetResolutionMeters
+            );
+            if (highResSample.usable()) {
+               return highResSample;
+            }
+         }
+
+         CanElevationCoverageIndex.TileReference nationalTile = this.coverageIndex.nationalTile();
+         return nationalTile != null
+            ? this.sample(nationalTile, lat, lon, TellusElevationSource.DemUsage.CANELEVATION_30M, targetResolutionMeters)
+            : CanElevationSource.Sample.none();
+      }
+   }
+
+   private CanElevationSource.Sample sampleAtLatLonLocalOnly(double lat, double lon, double targetResolutionMeters) {
+      if (!this.canUse() || !this.coverageIndex.containsCanada(lat, lon)) {
+         return CanElevationSource.Sample.none();
+      } else {
+         CanElevationCoverageIndex.TileReference highResTile = this.coverageIndex.findHighResTile(lat, lon);
+         if (highResTile != null) {
+            CanElevationSource.Sample highResSample = this.sampleLocalOnly(
+               highResTile,
+               lat,
+               lon,
+               TellusElevationSource.DemUsage.CANELEVATION_2M,
+               targetResolutionMeters
+            );
+            if (highResSample.usable()) {
+               return highResSample;
+            }
+         }
+
+         CanElevationCoverageIndex.TileReference nationalTile = this.coverageIndex.nationalTile();
+         return nationalTile != null
+            ? this.sampleLocalOnly(nationalTile, lat, lon, TellusElevationSource.DemUsage.CANELEVATION_30M, targetResolutionMeters)
+            : CanElevationSource.Sample.none();
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, Double.NaN);
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius, double targetResolutionMeters) {
+      if (!(worldScale <= 0.0) && radius > 0 && this.canUse()) {
+         LinkedHashSet<CanElevationCoverageIndex.TileReference> refs = new LinkedHashSet<>();
+         double blockRadius = Math.max(1, radius) * 256.0;
+
+         for (int dz = -1; dz <= 1; dz++) {
+            for (int dx = -1; dx <= 1; dx++) {
+               CanElevationSource.LatLon latLon = toLatLon(blockX + dx * blockRadius, blockZ + dz * blockRadius, worldScale);
+               if (latLon != null && this.coverageIndex.containsCanada(latLon.lat(), latLon.lon())) {
+                  CanElevationCoverageIndex.TileReference highResTile = this.coverageIndex.findHighResTile(latLon.lat(), latLon.lon());
+                  if (highResTile != null) {
+                     refs.add(highResTile);
+                  }
+
+                  CanElevationCoverageIndex.TileReference nationalTile = this.coverageIndex.nationalTile();
+                  if (nationalTile != null) {
+                     refs.add(nationalTile);
+                  }
+               }
+            }
+         }
+
+         for (CanElevationCoverageIndex.TileReference ref : refs) {
+            this.prefetchTile(ref, targetResolutionMeters);
+         }
+      }
+   }
+
+   private CanElevationSource.Sample sample(
+      CanElevationCoverageIndex.TileReference tileRef,
+      double lat,
+      double lon,
+      TellusElevationSource.DemUsage usage,
+      double targetResolutionMeters
+   ) {
+      CanElevationSource.Projection projection = project(lat, lon);
+      if (projection == null) {
+         return CanElevationSource.Sample.none();
+      } else {
+         CanElevationSource.TileFile tile = this.getTile(tileRef, usage, targetResolutionMeters);
+         if (tile == null) {
+            return CanElevationSource.Sample.none();
+         } else {
+            double value = tile.sampleProjected(projection.x(), projection.y());
+            return Double.isFinite(value)
+               ? new CanElevationSource.Sample(value, usage, tile.effectiveResolutionMeters())
+               : CanElevationSource.Sample.none();
+         }
+      }
+   }
+
+   private CanElevationSource.Sample sampleLocalOnly(
+      CanElevationCoverageIndex.TileReference tileRef,
+      double lat,
+      double lon,
+      TellusElevationSource.DemUsage usage,
+      double targetResolutionMeters
+   ) {
+      CanElevationSource.Projection projection = project(lat, lon);
+      if (projection == null) {
+         return CanElevationSource.Sample.none();
+      } else {
+         CanElevationSource.TileFile tile = this.getTileLocalOnly(tileRef, usage, targetResolutionMeters);
+         if (tile == null) {
+            return CanElevationSource.Sample.none();
+         } else {
+            double value = tile.sampleProjected(projection.x(), projection.y());
+            return Double.isFinite(value)
+               ? new CanElevationSource.Sample(value, usage, tile.effectiveResolutionMeters())
+               : CanElevationSource.Sample.none();
+         }
+      }
+   }
+
+   private boolean canUse() {
+      return ENABLED && this.coverageIndex.available();
+   }
+
+   private void prefetchTile(CanElevationCoverageIndex.TileReference tileRef, double targetResolutionMeters) {
+      CanElevationSource.TileCacheKey cacheKey = CanElevationSource.TileCacheKey.forTarget(tileRef, targetResolutionMeters);
+      if (this.fileCache.getIfPresent(cacheKey) == null) {
+         try {
+            this.fileCache.get(cacheKey);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch CANElevation tile {}", tileRef.id(), error);
+         }
+      }
+   }
+
+   private CanElevationSource.TileFile getTile(
+      CanElevationCoverageIndex.TileReference tileRef, TellusElevationSource.DemUsage usage, double targetResolutionMeters
+   ) {
+      CanElevationSource.TileCacheKey cacheKey = CanElevationSource.TileCacheKey.forTarget(tileRef, targetResolutionMeters);
+      try {
+         return this.fileCache.get(cacheKey);
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load CANElevation tile {}", tileRef.id(), error);
+         return null;
+      }
+   }
+
+   private CanElevationSource.TileFile getTileLocalOnly(
+      CanElevationCoverageIndex.TileReference tileRef, TellusElevationSource.DemUsage usage, double targetResolutionMeters
+   ) {
+      CanElevationSource.TileCacheKey cacheKey = CanElevationSource.TileCacheKey.forTarget(tileRef, targetResolutionMeters);
+      CanElevationSource.TileFile cached = this.fileCache.getIfPresent(cacheKey);
+      if (cached != null) {
+         return cached;
+      } else {
+         Path cacheDir = this.cacheRoot.resolve(tileRef.cacheDirectory());
+         if (!Files.isDirectory(cacheDir)) {
+            return null;
+         } else {
+            try {
+               CanElevationSource.TileFile opened = CanElevationSource.TileFile.openLocalOnly(
+                  tileRef, cacheDir, targetResolutionMeters, nativeResolutionMeters(tileRef)
+               );
+               CanElevationSource.TileFile raced = this.fileCache.asMap().putIfAbsent(cacheKey, opened);
+               return raced != null ? raced : opened;
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached CANElevation tile {}", tileRef.id(), error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private CanElevationSource.TileFile loadTile(CanElevationSource.TileCacheKey cacheKey) throws Exception {
+      CanElevationCoverageIndex.TileReference tileRef = cacheKey.tileRef();
+      return CanElevationSource.TileFile.open(
+         tileRef,
+         this.cacheRoot.resolve(tileRef.cacheDirectory()),
+         cacheKey.targetResolutionMeters(),
+         nativeResolutionMeters(tileRef)
+      );
+   }
+
+   private static CanElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0 ? new CanElevationSource.LatLon(lat, lon) : null;
+   }
+
+   private static CanElevationSource.Projection project(double latDeg, double lonDeg) {
+      if (!(latDeg >= -90.0) || !(latDeg <= 90.0) || !(lonDeg >= -180.0) || !(lonDeg <= 180.0)) {
+         return null;
+      } else {
+         double lat = Math.toRadians(latDeg);
+         double lon = Math.toRadians(lonDeg);
+         double rho = PROJ_A * PROJ_F0 * Math.pow(t(lat), PROJ_N);
+         double theta = PROJ_N * (lon - PROJ_LON_0);
+         double x = rho * Math.sin(theta);
+         double y = PROJ_RHO_0 - rho * Math.cos(theta);
+         return new CanElevationSource.Projection(x, y);
+      }
+   }
+
+   private static double m(double phi) {
+      double sin = Math.sin(phi);
+      return Math.cos(phi) / Math.sqrt(1.0 - PROJ_E2 * sin * sin);
+   }
+
+   private static double t(double phi) {
+      double sin = Math.sin(phi);
+      double part = (1.0 - PROJ_E * sin) / (1.0 + PROJ_E * sin);
+      return Math.tan(Math.PI / 4.0 - phi / 2.0) / Math.pow(part, PROJ_E / 2.0);
+   }
+
+   private static HttpURLConnection openConnection(URI uri, String rangeHeader) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+      if (rangeHeader != null) {
+         connection.setRequestProperty("Range", rangeHeader);
+      }
+
+      return connection;
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static double nativeResolutionMeters(CanElevationCoverageIndex.TileReference tileRef) {
+      return "mrdem".equals(tileRef.id()) ? 30.0 : 2.0;
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.CANELEVATION;
+   }
+
+   @Override
+   public void clearCache() {
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record Projection(double x, double y) {
+   }
+
+   private record TileCacheKey(CanElevationCoverageIndex.TileReference tileRef, int targetResolutionCentimeters) {
+      private TileCacheKey {
+         Objects.requireNonNull(tileRef, "tileRef");
+      }
+
+      private static CanElevationSource.TileCacheKey base(CanElevationCoverageIndex.TileReference tileRef) {
+         return new CanElevationSource.TileCacheKey(tileRef, 0);
+      }
+
+      private static CanElevationSource.TileCacheKey forTarget(CanElevationCoverageIndex.TileReference tileRef, double targetResolutionMeters) {
+         if (!(targetResolutionMeters > 0.0) || !Double.isFinite(targetResolutionMeters)) {
+            return base(tileRef);
+         } else {
+            return new CanElevationSource.TileCacheKey(tileRef, Math.max(1, (int)Math.round(targetResolutionMeters * 100.0)));
+         }
+      }
+
+      private double targetResolutionMeters() {
+         return this.targetResolutionCentimeters <= 0 ? Double.NaN : this.targetResolutionCentimeters / 100.0;
+      }
+   }
+
+   public record Sample(double elevation, TellusElevationSource.DemUsage usage, double resolutionMeters) {
+      private static CanElevationSource.Sample none() {
+         return new CanElevationSource.Sample(Double.NaN, null, Double.NaN);
+      }
+
+      public boolean usable() {
+         return this.usage != null && Double.isFinite(this.elevation);
+      }
+   }
+
+   private static final class CachedRangeReader {
+      private final CanElevationCoverageIndex.TileReference tileRef;
+      private final Path cacheDir;
+      private final boolean localOnly;
+
+      private CachedRangeReader(CanElevationCoverageIndex.TileReference tileRef, Path cacheDir) {
+         this(tileRef, cacheDir, false);
+      }
+
+      private CachedRangeReader(CanElevationCoverageIndex.TileReference tileRef, Path cacheDir, boolean localOnly) {
+         this.tileRef = Objects.requireNonNull(tileRef, "tileRef");
+         this.cacheDir = Objects.requireNonNull(cacheDir, "cacheDir");
+         this.localOnly = localOnly;
+      }
+
+      private byte[] read(long offset, int length) throws IOException {
+         if (length <= 0) {
+            return new byte[0];
+         } else {
+            Path cachePath = this.cacheDir.resolve(offset + "-" + length + ".bin");
+            byte[] cached = this.readCachedRange(cachePath, length);
+            if (cached != null) {
+               return cached;
+            } else {
+               if (this.localOnly) {
+                  throw new EOFException("CANElevation range not cached for " + this.tileRef.id());
+               }
+
+               byte[] data = this.readRemoteRange(offset, length);
+               this.writeCachedRange(cachePath, data);
+               return data;
+            }
+         }
+      }
+
+      private byte[] readCachedRange(Path cachePath, int expectedLength) throws IOException {
+         if (!Files.exists(cachePath)) {
+            return null;
+         } else {
+            byte[] data = Files.readAllBytes(cachePath);
+            if (data.length == expectedLength) {
+               return data;
+            } else {
+               Files.deleteIfExists(cachePath);
+               return null;
+            }
+         }
+      }
+
+      private byte[] readRemoteRange(long offset, int length) throws IOException {
+         String rangeHeader = "bytes=" + offset + "-" + (offset + length - 1L);
+         HttpURLConnection connection = CanElevationSource.openConnection(URI.create(this.tileRef.url()), rangeHeader);
+
+         try {
+            int status = connection.getResponseCode();
+            if (status != 200 && status != 206) {
+               throw new IOException("Unexpected CANElevation HTTP status " + status + " for " + this.tileRef.id());
+            } else {
+               DownloadProgressReporter.requestStarted((long)length);
+               try (InputStream input = connection.getInputStream()) {
+                  byte[] data = DownloadProgressReporter.readAllBytesWithProgress(input);
+                  if (data.length != length) {
+                     throw new EOFException("Unexpected CANElevation range length " + data.length + " for " + this.tileRef.id());
+                  } else {
+                     return data;
+                  }
+               }
+            }
+         } finally {
+            DownloadProgressReporter.requestFinished();
+            connection.disconnect();
+         }
+      }
+
+      private void writeCachedRange(Path cachePath, byte[] data) {
+         try {
+            Files.createDirectories(cachePath.getParent());
+            Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+            Files.write(tempPath, data);
+            Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to cache CANElevation range {}", cachePath, error);
+         }
+      }
+   }
+
+   private static final class TileFile {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_BITS_PER_SAMPLE = 258;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_STRIP_OFFSETS = 273;
+      private static final int TAG_SAMPLES_PER_PIXEL = 277;
+      private static final int TAG_ROWS_PER_STRIP = 278;
+      private static final int TAG_STRIP_BYTE_COUNTS = 279;
+      private static final int TAG_PREDICTOR = 317;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_SAMPLE_FORMAT = 339;
+      private static final int TAG_MODEL_PIXEL_SCALE = 33550;
+      private static final int TAG_MODEL_TIEPOINT = 33922;
+      private static final int TAG_GDAL_NODATA = 42113;
+      private static final int TYPE_BYTE = 1;
+      private static final int TYPE_ASCII = 2;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int TYPE_DOUBLE = 12;
+      private static final int TYPE_LONG8 = 16;
+      private static final int COMPRESSION_NONE = 1;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private final String tileId;
+      private final CanElevationSource.CachedRangeReader reader;
+      private final ByteOrder order;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final int predictor;
+      private final int bytesPerSample;
+      private final int samplesPerPixel;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final double originX;
+      private final double originY;
+      private final double pixelSizeX;
+      private final double pixelSizeY;
+      private final float noData;
+      private final Map<Integer, float[]> tileCache;
+
+      private TileFile(
+         String tileId,
+         CanElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         int predictor,
+         int bytesPerSample,
+         int samplesPerPixel,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         double originX,
+         double originY,
+         double pixelSizeX,
+         double pixelSizeY,
+         float noData
+      ) {
+         this.tileId = tileId;
+         this.reader = reader;
+         this.order = order;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.compression = compression;
+         this.predictor = predictor;
+         this.bytesPerSample = bytesPerSample;
+         this.samplesPerPixel = samplesPerPixel;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.originX = originX;
+         this.originY = originY;
+         this.pixelSizeX = pixelSizeX;
+         this.pixelSizeY = pixelSizeY;
+         this.noData = noData;
+         this.tileCache = new LinkedHashMap<Integer, float[]>(MAX_TILE_CACHE, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, float[]> eldest) {
+               return this.size() > MAX_TILE_CACHE;
+            }
+         };
+      }
+
+      private double sampleProjected(double x, double y) {
+         double globalX = (x - this.originX) / this.pixelSizeX;
+         double globalY = (this.originY - y) / this.pixelSizeY;
+         if (globalX < -1.0 || globalY < -1.0 || globalX > this.width || globalY > this.height) {
+            return Double.NaN;
+         } else {
+            int maxPixelX = this.width - 1;
+            int maxPixelY = this.height - 1;
+            double clampedX = Mth.clamp(globalX, 0.0, maxPixelX);
+            double clampedY = Mth.clamp(globalY, 0.0, maxPixelY);
+            int x0 = Mth.floor(clampedX);
+            int y0 = Mth.floor(clampedY);
+            int x1 = Math.min(x0 + 1, maxPixelX);
+            int y1 = Math.min(y0 + 1, maxPixelY);
+            double dx = clampedX - x0;
+            double dy = clampedY - y0;
+            float v00 = this.sampleValue(x0, y0);
+            float v10 = this.sampleValue(x1, y0);
+            float v01 = this.sampleValue(x0, y1);
+            float v11 = this.sampleValue(x1, y1);
+            return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+         }
+      }
+
+      private double effectiveResolutionMeters() {
+         return (Math.abs(this.pixelSizeX) + Math.abs(this.pixelSizeY)) * 0.5;
+      }
+
+      private float sampleValue(int pixelX, int pixelY) {
+         int clampedX = Mth.clamp(pixelX, 0, this.width - 1);
+         int clampedY = Mth.clamp(pixelY, 0, this.height - 1);
+         int tileX = clampedX / this.tileWidth;
+         int tileY = clampedY / this.tileHeight;
+         int tileIndex = tileY * this.tilesPerRow + tileX;
+
+         try {
+            float[] tile = this.getTile(tileIndex);
+            int localX = clampedX - tileX * this.tileWidth;
+            int localY = clampedY - tileY * this.tileHeight;
+            return tile[localX + localY * this.tileWidth];
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to read CANElevation tile {} block from {}", tileIndex, this.tileId, error);
+            return Float.NaN;
+         }
+      }
+
+      private float[] getTile(int tileIndex) throws IOException {
+         synchronized(this.tileCache) {
+            float[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         float[] tile = this.readTile(tileIndex);
+         synchronized(this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private float[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = this.reader.read(offset, length);
+         int expectedSize = this.tileWidth * this.tileHeight * this.bytesPerSample * this.samplesPerPixel;
+         if (this.samplesPerPixel != 1) {
+            throw new IOException("Unsupported CANElevation TIFF samples per pixel " + this.samplesPerPixel);
+         } else {
+            byte[] raw = switch (this.compression) {
+               case COMPRESSION_NONE -> compressed;
+               case COMPRESSION_LZW -> decompressLzw(compressed, expectedSize);
+               case COMPRESSION_DEFLATE -> inflate(compressed, expectedSize);
+               default -> throw new IOException("Unsupported CANElevation TIFF compression " + this.compression);
+            };
+            if (raw.length != expectedSize) {
+               throw new IOException("Unexpected CANElevation tile length " + raw.length + " for " + this.tileId);
+            } else {
+               if (this.predictor == 3) {
+                  applyFloatingPointPredictor(raw, this.tileWidth, this.tileHeight, this.bytesPerSample, this.samplesPerPixel, this.order);
+               } else if (this.predictor != 1) {
+                  throw new IOException("Unsupported CANElevation TIFF predictor " + this.predictor);
+               }
+
+               float[] values = new float[this.tileWidth * this.tileHeight];
+               ByteBuffer buffer = ByteBuffer.wrap(raw).order(this.order);
+
+               for (int i = 0; i < values.length; i++) {
+                  float value = buffer.getFloat();
+                  values[i] = value <= this.noData + 1.0F ? Float.NaN : value;
+               }
+
+               return values;
+            }
+         }
+      }
+
+      private static CanElevationSource.TileFile open(
+         CanElevationCoverageIndex.TileReference tileRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters
+      ) throws IOException {
+         return open(tileRef, cacheDir, targetResolutionMeters, nativeResolutionMeters, false);
+      }
+
+      private static CanElevationSource.TileFile openLocalOnly(
+         CanElevationCoverageIndex.TileReference tileRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters
+      ) throws IOException {
+         return open(tileRef, cacheDir, targetResolutionMeters, nativeResolutionMeters, true);
+      }
+
+      private static CanElevationSource.TileFile open(
+         CanElevationCoverageIndex.TileReference tileRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters, boolean localOnly
+      ) throws IOException {
+         CanElevationSource.CachedRangeReader reader = new CanElevationSource.CachedRangeReader(tileRef, cacheDir, localOnly);
+         byte[] header = reader.read(0L, 32);
+         ByteOrder order = switch (header[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid CANElevation TIFF byte order for " + tileRef.id());
+         };
+         ByteBuffer headerBuf = ByteBuffer.wrap(header).order(order);
+         headerBuf.getShort();
+         short magic = headerBuf.getShort();
+         if (magic == 42) {
+            return openStandardTiff(tileRef, reader, order, headerBuf, targetResolutionMeters, nativeResolutionMeters);
+         } else if (magic == 43) {
+            return openBigTiff(tileRef, reader, order, headerBuf, targetResolutionMeters, nativeResolutionMeters);
+         } else {
+            throw new IOException("Unsupported CANElevation TIFF magic " + magic + " for " + tileRef.id());
+         }
+      }
+
+      private static CanElevationSource.TileFile openStandardTiff(
+         CanElevationCoverageIndex.TileReference tileRef,
+         CanElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         ByteBuffer headerBuf,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         long firstIfdOffset = Integer.toUnsignedLong(headerBuf.getInt());
+         CanElevationSource.TileFile.GeoReference baseGeoReference = readStandardGeoReference(reader, order, firstIfdOffset);
+         long ifdOffset = selectIfdOffset(reader, order, false, firstIfdOffset, targetResolutionMeters, nativeResolutionMeters);
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return buildTileFile(tileRef, reader, order, false, entryCount, entries, baseGeoReference);
+      }
+
+      private static CanElevationSource.TileFile openBigTiff(
+         CanElevationCoverageIndex.TileReference tileRef,
+         CanElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         ByteBuffer headerBuf,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         short offsetSize = headerBuf.getShort();
+         headerBuf.getShort();
+         if (offsetSize != 8) {
+            throw new IOException("Unsupported CANElevation BigTIFF offset size " + offsetSize + " for " + tileRef.id());
+         } else {
+            long firstIfdOffset = headerBuf.getLong();
+            CanElevationSource.TileFile.GeoReference baseGeoReference = readBigGeoReference(reader, order, firstIfdOffset);
+            long ifdOffset = selectIfdOffset(reader, order, true, firstIfdOffset, targetResolutionMeters, nativeResolutionMeters);
+            long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+            if (entryCount < 0L || entryCount > 1000000L) {
+               throw new IOException("Invalid CANElevation BigTIFF entry count " + entryCount + " for " + tileRef.id());
+            } else {
+               byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+               ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+               return buildTileFile(tileRef, reader, order, true, entryCount, entries, baseGeoReference);
+            }
+         }
+      }
+
+      private static long selectIfdOffset(
+         CanElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long firstIfdOffset,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         if (!(targetResolutionMeters > 0.0) || !Double.isFinite(targetResolutionMeters) || !(nativeResolutionMeters > 0.0)) {
+            return firstIfdOffset;
+         } else {
+            long currentOffset = firstIfdOffset;
+            long bestOffset = firstIfdOffset;
+            int baseWidth = -1;
+            double bestResolution = nativeResolutionMeters;
+            double bestScore = Math.abs(Math.log(bestResolution / targetResolutionMeters));
+
+            for (int level = 0; currentOffset != 0L && level < 16; level++) {
+               CanElevationSource.TileFile.IfdSummary summary = bigTiff
+                  ? readBigIfdSummary(reader, order, currentOffset)
+                  : readStandardIfdSummary(reader, order, currentOffset);
+               if (summary.width() <= 0) {
+                  break;
+               }
+
+               if (baseWidth < 0) {
+                  baseWidth = summary.width();
+               }
+
+               double candidateResolution = nativeResolutionMeters * ((double)baseWidth / (double)summary.width());
+               double candidateScore = Math.abs(Math.log(candidateResolution / targetResolutionMeters));
+               if (candidateScore < bestScore - 1.0E-9
+                  || Math.abs(candidateScore - bestScore) <= 1.0E-9 && candidateResolution < bestResolution) {
+                  bestOffset = currentOffset;
+                  bestResolution = candidateResolution;
+                  bestScore = candidateScore;
+               }
+
+               currentOffset = summary.nextIfdOffset();
+            }
+
+            return bestOffset;
+         }
+      }
+
+      private static CanElevationSource.TileFile.IfdSummary readStandardIfdSummary(
+         CanElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] ifdBytes = reader.read(ifdOffset + 2L, entryCount * 12 + 4);
+         ByteBuffer entries = ByteBuffer.wrap(ifdBytes).order(order);
+         int width = -1;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[4];
+            entries.get(inlineBytes, 0, 4);
+            if (tag == TAG_IMAGE_WIDTH && count == 1L) {
+               width = readInlineDimension(inlineBytes, type, order);
+            }
+         }
+
+         long nextIfdOffset = Integer.toUnsignedLong(ByteBuffer.wrap(ifdBytes, entryCount * 12, 4).order(order).getInt());
+         return new CanElevationSource.TileFile.IfdSummary(width, nextIfdOffset);
+      }
+
+      private static CanElevationSource.TileFile.IfdSummary readBigIfdSummary(
+         CanElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+         if (entryCount < 0L || entryCount > 1000000L) {
+            throw new IOException("Invalid CANElevation BigTIFF entry count " + entryCount);
+         } else {
+            byte[] ifdBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L + 8L));
+            ByteBuffer entries = ByteBuffer.wrap(ifdBytes).order(order);
+            int width = -1;
+
+            for (int i = 0; i < entryCount; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               long count = entries.getLong();
+               byte[] inlineBytes = new byte[8];
+               entries.get(inlineBytes);
+               if (tag == TAG_IMAGE_WIDTH && count == 1L) {
+                  width = readInlineDimension(inlineBytes, type, order);
+               }
+            }
+
+            long nextIfdOffset = ByteBuffer.wrap(ifdBytes, Math.toIntExact(entryCount * 20L), 8).order(order).getLong();
+            return new CanElevationSource.TileFile.IfdSummary(width, nextIfdOffset);
+         }
+      }
+
+      private static int readInlineDimension(byte[] inlineBytes, int type, ByteOrder order) throws IOException {
+         ByteBuffer buffer = ByteBuffer.wrap(inlineBytes).order(order);
+         return switch (type) {
+            case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+            case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+            case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+            default -> throw new IOException("Unsupported TIFF dimension type " + type);
+         };
+      }
+
+      private static CanElevationSource.TileFile.GeoReference readStandardGeoReference(
+         CanElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return readGeoReference(reader, order, false, entryCount, entries);
+      }
+
+      private static CanElevationSource.TileFile.GeoReference readBigGeoReference(
+         CanElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+         if (entryCount < 0L || entryCount > 1000000L) {
+            throw new IOException("Invalid CANElevation BigTIFF entry count " + entryCount);
+         } else {
+            byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+            ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+            return readGeoReference(reader, order, true, entryCount, entries);
+         }
+      }
+
+      private static CanElevationSource.TileFile.GeoReference readGeoReference(
+         CanElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            }
+         }
+
+         return width > 0 && height > 0 ? geoReferenceFromTags(width, height, pixelScale, tiePoints) : null;
+      }
+
+      private static CanElevationSource.TileFile buildTileFile(
+         CanElevationCoverageIndex.TileReference tileRef,
+         CanElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries,
+         CanElevationSource.TileFile.GeoReference baseGeoReference
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         int tileWidth = -1;
+         int tileHeight = -1;
+         int compression = -1;
+         int predictor = 1;
+         int bitsPerSample = -1;
+         int sampleFormat = -1;
+         int samplesPerPixel = 1;
+         long[] tileOffsets = null;
+         int[] tileByteCounts = null;
+         int rowsPerStrip = -1;
+         long[] stripOffsets = null;
+         int[] stripByteCounts = null;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+         float noData = (float)DEFAULT_NO_DATA;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_BITS_PER_SAMPLE -> bitsPerSample = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_COMPRESSION -> compression = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_OFFSETS -> stripOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLES_PER_PIXEL -> samplesPerPixel = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_ROWS_PER_STRIP -> rowsPerStrip = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_BYTE_COUNTS -> stripByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_PREDICTOR -> predictor = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_WIDTH -> tileWidth = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_HEIGHT -> tileHeight = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_OFFSETS -> tileOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_BYTE_COUNTS -> tileByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLE_FORMAT -> sampleFormat = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_GDAL_NODATA -> noData = parseNoData(readAscii(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize));
+            }
+         }
+
+         if (width <= 0 || height <= 0) {
+            throw new IOException("Missing CANElevation TIFF size tags for " + tileRef.id());
+         } else {
+            if ((tileOffsets == null || tileByteCounts == null) && stripOffsets != null && stripByteCounts != null && rowsPerStrip > 0) {
+               tileWidth = width;
+               tileHeight = rowsPerStrip;
+               tileOffsets = stripOffsets;
+               tileByteCounts = stripByteCounts;
+            }
+
+            if (tileWidth <= 0 || tileHeight <= 0) {
+               throw new IOException("Missing CANElevation TIFF tile geometry for " + tileRef.id());
+            } else if (tileOffsets == null || tileByteCounts == null) {
+               throw new IOException("Missing CANElevation TIFF tile offsets for " + tileRef.id());
+            } else if (bitsPerSample != 32 || sampleFormat != 3) {
+               throw new IOException("Unsupported CANElevation TIFF sample format " + sampleFormat + " bits " + bitsPerSample);
+            } else {
+               CanElevationSource.TileFile.GeoReference geoReference = geoReferenceFromTags(width, height, pixelScale, tiePoints);
+               if (geoReference == null && baseGeoReference != null) {
+                  geoReference = baseGeoReference.scaledTo(width, height);
+               }
+
+               if (geoReference != null) {
+                  return new CanElevationSource.TileFile(
+                     tileRef.id(),
+                     reader,
+                     order,
+                     width,
+                     height,
+                     tileWidth,
+                     tileHeight,
+                     compression,
+                     predictor,
+                     4,
+                     samplesPerPixel,
+                     tileOffsets,
+                     tileByteCounts,
+                     geoReference.originX(),
+                     geoReference.originY(),
+                     geoReference.pixelSizeX(),
+                     geoReference.pixelSizeY(),
+                     noData
+                  );
+               }
+
+               throw new IOException("Missing CANElevation TIFF georeferencing tags for " + tileRef.id());
+            }
+         }
+      }
+
+      private static CanElevationSource.TileFile.GeoReference geoReferenceFromTags(int width, int height, double[] pixelScale, double[] tiePoints) {
+         if (width <= 0 || height <= 0 || pixelScale == null || pixelScale.length < 2 || tiePoints == null || tiePoints.length < 6) {
+            return null;
+         } else {
+            double pixelSizeX = pixelScale[0];
+            double pixelSizeY = pixelScale[1];
+            double originX = tiePoints[3] - tiePoints[0] * pixelSizeX;
+            double originY = tiePoints[4] + tiePoints[1] * pixelSizeY;
+            return new CanElevationSource.TileFile.GeoReference(width, height, originX, originY, pixelSizeX, pixelSizeY);
+         }
+      }
+
+      private static int readIntValue(
+         CanElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count != 1L) {
+            throw new IOException("Expected single TIFF value");
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            return switch (type) {
+               case TYPE_BYTE -> buffer.get() & 255;
+               case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+               case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+               case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+               default -> throw new IOException("Unsupported TIFF value type " + type);
+            };
+         }
+      }
+
+      private static long[] readLongArray(
+         CanElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new long[0];
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            long[] values = new long[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = switch (type) {
+                  case TYPE_BYTE -> buffer.get() & 255;
+                  case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+                  case TYPE_LONG -> Integer.toUnsignedLong(buffer.getInt());
+                  case TYPE_LONG8 -> buffer.getLong();
+                  default -> throw new IOException("Unsupported TIFF array type " + type);
+               };
+            }
+
+            return values;
+         }
+      }
+
+      private static int[] readIntArray(
+         CanElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         long[] values = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+         int[] output = new int[values.length];
+
+         for (int i = 0; i < values.length; i++) {
+            if (values[i] > 2147483647L) {
+               throw new IOException("TIFF byte count too large " + values[i]);
+            }
+
+            output[i] = (int)values[i];
+         }
+
+         return output;
+      }
+
+      private static double[] readDoubleArray(
+         CanElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new double[0];
+         } else if (type != TYPE_DOUBLE) {
+            throw new IOException("Unsupported TIFF double array type " + type);
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            double[] values = new double[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getDouble();
+            }
+
+            return values;
+         }
+      }
+
+      private static String readAscii(
+         CanElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return "";
+         } else if (type != TYPE_ASCII) {
+            throw new IOException("Unsupported TIFF ASCII type " + type);
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            int length = (int)Math.min(count, data.length);
+
+            while (length > 0 && data[length - 1] == 0) {
+               length--;
+            }
+
+            return new String(data, 0, length, StandardCharsets.US_ASCII);
+         }
+      }
+
+      private static byte[] readFieldData(
+         CanElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         int size = typeSize(type);
+         if (size <= 0) {
+            throw new IOException("Unsupported TIFF field type " + type);
+         } else {
+            long byteSize = count * size;
+            if (byteSize <= inlineSize) {
+               byte[] data = new byte[(int)byteSize];
+               System.arraycopy(inlineBytes, 0, data, 0, (int)byteSize);
+               return data;
+            } else if (byteSize > Integer.MAX_VALUE) {
+               throw new IOException("TIFF field too large");
+            } else {
+               return reader.read(valueOrOffset, (int)byteSize);
+            }
+         }
+      }
+
+      private static float parseNoData(String value) {
+         if (value == null || value.isBlank()) {
+            return (float)DEFAULT_NO_DATA;
+         } else {
+            try {
+               return Float.parseFloat(value.trim());
+            } catch (NumberFormatException error) {
+               return (float)DEFAULT_NO_DATA;
+            }
+         }
+      }
+
+      private static int typeSize(int type) {
+         return switch (type) {
+            case TYPE_BYTE, TYPE_ASCII -> 1;
+            case TYPE_SHORT -> 2;
+            case TYPE_LONG -> 4;
+            case TYPE_DOUBLE, TYPE_LONG8 -> 8;
+            default -> 0;
+         };
+      }
+
+      private record IfdSummary(int width, long nextIfdOffset) {
+      }
+
+      private record GeoReference(int width, int height, double originX, double originY, double pixelSizeX, double pixelSizeY) {
+         private CanElevationSource.TileFile.GeoReference scaledTo(int newWidth, int newHeight) {
+            if (newWidth <= 0 || newHeight <= 0 || this.width <= 0 || this.height <= 0) {
+               return this;
+            } else {
+               return new CanElevationSource.TileFile.GeoReference(
+                  newWidth,
+                  newHeight,
+                  this.originX,
+                  this.originY,
+                  this.pixelSizeX * (double)this.width / (double)newWidth,
+                  this.pixelSizeY * (double)this.height / (double)newHeight
+               );
+            }
+         }
+      }
+
+      private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+         double w00 = (1.0 - dx) * (1.0 - dy);
+         double w10 = dx * (1.0 - dy);
+         double w01 = (1.0 - dx) * dy;
+         double w11 = dx * dy;
+         double sum = 0.0;
+         double weight = 0.0;
+         if (Float.isFinite(v00)) {
+            sum += v00 * w00;
+            weight += w00;
+         }
+
+         if (Float.isFinite(v10)) {
+            sum += v10 * w10;
+            weight += w10;
+         }
+
+         if (Float.isFinite(v01)) {
+            sum += v01 * w01;
+            weight += w01;
+         }
+
+         if (Float.isFinite(v11)) {
+            sum += v11 * w11;
+            weight += w11;
+         }
+
+         return weight <= 0.0 ? Double.NaN : sum / weight;
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            } else {
+               return output;
+            }
+         }
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+         int outputPos = 0;
+         int bitPos = 0;
+         int codeSize = 9;
+         int clearCode = 256;
+         int endCode = 257;
+         int nextCode = 258;
+         byte[][] dictionary = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            dictionary[i] = new byte[]{(byte)i};
+         }
+
+         byte[] previous = null;
+
+         while (true) {
+            int code = readLzwCode(compressed, bitPos, codeSize);
+            bitPos += codeSize;
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 258; i < dictionary.length; i++) {
+                  dictionary[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else if (code == endCode) {
+               break;
+            } else {
+               byte[] entry;
+               if (code < nextCode && dictionary[code] != null) {
+                  entry = dictionary[code];
+               } else {
+                  if (previous == null) {
+                     throw new IOException("Invalid CANElevation LZW stream");
+                  }
+
+                  entry = append(previous, previous[0]);
+               }
+
+               if (outputPos + entry.length > output.length) {
+                  throw new IOException("CANElevation LZW output overflow");
+               }
+
+               System.arraycopy(entry, 0, output, outputPos, entry.length);
+               outputPos += entry.length;
+               if (previous != null && nextCode < dictionary.length) {
+                  dictionary[nextCode++] = append(previous, entry[0]);
+                  if (nextCode == 511 || nextCode == 1023 || nextCode == 2047) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+            }
+         }
+
+         if (outputPos != output.length) {
+            byte[] copy = new byte[outputPos];
+            System.arraycopy(output, 0, copy, 0, outputPos);
+            return copy;
+         } else {
+            return output;
+         }
+      }
+
+      private static void applyFloatingPointPredictor(byte[] data, int width, int height, int bytesPerSample, int samplesPerPixel, ByteOrder order)
+         throws IOException {
+         int rowBytes = width * bytesPerSample * samplesPerPixel;
+         if (rowBytes > 0) {
+            if (samplesPerPixel > 0 && rowBytes % (bytesPerSample * samplesPerPixel) == 0) {
+               int wordCount = rowBytes / bytesPerSample;
+               byte[] tmp = new byte[rowBytes];
+
+               for (int row = 0; row < height; row++) {
+                  int rowStart = row * rowBytes;
+                  int count = rowBytes;
+
+                  for (int offset = rowStart; count > samplesPerPixel; count -= samplesPerPixel) {
+                     for (int i = 0; i < samplesPerPixel; i++) {
+                        int target = offset + samplesPerPixel;
+                        int value = (data[target] & 255) + (data[offset] & 255);
+                        data[target] = (byte)value;
+                        offset++;
+                     }
+                  }
+
+                  System.arraycopy(data, rowStart, tmp, 0, rowBytes);
+
+                  for (int word = 0; word < wordCount; word++) {
+                     int base = rowStart + word * bytesPerSample;
+
+                     for (int byteIndex = 0; byteIndex < bytesPerSample; byteIndex++) {
+                        int sourceIndex = order == ByteOrder.BIG_ENDIAN ? byteIndex * wordCount + word : (bytesPerSample - byteIndex - 1) * wordCount + word;
+                        data[base + byteIndex] = tmp[sourceIndex];
+                     }
+                  }
+               }
+            } else {
+               throw new IOException("Invalid floating point predictor stride");
+            }
+         }
+      }
+
+      private static int readLzwCode(byte[] data, int bitPos, int codeSize) {
+         int totalBits = data.length * 8;
+         if (bitPos + codeSize > totalBits) {
+            return -1;
+         } else {
+            int code = 0;
+
+            for (int i = 0; i < codeSize; i++) {
+               int currentBit = bitPos + i;
+               int currentByte = data[currentBit >> 3] & 255;
+               int bit = currentByte >> 7 - (currentBit & 7) & 1;
+               code = code << 1 | bit;
+            }
+
+            return code;
+         }
+      }
+
+      private static byte[] append(byte[] prefix, byte suffix) {
+         byte[] out = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, out, 0, prefix.length);
+         out[prefix.length] = suffix;
+         return out;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/CopernicusDemElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/CopernicusDemElevationSource.java
@@ -1,0 +1,991 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class CopernicusDemElevationSource implements TellusCacheHandle {
+   private static final String GLO_30_BASE_URL = "https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com";
+   private static final String GLO_90_BASE_URL = "https://copernicus-dem-90m.s3.eu-central-1.amazonaws.com";
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final int MAX_FILE_CACHE = intProperty("tellus.copernicus.cacheFiles", 16);
+   private static final int MAX_TILE_CACHE = intProperty("tellus.copernicus.cacheTiles", 16);
+   private static final CopernicusDemElevationSource.TileRecord MISSING_TILE = new CopernicusDemElevationSource.TileRecord(null, true);
+   private final Path cacheRoot;
+   private final LoadingCache<CopernicusDemElevationSource.TileKey, CopernicusDemElevationSource.TileRecord> fileCache;
+
+   public CopernicusDemElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-copernicus");
+      this.fileCache = CacheBuilder.newBuilder().maximumSize(MAX_FILE_CACHE).build(new CacheLoader<CopernicusDemElevationSource.TileKey, CopernicusDemElevationSource.TileRecord>() {
+         public CopernicusDemElevationSource.TileRecord load(CopernicusDemElevationSource.TileKey key) throws Exception {
+            return CopernicusDemElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public double sampleElevationMeters(double blockX, double blockZ, double worldScale) {
+      if (worldScale <= 0.0) {
+         return Double.NaN;
+      } else {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleElevationMeters(lat, lon);
+      }
+   }
+
+   public double sampleElevationMetersLocalOnly(double blockX, double blockZ, double worldScale) {
+      if (worldScale <= 0.0) {
+         return Double.NaN;
+      } else {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleElevationMetersLocalOnly(lat, lon);
+      }
+   }
+
+   public double sampleElevationMeters(double lat, double lon) {
+      if (!(lat >= -90.0) || !(lat <= 90.0) || !(lon >= -180.0) || !(lon <= 180.0)) {
+         return Double.NaN;
+      } else {
+         double sample30 = this.sampleAtLevel(CopernicusDemElevationSource.Level.GLO_30, lat, lon);
+         if (!Double.isNaN(sample30)) {
+            return sample30;
+         } else {
+            return this.sampleAtLevel(CopernicusDemElevationSource.Level.GLO_90, lat, lon);
+         }
+      }
+   }
+
+   public double sampleElevationMetersLocalOnly(double lat, double lon) {
+      if (!(lat >= -90.0) || !(lat <= 90.0) || !(lon >= -180.0) || !(lon <= 180.0)) {
+         return Double.NaN;
+      } else {
+         double sample30 = this.sampleAtLevelLocalOnly(CopernicusDemElevationSource.Level.GLO_30, lat, lon);
+         return !Double.isNaN(sample30) ? sample30 : this.sampleAtLevelLocalOnly(CopernicusDemElevationSource.Level.GLO_90, lat, lon);
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      if (!(worldScale <= 0.0) && radius > 0) {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+
+         CopernicusDemElevationSource.TileKey center30 = tileKeyForLatLon(CopernicusDemElevationSource.Level.GLO_30, lat, lon);
+         if (center30 != null) {
+            this.prefetchNeighborhood(center30, 1);
+            CopernicusDemElevationSource.TileRecord cached = this.fileCache.getIfPresent(center30);
+            if (cached != null && cached.missing()) {
+               CopernicusDemElevationSource.TileKey center90 = tileKeyForLatLon(CopernicusDemElevationSource.Level.GLO_90, lat, lon);
+               if (center90 != null) {
+                  this.prefetchNeighborhood(center90, 1);
+               }
+            }
+         }
+      }
+   }
+
+   private void prefetchNeighborhood(CopernicusDemElevationSource.TileKey center, int tileRadius) {
+      for (int dLat = -tileRadius; dLat <= tileRadius; dLat++) {
+         for (int dLon = -tileRadius; dLon <= tileRadius; dLon++) {
+            CopernicusDemElevationSource.TileKey key = new CopernicusDemElevationSource.TileKey(center.level(), center.tileLat() + dLat, center.tileLon() + dLon);
+            if (key.tileLat() >= -90 && key.tileLat() <= 89 && key.tileLon() >= -180 && key.tileLon() <= 179) {
+               this.prefetchTile(key);
+            }
+         }
+      }
+   }
+
+   private void prefetchTile(CopernicusDemElevationSource.TileKey key) {
+      if (this.fileCache.getIfPresent(key) == null) {
+         try {
+            this.fileCache.get(key);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch Copernicus DEM tile {}", key, error);
+         }
+      }
+   }
+
+   private double sampleAtLevel(CopernicusDemElevationSource.Level level, double lat, double lon) {
+      double clampedLat = Math.max(-90.0, Math.min(89.999999, lat));
+      double clampedLon = Math.max(-180.0, Math.min(179.999999, lon));
+      int samplesPerDegree = level.samplesPerDegree;
+      int maxPixelX = 360 * samplesPerDegree - 1;
+      int maxPixelY = 180 * samplesPerDegree - 1;
+      double globalX = Mth.clamp((clampedLon + 180.0) * samplesPerDegree, 0.0, maxPixelX);
+      double globalY = Mth.clamp((90.0 - clampedLat) * samplesPerDegree, 0.0, maxPixelY);
+      int x0 = Mth.floor(globalX);
+      int y0 = Mth.floor(globalY);
+      int x1 = Math.min(x0 + 1, maxPixelX);
+      int y1 = Math.min(y0 + 1, maxPixelY);
+      double dx = globalX - x0;
+      double dy = globalY - y0;
+      float v00 = this.samplePixel(level, x0, y0);
+      float v10 = this.samplePixel(level, x1, y0);
+      float v01 = this.samplePixel(level, x0, y1);
+      float v11 = this.samplePixel(level, x1, y1);
+      return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+   }
+
+   private double sampleAtLevelLocalOnly(CopernicusDemElevationSource.Level level, double lat, double lon) {
+      double clampedLat = Math.max(-90.0, Math.min(89.999999, lat));
+      double clampedLon = Math.max(-180.0, Math.min(179.999999, lon));
+      int samplesPerDegree = level.samplesPerDegree;
+      int maxPixelX = 360 * samplesPerDegree - 1;
+      int maxPixelY = 180 * samplesPerDegree - 1;
+      double globalX = Mth.clamp((clampedLon + 180.0) * samplesPerDegree, 0.0, maxPixelX);
+      double globalY = Mth.clamp((90.0 - clampedLat) * samplesPerDegree, 0.0, maxPixelY);
+      int x0 = Mth.floor(globalX);
+      int y0 = Mth.floor(globalY);
+      int x1 = Math.min(x0 + 1, maxPixelX);
+      int y1 = Math.min(y0 + 1, maxPixelY);
+      double dx = globalX - x0;
+      double dy = globalY - y0;
+      float v00 = this.samplePixelLocalOnly(level, x0, y0);
+      float v10 = this.samplePixelLocalOnly(level, x1, y0);
+      float v01 = this.samplePixelLocalOnly(level, x0, y1);
+      float v11 = this.samplePixelLocalOnly(level, x1, y1);
+      return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+   }
+
+   private float samplePixel(CopernicusDemElevationSource.Level level, int pixelX, int pixelY) {
+      int tileColumn = Math.floorDiv(pixelX, level.samplesPerDegree);
+      int tileRow = Math.floorDiv(pixelY, level.samplesPerDegree);
+      int tileLon = tileColumn - 180;
+      int tileLat = 89 - tileRow;
+      CopernicusDemElevationSource.TileFile tile = this.getTile(new CopernicusDemElevationSource.TileKey(level, tileLat, tileLon));
+      if (tile == null) {
+         return Float.NaN;
+      } else {
+         int localX = pixelX - tileColumn * level.samplesPerDegree;
+         int localY = pixelY - tileRow * level.samplesPerDegree;
+         return tile.sampleValue(localX, localY);
+      }
+   }
+
+   private float samplePixelLocalOnly(CopernicusDemElevationSource.Level level, int pixelX, int pixelY) {
+      int tileColumn = Math.floorDiv(pixelX, level.samplesPerDegree);
+      int tileRow = Math.floorDiv(pixelY, level.samplesPerDegree);
+      int tileLon = tileColumn - 180;
+      int tileLat = 89 - tileRow;
+      CopernicusDemElevationSource.TileFile tile = this.getTileLocalOnly(new CopernicusDemElevationSource.TileKey(level, tileLat, tileLon));
+      if (tile == null) {
+         return Float.NaN;
+      } else {
+         int localX = pixelX - tileColumn * level.samplesPerDegree;
+         int localY = pixelY - tileRow * level.samplesPerDegree;
+         return tile.sampleValue(localX, localY);
+      }
+   }
+
+   private CopernicusDemElevationSource.TileFile getTile(CopernicusDemElevationSource.TileKey key) {
+      try {
+         CopernicusDemElevationSource.TileRecord record = this.fileCache.get(key);
+         return record.missing() ? null : record.file();
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load Copernicus DEM tile {}", key, error);
+         return null;
+      }
+   }
+
+   private CopernicusDemElevationSource.TileFile getTileLocalOnly(CopernicusDemElevationSource.TileKey key) {
+      CopernicusDemElevationSource.TileRecord cached = this.fileCache.getIfPresent(key);
+      if (cached != null) {
+         return cached.missing() ? null : cached.file();
+      } else {
+         Path tileCacheDir = this.cacheRoot.resolve(key.cacheDirectory());
+         Path missingMarker = tileCacheDir.resolve(".missing");
+         if (Files.exists(missingMarker)) {
+            this.fileCache.put(key, MISSING_TILE);
+            return null;
+         } else if (!Files.isDirectory(tileCacheDir)) {
+            return null;
+         } else {
+            try {
+               CopernicusDemElevationSource.TileRecord record = new CopernicusDemElevationSource.TileRecord(
+                  CopernicusDemElevationSource.TileFile.openLocalOnly(key.url(), tileCacheDir), false
+               );
+               CopernicusDemElevationSource.TileRecord raced = this.fileCache.asMap().putIfAbsent(key, record);
+               CopernicusDemElevationSource.TileRecord resolved = raced != null ? raced : record;
+               return resolved.missing() ? null : resolved.file();
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached Copernicus DEM tile {}", key, error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private CopernicusDemElevationSource.TileRecord loadTile(CopernicusDemElevationSource.TileKey key) throws Exception {
+      Path tileCacheDir = this.cacheRoot.resolve(key.cacheDirectory());
+      Path missingMarker = tileCacheDir.resolve(".missing");
+      if (Files.exists(missingMarker)) {
+         return MISSING_TILE;
+      }
+
+      try {
+         return new CopernicusDemElevationSource.TileRecord(CopernicusDemElevationSource.TileFile.open(key.url(), tileCacheDir), false);
+      } catch (CopernicusDemElevationSource.MissingTileException error) {
+         this.writeMissingMarker(missingMarker);
+         return MISSING_TILE;
+      }
+   }
+
+   private void writeMissingMarker(Path missingMarker) {
+      try {
+         Files.createDirectories(missingMarker.getParent());
+         if (!Files.exists(missingMarker)) {
+            Files.writeString(missingMarker, "missing");
+         }
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to persist Copernicus missing-tile marker {}", missingMarker, error);
+      }
+   }
+
+   private static CopernicusDemElevationSource.TileKey tileKeyForLatLon(CopernicusDemElevationSource.Level level, double lat, double lon) {
+      if (!(lat >= -90.0) || !(lat <= 90.0) || !(lon >= -180.0) || !(lon <= 180.0)) {
+         return null;
+      } else {
+         int tileLat = Math.max(-90, Math.min(89, (int)Math.floor(Math.min(lat, 89.999999))));
+         int tileLon = Math.max(-180, Math.min(179, (int)Math.floor(Math.min(lon, 179.999999))));
+         return new CopernicusDemElevationSource.TileKey(level, tileLat, tileLon);
+      }
+   }
+
+   private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+      double w00 = (1.0 - dx) * (1.0 - dy);
+      double w10 = dx * (1.0 - dy);
+      double w01 = (1.0 - dx) * dy;
+      double w11 = dx * dy;
+      double sum = 0.0;
+      double weight = 0.0;
+      if (Float.isFinite(v00)) {
+         sum += v00 * w00;
+         weight += w00;
+      }
+
+      if (Float.isFinite(v10)) {
+         sum += v10 * w10;
+         weight += w10;
+      }
+
+      if (Float.isFinite(v01)) {
+         sum += v01 * w01;
+         weight += w01;
+      }
+
+      if (Float.isFinite(v11)) {
+         sum += v11 * w11;
+         weight += w11;
+      }
+
+      return weight <= 0.0 ? Double.NaN : sum / weight;
+   }
+
+   private static HttpURLConnection openConnection(URI uri, String rangeHeader) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+      if (rangeHeader != null) {
+         connection.setRequestProperty("Range", rangeHeader);
+      }
+
+      return connection;
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.COPERNICUS;
+   }
+
+   @Override
+   public void clearCache() {
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+   }
+
+   private static final class MissingTileException extends IOException {
+      private MissingTileException(String message) {
+         super(message);
+      }
+   }
+
+   private static final class RangeReader {
+      private final String url;
+      private final Path cacheDir;
+      private final boolean localOnly;
+
+      private RangeReader(String url, Path cacheDir) {
+         this(url, cacheDir, false);
+      }
+
+      private RangeReader(String url, Path cacheDir, boolean localOnly) {
+         this.url = Objects.requireNonNull(url, "url");
+         this.cacheDir = Objects.requireNonNull(cacheDir, "cacheDir");
+         this.localOnly = localOnly;
+      }
+
+      private byte[] read(long offset, int length) throws IOException {
+         if (length <= 0) {
+            return new byte[0];
+         } else {
+            Path cachePath = this.cacheDir.resolve(offset + "-" + length + ".bin");
+            byte[] cached = this.readCachedRange(cachePath, length);
+            if (cached != null) {
+               return cached;
+            } else if (this.localOnly) {
+               throw new EOFException("Copernicus DEM range not cached for " + this.url);
+            }
+
+            String rangeHeader = "bytes=" + offset + "-" + (offset + length - 1L);
+            HttpURLConnection connection = CopernicusDemElevationSource.openConnection(URI.create(this.url), rangeHeader);
+            try {
+               int status = connection.getResponseCode();
+               if (status == 404) {
+                  throw new CopernicusDemElevationSource.MissingTileException("Missing Copernicus DEM tile " + this.url);
+               } else if (status == 416) {
+                  throw new EOFException("Range not satisfiable for " + this.url);
+               } else if (status != 206 && status != 200) {
+                  throw new IOException("Unexpected HTTP status " + status + " for " + this.url);
+               } else {
+                  DownloadProgressReporter.requestStarted((long)length);
+                  try (InputStream input = connection.getInputStream()) {
+                     byte[] data = DownloadProgressReporter.readAllBytesWithProgress(input);
+                     if (data.length != length) {
+                        throw new EOFException("Unexpected range length " + data.length + " for " + this.url);
+                     } else {
+                        this.writeCachedRange(cachePath, data);
+                        return data;
+                     }
+                  } finally {
+                     DownloadProgressReporter.requestFinished();
+                  }
+               }
+            } finally {
+               connection.disconnect();
+            }
+         }
+      }
+
+      private byte[] readCachedRange(Path cachePath, int expectedLength) throws IOException {
+         if (!Files.exists(cachePath)) {
+            return null;
+         } else {
+            byte[] data = Files.readAllBytes(cachePath);
+            if (data.length == expectedLength) {
+               return data;
+            } else {
+               Files.deleteIfExists(cachePath);
+               return null;
+            }
+         }
+      }
+
+      private void writeCachedRange(Path cachePath, byte[] data) {
+         try {
+            Files.createDirectories(cachePath.getParent());
+            Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+            Files.write(tempPath, data);
+            Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to cache Copernicus DEM range {}", cachePath, error);
+         }
+      }
+   }
+
+   private static final class TileFile {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_BITS_PER_SAMPLE = 258;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_STRIP_OFFSETS = 273;
+      private static final int TAG_SAMPLES_PER_PIXEL = 277;
+      private static final int TAG_ROWS_PER_STRIP = 278;
+      private static final int TAG_STRIP_BYTE_COUNTS = 279;
+      private static final int TAG_PREDICTOR = 317;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_SAMPLE_FORMAT = 339;
+      private static final int TYPE_BYTE = 1;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int TYPE_LONG8 = 16;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private final String url;
+      private final CopernicusDemElevationSource.RangeReader reader;
+      private final ByteOrder order;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final int predictor;
+      private final int bytesPerSample;
+      private final int samplesPerPixel;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final Map<Integer, float[]> tileCache;
+
+      private TileFile(
+         String url,
+         CopernicusDemElevationSource.RangeReader reader,
+         ByteOrder order,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         int predictor,
+         int bytesPerSample,
+         int samplesPerPixel,
+         long[] tileOffsets,
+         int[] tileByteCounts
+      ) {
+         this.url = url;
+         this.reader = reader;
+         this.order = order;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.compression = compression;
+         this.predictor = predictor;
+         this.bytesPerSample = bytesPerSample;
+         this.samplesPerPixel = samplesPerPixel;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.tileCache = new LinkedHashMap<Integer, float[]>(MAX_TILE_CACHE, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, float[]> eldest) {
+               return this.size() > MAX_TILE_CACHE;
+            }
+         };
+      }
+
+      private float sampleValue(int pixelX, int pixelY) {
+         int clampedX = Mth.clamp(pixelX, 0, this.width - 1);
+         int clampedY = Mth.clamp(pixelY, 0, this.height - 1);
+         int tileX = clampedX / this.tileWidth;
+         int tileY = clampedY / this.tileHeight;
+         int tileIndex = tileY * this.tilesPerRow + tileX;
+
+         try {
+            float[] tile = this.getTile(tileIndex);
+            int localX = clampedX - tileX * this.tileWidth;
+            int localY = clampedY - tileY * this.tileHeight;
+            return tile[localX + localY * this.tileWidth];
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to read Copernicus DEM tile {} from {}", tileIndex, this.url, error);
+            return Float.NaN;
+         }
+      }
+
+      private float[] getTile(int tileIndex) throws IOException {
+         synchronized(this.tileCache) {
+            float[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         float[] tile = this.readTile(tileIndex);
+         synchronized(this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private float[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = this.reader.read(offset, length);
+         int expectedSize = this.tileWidth * this.tileHeight * this.bytesPerSample * this.samplesPerPixel;
+         if (this.samplesPerPixel != 1) {
+            throw new IOException("Unsupported TIFF samples per pixel " + this.samplesPerPixel);
+         } else {
+            byte[] raw = switch (this.compression) {
+               case COMPRESSION_LZW -> decompressLzw(compressed, expectedSize);
+               case COMPRESSION_DEFLATE -> inflate(compressed, expectedSize);
+               default -> throw new IOException("Unsupported TIFF compression " + this.compression);
+            };
+            if (this.predictor == 3) {
+               applyFloatingPointPredictor(raw, this.tileWidth, this.tileHeight, this.bytesPerSample, this.samplesPerPixel, this.order);
+            } else if (this.predictor != 1) {
+               throw new IOException("Unsupported TIFF predictor " + this.predictor);
+            }
+
+            float[] values = new float[this.tileWidth * this.tileHeight];
+            ByteBuffer buffer = ByteBuffer.wrap(raw).order(this.order);
+
+            for (int i = 0; i < values.length; i++) {
+               values[i] = buffer.getFloat();
+            }
+
+            return values;
+         }
+      }
+
+      private static CopernicusDemElevationSource.TileFile open(String url, Path cacheDir) throws IOException {
+         return open(url, cacheDir, false);
+      }
+
+      private static CopernicusDemElevationSource.TileFile openLocalOnly(String url, Path cacheDir) throws IOException {
+         return open(url, cacheDir, true);
+      }
+
+      private static CopernicusDemElevationSource.TileFile open(String url, Path cacheDir, boolean localOnly) throws IOException {
+         CopernicusDemElevationSource.RangeReader reader = new CopernicusDemElevationSource.RangeReader(url, cacheDir, localOnly);
+         byte[] header = reader.read(0L, 16);
+         ByteOrder order = switch (header[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid TIFF byte order");
+         };
+         ByteBuffer headerBuf = ByteBuffer.wrap(header).order(order);
+         headerBuf.getShort();
+         short magic = headerBuf.getShort();
+         if (magic != 42) {
+            throw new IOException("Expected standard TIFF magic");
+         } else {
+            long ifdOffset = Integer.toUnsignedLong(headerBuf.getInt());
+            int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+            byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+            ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+            int width = -1;
+            int height = -1;
+            int tileWidth = -1;
+            int tileHeight = -1;
+            int compression = -1;
+            int predictor = 1;
+            int bitsPerSample = -1;
+            int sampleFormat = -1;
+            int samplesPerPixel = 1;
+            long[] tileOffsets = null;
+            int[] tileByteCounts = null;
+            int rowsPerStrip = -1;
+            long[] stripOffsets = null;
+            int[] stripByteCounts = null;
+
+            for (int i = 0; i < entryCount; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               long count = Integer.toUnsignedLong(entries.getInt());
+               long value = Integer.toUnsignedLong(entries.getInt());
+               switch (tag) {
+                  case TAG_IMAGE_WIDTH:
+                     width = readIntValue(type, count, value);
+                     break;
+                  case TAG_IMAGE_HEIGHT:
+                     height = readIntValue(type, count, value);
+                     break;
+                  case TAG_BITS_PER_SAMPLE:
+                     bitsPerSample = readIntValue(type, count, value);
+                     break;
+                  case TAG_COMPRESSION:
+                     compression = readIntValue(type, count, value);
+                     break;
+                  case TAG_STRIP_OFFSETS:
+                     stripOffsets = readLongArray(reader, value, count, type, order);
+                     break;
+                  case TAG_SAMPLES_PER_PIXEL:
+                     samplesPerPixel = readIntValue(type, count, value);
+                     break;
+                  case TAG_ROWS_PER_STRIP:
+                     rowsPerStrip = readIntValue(type, count, value);
+                     break;
+                  case TAG_STRIP_BYTE_COUNTS:
+                     stripByteCounts = readIntArray(reader, value, count, type, order);
+                     break;
+                  case TAG_PREDICTOR:
+                     predictor = readIntValue(type, count, value);
+                     break;
+                  case TAG_TILE_WIDTH:
+                     tileWidth = readIntValue(type, count, value);
+                     break;
+                  case TAG_TILE_HEIGHT:
+                     tileHeight = readIntValue(type, count, value);
+                     break;
+                  case TAG_TILE_OFFSETS:
+                     tileOffsets = readLongArray(reader, value, count, type, order);
+                     break;
+                  case TAG_TILE_BYTE_COUNTS:
+                     tileByteCounts = readIntArray(reader, value, count, type, order);
+                     break;
+                  case TAG_SAMPLE_FORMAT:
+                     sampleFormat = readIntValue(type, count, value);
+               }
+            }
+
+            if (width <= 0 || height <= 0) {
+               throw new IOException("Missing TIFF size tags");
+            } else {
+               if ((tileOffsets == null || tileByteCounts == null) && stripOffsets != null && stripByteCounts != null && rowsPerStrip > 0) {
+                  tileWidth = width;
+                  tileHeight = rowsPerStrip;
+                  tileOffsets = stripOffsets;
+                  tileByteCounts = stripByteCounts;
+               }
+
+               if (tileWidth <= 0 || tileHeight <= 0) {
+                  throw new IOException("Missing TIFF tile geometry");
+               } else if (tileOffsets == null || tileByteCounts == null) {
+                  throw new IOException("Missing TIFF tile offsets");
+               } else if (bitsPerSample == 32 && sampleFormat == 3) {
+                  return new CopernicusDemElevationSource.TileFile(
+                     url,
+                     reader,
+                     order,
+                     width,
+                     height,
+                     tileWidth,
+                     tileHeight,
+                     compression,
+                     predictor,
+                     4,
+                     samplesPerPixel,
+                     tileOffsets,
+                     tileByteCounts
+                  );
+               } else {
+                  throw new IOException("Unsupported TIFF sample format " + sampleFormat + " bits " + bitsPerSample);
+               }
+            }
+         }
+      }
+
+      private static int readIntValue(int type, long count, long value) throws IOException {
+         if (count != 1L) {
+            throw new IOException("Expected single TIFF value");
+         } else if (type == TYPE_BYTE || type == TYPE_SHORT || type == TYPE_LONG || type == TYPE_LONG8) {
+            return (int)value;
+         } else {
+            throw new IOException("Unsupported TIFF value type " + type);
+         }
+      }
+
+      private static long[] readLongArray(CopernicusDemElevationSource.RangeReader reader, long valueOrOffset, long count, int type, ByteOrder order)
+         throws IOException {
+         if (count <= 0L) {
+            return new long[0];
+         } else {
+            int size = typeSize(type);
+            if (size <= 0) {
+               throw new IOException("Unsupported TIFF array type " + type);
+            } else {
+               long byteSize = count * size;
+               byte[] data = byteSize <= 4L
+                  ? ByteBuffer.allocate(4).order(order).putInt((int)valueOrOffset).array()
+                  : reader.read(valueOrOffset, (int)byteSize);
+               ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+               long[] values = new long[(int)count];
+
+               for (int i = 0; i < count; i++) {
+                  values[i] = switch (type) {
+                     case TYPE_BYTE -> buffer.get() & 255;
+                     case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+                     case TYPE_LONG -> Integer.toUnsignedLong(buffer.getInt());
+                     case TYPE_LONG8 -> buffer.getLong();
+                     default -> throw new IOException("Unsupported TIFF array type " + type);
+                  };
+               }
+
+               return values;
+            }
+         }
+      }
+
+      private static int[] readIntArray(CopernicusDemElevationSource.RangeReader reader, long valueOrOffset, long count, int type, ByteOrder order)
+         throws IOException {
+         long[] values = readLongArray(reader, valueOrOffset, count, type, order);
+         int[] output = new int[values.length];
+
+         for (int i = 0; i < values.length; i++) {
+            if (values[i] > 2147483647L) {
+               throw new IOException("TIFF byte count too large " + values[i]);
+            }
+
+            output[i] = (int)values[i];
+         }
+
+         return output;
+      }
+
+      private static int typeSize(int type) {
+         return switch (type) {
+            case TYPE_BYTE -> 1;
+            case TYPE_SHORT -> 2;
+            case TYPE_LONG -> 4;
+            case TYPE_LONG8 -> 8;
+            default -> 0;
+         };
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            } else {
+               return output;
+            }
+         }
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[][] table = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            table[i] = new byte[]{(byte)i};
+         }
+
+         int clearCode = 256;
+         int endCode = 257;
+         int codeSize = 9;
+         int nextCode = 258;
+         byte[] output = new byte[expectedSize];
+         int outPos = 0;
+         CopernicusDemElevationSource.TileFile.LzwBitReader reader = new CopernicusDemElevationSource.TileFile.LzwBitReader(compressed);
+         byte[] previous = null;
+
+         while (true) {
+            int code = reader.read(codeSize);
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 0; i < 256; i++) {
+                  table[i] = new byte[]{(byte)i};
+               }
+
+               for (int i = 256; i < table.length; i++) {
+                  table[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else {
+               if (code == endCode) {
+                  break;
+               }
+
+               byte[] entry;
+               if (code < nextCode && table[code] != null) {
+                  entry = table[code];
+               } else {
+                  if (code != nextCode || previous == null) {
+                     throw new IOException("Invalid LZW code " + code);
+                  }
+
+                  entry = concat(previous, previous[0]);
+               }
+
+               if (outPos + entry.length > output.length) {
+                  throw new IOException("Unexpected LZW output size");
+               }
+
+               System.arraycopy(entry, 0, output, outPos, entry.length);
+               outPos += entry.length;
+               if (previous != null && nextCode < table.length) {
+                  table[nextCode++] = concat(previous, entry[0]);
+                  int threshold = (1 << codeSize) - 1;
+                  if (nextCode == threshold && codeSize < 12) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+               if (outPos == output.length) {
+                  break;
+               }
+            }
+         }
+
+         if (outPos != output.length) {
+            throw new IOException("Unexpected LZW output length " + outPos);
+         } else {
+            return output;
+         }
+      }
+
+      private static void applyFloatingPointPredictor(byte[] data, int width, int height, int bytesPerSample, int samplesPerPixel, ByteOrder order)
+         throws IOException {
+         int rowBytes = width * bytesPerSample * samplesPerPixel;
+         if (rowBytes > 0) {
+            if (samplesPerPixel > 0 && rowBytes % (bytesPerSample * samplesPerPixel) == 0) {
+               int wordCount = rowBytes / bytesPerSample;
+               byte[] tmp = new byte[rowBytes];
+
+               for (int row = 0; row < height; row++) {
+                  int rowStart = row * rowBytes;
+                  int count = rowBytes;
+
+                  for (int offset = rowStart; count > samplesPerPixel; count -= samplesPerPixel) {
+                     for (int i = 0; i < samplesPerPixel; i++) {
+                        int target = offset + samplesPerPixel;
+                        int value = (data[target] & 255) + (data[offset] & 255);
+                        data[target] = (byte)value;
+                        offset++;
+                     }
+                  }
+
+                  System.arraycopy(data, rowStart, tmp, 0, rowBytes);
+
+                  for (int word = 0; word < wordCount; word++) {
+                     int base = rowStart + word * bytesPerSample;
+
+                     for (int byteIndex = 0; byteIndex < bytesPerSample; byteIndex++) {
+                        int sourceIndex = order == ByteOrder.BIG_ENDIAN ? byteIndex * wordCount + word : (bytesPerSample - byteIndex - 1) * wordCount + word;
+                        data[base + byteIndex] = tmp[sourceIndex];
+                     }
+                  }
+               }
+            } else {
+               throw new IOException("Invalid floating point predictor stride");
+            }
+         }
+      }
+
+      private static byte[] concat(byte[] prefix, byte suffix) {
+         byte[] combined = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, combined, 0, prefix.length);
+         combined[prefix.length] = suffix;
+         return combined;
+      }
+
+      private static final class LzwBitReader {
+         private final byte[] data;
+         private int bitPos;
+
+         private LzwBitReader(byte[] data) {
+            this.data = data;
+         }
+
+         private int read(int bits) {
+            int totalBits = this.data.length * 8;
+            if (this.bitPos + bits > totalBits) {
+               return -1;
+            } else {
+               int result = 0;
+
+               for (int i = 0; i < bits; i++) {
+                  int byteIndex = (this.bitPos + i) / 8;
+                  int bitIndex = 7 - (this.bitPos + i) % 8;
+                  int bit = this.data[byteIndex] >> bitIndex & 1;
+                  result = result << 1 | bit;
+               }
+
+               this.bitPos += bits;
+               return result;
+            }
+         }
+      }
+   }
+
+   private static enum Level {
+      GLO_30("10", 3600, GLO_30_BASE_URL),
+      GLO_90("30", 1200, GLO_90_BASE_URL);
+
+      private final String productCode;
+      private final int samplesPerDegree;
+      private final String baseUrl;
+
+      private Level(String productCode, int samplesPerDegree, String baseUrl) {
+         this.productCode = productCode;
+         this.samplesPerDegree = samplesPerDegree;
+         this.baseUrl = baseUrl;
+      }
+   }
+
+   private record TileRecord(CopernicusDemElevationSource.TileFile file, boolean missing) {
+   }
+
+   private record TileKey(CopernicusDemElevationSource.Level level, int tileLat, int tileLon) {
+      private String cacheDirectory() {
+         String ns = this.tileLat >= 0 ? "N" : "S";
+         String ew = this.tileLon >= 0 ? "E" : "W";
+         int lat = Math.abs(this.tileLat);
+         int lon = Math.abs(this.tileLon);
+         return this.level.name().toLowerCase(Locale.ROOT) + "/" + String.format("%s%02d_%s%03d", ns, lat, ew, lon);
+      }
+
+      private String url() {
+         String ns = this.tileLat >= 0 ? "N" : "S";
+         String ew = this.tileLon >= 0 ? "E" : "W";
+         int lat = Math.abs(this.tileLat);
+         int lon = Math.abs(this.tileLon);
+         String name = String.format(
+            "Copernicus_DSM_COG_%s_%s%02d_00_%s%03d_00_DEM",
+            this.level.productCode,
+            ns,
+            lat,
+            ew,
+            lon
+         );
+         return this.level.baseUrl + "/" + name + "/" + name + ".tif";
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/JapanGsiElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/JapanGsiElevationSource.java
@@ -1,0 +1,608 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import javax.imageio.ImageIO;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class JapanGsiElevationSource implements TellusCacheHandle {
+   private static final String BASE_ENDPOINT = "https://cyberjapandata.gsi.go.jp/xyz";
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final int TILE_SIZE = 256;
+   private static final int MIN_ZOOM = 1;
+   private static final double EQUATOR_CIRCUMFERENCE = 4.0075017E7;
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final int GSI_NO_DATA_R = 128;
+   private static final int GSI_NO_DATA_G = 0;
+   private static final int GSI_NO_DATA_B = 0;
+   private static final double GSI_UNIT_METERS = 0.01;
+   private static final int MAX_CACHE_TILES = intProperty("tellus.japangsi.cacheTiles", 256);
+   private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("tellus.japangsi.enabled", "true"));
+   private static final JapanGsiElevationSource.TileRecord MISSING_TILE = new JapanGsiElevationSource.TileRecord(null, true);
+   private static final JapanGsiElevationSource.TileLayer[] ALL_LAYERS = JapanGsiElevationSource.TileLayer.values();
+   private static final JapanGsiElevationSource.TileLayer[] MEDIUM_RES_LAYERS = new JapanGsiElevationSource.TileLayer[]{
+      JapanGsiElevationSource.TileLayer.DEM5A,
+      JapanGsiElevationSource.TileLayer.DEM5B,
+      JapanGsiElevationSource.TileLayer.DEM5C,
+      JapanGsiElevationSource.TileLayer.DEM10B
+   };
+   private static final JapanGsiElevationSource.TileLayer[] COARSE_LAYERS = new JapanGsiElevationSource.TileLayer[]{JapanGsiElevationSource.TileLayer.DEM10B};
+   private final Path cacheRoot;
+   private final LoadingCache<JapanGsiElevationSource.TileKey, JapanGsiElevationSource.TileRecord> tileCache;
+
+   public JapanGsiElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-japangsi");
+      this.tileCache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_TILES).build(new CacheLoader<JapanGsiElevationSource.TileKey, JapanGsiElevationSource.TileRecord>() {
+         public JapanGsiElevationSource.TileRecord load(JapanGsiElevationSource.TileKey key) throws Exception {
+            return JapanGsiElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isLikelyInCoverage(double lat, double lon) {
+      return ENABLED && isInCoverageBox(lat, lon);
+   }
+
+   public JapanGsiElevationSource.Sample sample(double blockX, double blockZ, double worldScale) {
+      return this.sample(blockX, blockZ, worldScale, Double.NaN);
+   }
+
+   public JapanGsiElevationSource.Sample sample(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!ENABLED || worldScale <= 0.0) {
+         return JapanGsiElevationSource.Sample.none();
+      } else {
+         JapanGsiElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         if (latLon == null || !this.isLikelyInCoverage(latLon.lat(), latLon.lon())) {
+            return JapanGsiElevationSource.Sample.none();
+         } else {
+            double sampleResolutionMeters = resolveSampleResolutionMeters(worldScale, targetResolutionMeters);
+
+            for (JapanGsiElevationSource.TileLayer layer : ALL_LAYERS) {
+               double sample = this.sampleLayer(layer, latLon.lat(), latLon.lon(), sampleResolutionMeters);
+               if (Double.isFinite(sample)) {
+                  return new JapanGsiElevationSource.Sample(sample, TellusElevationSource.DemUsage.JAPANGSI, layer.nominalResolutionMeters());
+               }
+            }
+
+            return JapanGsiElevationSource.Sample.none();
+         }
+      }
+   }
+
+   public JapanGsiElevationSource.Sample sampleLocalOnly(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!ENABLED || worldScale <= 0.0) {
+         return JapanGsiElevationSource.Sample.none();
+      } else {
+         JapanGsiElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         if (latLon == null || !this.isLikelyInCoverage(latLon.lat(), latLon.lon())) {
+            return JapanGsiElevationSource.Sample.none();
+         } else {
+            double sampleResolutionMeters = resolveSampleResolutionMeters(worldScale, targetResolutionMeters);
+
+            for (JapanGsiElevationSource.TileLayer layer : ALL_LAYERS) {
+               double sample = this.sampleLayerLocalOnly(layer, latLon.lat(), latLon.lon(), sampleResolutionMeters);
+               if (Double.isFinite(sample)) {
+                  return new JapanGsiElevationSource.Sample(sample, TellusElevationSource.DemUsage.JAPANGSI, layer.nominalResolutionMeters());
+               }
+            }
+
+            return JapanGsiElevationSource.Sample.none();
+         }
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, Double.NaN);
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius, double targetResolutionMeters) {
+      if (ENABLED && !(worldScale <= 0.0) && radius >= 0) {
+         JapanGsiElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         if (latLon != null && this.isLikelyInCoverage(latLon.lat(), latLon.lon())) {
+            double sampleResolutionMeters = resolveSampleResolutionMeters(worldScale, targetResolutionMeters);
+            int tileRadius = Math.max(0, radius);
+
+            for (JapanGsiElevationSource.TileLayer layer : prefetchLayers(sampleResolutionMeters)) {
+               JapanGsiElevationSource.TileCoordinate center = tileCoordinateForLatLon(latLon.lat(), latLon.lon(), selectZoom(sampleResolutionMeters, layer.maxZoom()));
+               if (center != null) {
+                  this.prefetchNeighborhood(new JapanGsiElevationSource.TileKey(layer, center.zoom(), center.tileX(), center.tileY()), tileRadius);
+               }
+            }
+         }
+      }
+   }
+
+   private void prefetchNeighborhood(JapanGsiElevationSource.TileKey center, int tileRadius) {
+      int tilesPerAxis = 1 << center.zoom();
+
+      for (int dy = -tileRadius; dy <= tileRadius; dy++) {
+         for (int dx = -tileRadius; dx <= tileRadius; dx++) {
+            int tileX = center.x() + dx;
+            int tileY = center.y() + dy;
+            if (tileX >= 0 && tileY >= 0 && tileX < tilesPerAxis && tileY < tilesPerAxis) {
+               this.prefetchTile(new JapanGsiElevationSource.TileKey(center.layer(), center.zoom(), tileX, tileY));
+            }
+         }
+      }
+   }
+
+   private void prefetchTile(JapanGsiElevationSource.TileKey key) {
+      if (this.tileCache.getIfPresent(key) == null) {
+         try {
+            this.tileCache.get(key);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch Japan GSI tile {}", key, error);
+         }
+      }
+   }
+
+   private double sampleLayer(JapanGsiElevationSource.TileLayer layer, double lat, double lon, double sampleResolutionMeters) {
+      JapanGsiElevationSource.TileCoordinate coord = tileCoordinateForLatLon(lat, lon, selectZoom(sampleResolutionMeters, layer.maxZoom()));
+      if (coord == null) {
+         return Double.NaN;
+      } else {
+         FloatRaster raster = this.getTile(new JapanGsiElevationSource.TileKey(layer, coord.zoom(), coord.tileX(), coord.tileY()));
+         if (raster == null) {
+            return Double.NaN;
+         } else {
+            return this.sampleBilinearAcrossTiles(coord, raster, layer);
+         }
+      }
+   }
+
+   private double sampleLayerLocalOnly(JapanGsiElevationSource.TileLayer layer, double lat, double lon, double sampleResolutionMeters) {
+      JapanGsiElevationSource.TileCoordinate coord = tileCoordinateForLatLon(lat, lon, selectZoom(sampleResolutionMeters, layer.maxZoom()));
+      if (coord == null) {
+         return Double.NaN;
+      } else {
+         FloatRaster raster = this.getTileLocalOnly(new JapanGsiElevationSource.TileKey(layer, coord.zoom(), coord.tileX(), coord.tileY()));
+         return raster == null ? Double.NaN : this.sampleBilinearAcrossTilesLocalOnly(coord, raster, layer);
+      }
+   }
+
+   private FloatRaster getTile(JapanGsiElevationSource.TileKey key) {
+      try {
+         JapanGsiElevationSource.TileRecord record = this.tileCache.get(key);
+         return record.missing() ? null : record.raster();
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load Japan GSI tile {}", key, error);
+         return null;
+      }
+   }
+
+   private FloatRaster getTileLocalOnly(JapanGsiElevationSource.TileKey key) {
+      JapanGsiElevationSource.TileRecord cached = this.tileCache.getIfPresent(key);
+      if (cached != null) {
+         return cached.missing() ? null : cached.raster();
+      } else {
+         Path missingMarker = key.missingMarkerPath(this.cacheRoot);
+         if (Files.exists(missingMarker)) {
+            this.tileCache.put(key, MISSING_TILE);
+            return null;
+         } else {
+            Path cachePath = key.cachePath(this.cacheRoot);
+            if (!Files.exists(cachePath)) {
+               return null;
+            } else {
+               try (InputStream input = Files.newInputStream(cachePath)) {
+                  JapanGsiElevationSource.TileRecord record = new JapanGsiElevationSource.TileRecord(readPngRaster(input), false);
+                  JapanGsiElevationSource.TileRecord raced = this.tileCache.asMap().putIfAbsent(key, record);
+                  JapanGsiElevationSource.TileRecord resolved = raced != null ? raced : record;
+                  return resolved.missing() ? null : resolved.raster();
+               } catch (IOException error) {
+                  Tellus.LOGGER.debug("Failed to load cached Japan GSI tile {}", key, error);
+                  return null;
+               }
+            }
+         }
+      }
+   }
+
+   private JapanGsiElevationSource.TileRecord loadTile(JapanGsiElevationSource.TileKey key) throws Exception {
+      Path cachePath = key.cachePath(this.cacheRoot);
+      if (Files.exists(cachePath)) {
+         try {
+            try (InputStream input = Files.newInputStream(cachePath)) {
+               return new JapanGsiElevationSource.TileRecord(readPngRaster(input), false);
+            }
+         } catch (IOException error) {
+            Files.deleteIfExists(cachePath);
+         }
+      }
+
+      Path missingMarker = key.missingMarkerPath(this.cacheRoot);
+      if (Files.exists(missingMarker)) {
+         return MISSING_TILE;
+      } else {
+         byte[] data;
+         try {
+            data = this.downloadTile(key);
+         } catch (JapanGsiElevationSource.MissingTileException error) {
+            this.writeMissingMarker(missingMarker);
+            return MISSING_TILE;
+         }
+
+         this.cacheTile(cachePath, data);
+
+         try (InputStream input = new ByteArrayInputStream(data)) {
+            return new JapanGsiElevationSource.TileRecord(readPngRaster(input), false);
+         } catch (IOException error) {
+            Files.deleteIfExists(cachePath);
+            throw error;
+         }
+      }
+   }
+
+   private byte[] downloadTile(JapanGsiElevationSource.TileKey key) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)URI.create(key.url()).toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+
+      try {
+         int status = connection.getResponseCode();
+         if (status == 404) {
+            throw new JapanGsiElevationSource.MissingTileException();
+         } else if (status != 200) {
+            throw new IOException("Unexpected Japan GSI status " + status + " for " + key.url());
+         } else {
+            DownloadProgressReporter.requestStarted(Math.max(0L, connection.getContentLengthLong()));
+
+            try (InputStream input = Objects.requireNonNull(connection.getInputStream(), "japanGsiResponse")) {
+               return DownloadProgressReporter.readAllBytesWithProgress(input);
+            } finally {
+               DownloadProgressReporter.requestFinished();
+            }
+         }
+      } finally {
+         connection.disconnect();
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] data) throws IOException {
+      Files.createDirectories(cachePath.getParent());
+      Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+      Files.write(tempPath, data);
+
+      try {
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (IOException error) {
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      }
+   }
+
+   private void writeMissingMarker(Path missingMarker) {
+      try {
+         Files.createDirectories(missingMarker.getParent());
+         if (!Files.exists(missingMarker)) {
+            Files.writeString(missingMarker, "missing");
+         }
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to persist Japan GSI missing marker {}", missingMarker, error);
+      }
+   }
+
+   private double sampleBilinearAcrossTiles(JapanGsiElevationSource.TileCoordinate coord, FloatRaster baseRaster, JapanGsiElevationSource.TileLayer layer) {
+      int tilesPerAxis = 1 << coord.zoom();
+      int maxPixel = tilesPerAxis * TILE_SIZE - 1;
+      double clampedX = Mth.clamp(coord.globalPixelX(), 0.0, maxPixel);
+      double clampedY = Mth.clamp(coord.globalPixelY(), 0.0, maxPixel);
+      int x0 = Mth.floor(clampedX);
+      int y0 = Mth.floor(clampedY);
+      int x1 = Math.min(x0 + 1, maxPixel);
+      int y1 = Math.min(y0 + 1, maxPixel);
+      double dx = clampedX - x0;
+      double dy = clampedY - y0;
+      float v00 = this.samplePixel(layer, coord.zoom(), x0, y0, coord.tileX(), coord.tileY(), baseRaster);
+      float v10 = this.samplePixel(layer, coord.zoom(), x1, y0, coord.tileX(), coord.tileY(), baseRaster);
+      float v01 = this.samplePixel(layer, coord.zoom(), x0, y1, coord.tileX(), coord.tileY(), baseRaster);
+      float v11 = this.samplePixel(layer, coord.zoom(), x1, y1, coord.tileX(), coord.tileY(), baseRaster);
+      return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+   }
+
+   private double sampleBilinearAcrossTilesLocalOnly(
+      JapanGsiElevationSource.TileCoordinate coord, FloatRaster baseRaster, JapanGsiElevationSource.TileLayer layer
+   ) {
+      int tilesPerAxis = 1 << coord.zoom();
+      int maxPixel = tilesPerAxis * TILE_SIZE - 1;
+      double clampedX = Mth.clamp(coord.globalPixelX(), 0.0, maxPixel);
+      double clampedY = Mth.clamp(coord.globalPixelY(), 0.0, maxPixel);
+      int x0 = Mth.floor(clampedX);
+      int y0 = Mth.floor(clampedY);
+      int x1 = Math.min(x0 + 1, maxPixel);
+      int y1 = Math.min(y0 + 1, maxPixel);
+      double dx = clampedX - x0;
+      double dy = clampedY - y0;
+      float v00 = this.samplePixelLocalOnly(layer, coord.zoom(), x0, y0, coord.tileX(), coord.tileY(), baseRaster);
+      float v10 = this.samplePixelLocalOnly(layer, coord.zoom(), x1, y0, coord.tileX(), coord.tileY(), baseRaster);
+      float v01 = this.samplePixelLocalOnly(layer, coord.zoom(), x0, y1, coord.tileX(), coord.tileY(), baseRaster);
+      float v11 = this.samplePixelLocalOnly(layer, coord.zoom(), x1, y1, coord.tileX(), coord.tileY(), baseRaster);
+      return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+   }
+
+   private float samplePixel(
+      JapanGsiElevationSource.TileLayer layer, int zoom, int pixelX, int pixelY, int baseTileX, int baseTileY, FloatRaster baseRaster
+   ) {
+      int tileX = Math.floorDiv(pixelX, TILE_SIZE);
+      int tileY = Math.floorDiv(pixelY, TILE_SIZE);
+      int tilesPerAxis = 1 << zoom;
+      if (tileX < 0 || tileY < 0 || tileX >= tilesPerAxis || tileY >= tilesPerAxis) {
+         return Float.NaN;
+      } else {
+         FloatRaster raster = tileX == baseTileX && tileY == baseTileY ? baseRaster : this.getTile(new JapanGsiElevationSource.TileKey(layer, zoom, tileX, tileY));
+         if (raster == null) {
+            return Float.NaN;
+         } else {
+            int localX = pixelX - tileX * TILE_SIZE;
+            int localY = pixelY - tileY * TILE_SIZE;
+            return raster.get(localX, localY);
+         }
+      }
+   }
+
+   private float samplePixelLocalOnly(
+      JapanGsiElevationSource.TileLayer layer, int zoom, int pixelX, int pixelY, int baseTileX, int baseTileY, FloatRaster baseRaster
+   ) {
+      int tileX = Math.floorDiv(pixelX, TILE_SIZE);
+      int tileY = Math.floorDiv(pixelY, TILE_SIZE);
+      int tilesPerAxis = 1 << zoom;
+      if (tileX < 0 || tileY < 0 || tileX >= tilesPerAxis || tileY >= tilesPerAxis) {
+         return Float.NaN;
+      } else {
+         FloatRaster raster = tileX == baseTileX && tileY == baseTileY
+            ? baseRaster
+            : this.getTileLocalOnly(new JapanGsiElevationSource.TileKey(layer, zoom, tileX, tileY));
+         if (raster == null) {
+            return Float.NaN;
+         } else {
+            int localX = pixelX - tileX * TILE_SIZE;
+            int localY = pixelY - tileY * TILE_SIZE;
+            return raster.get(localX, localY);
+         }
+      }
+   }
+
+   private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+      double w00 = (1.0 - dx) * (1.0 - dy);
+      double w10 = dx * (1.0 - dy);
+      double w01 = (1.0 - dx) * dy;
+      double w11 = dx * dy;
+      double sum = 0.0;
+      double weight = 0.0;
+      if (Float.isFinite(v00)) {
+         sum += v00 * w00;
+         weight += w00;
+      }
+
+      if (Float.isFinite(v10)) {
+         sum += v10 * w10;
+         weight += w10;
+      }
+
+      if (Float.isFinite(v01)) {
+         sum += v01 * w01;
+         weight += w01;
+      }
+
+      if (Float.isFinite(v11)) {
+         sum += v11 * w11;
+         weight += w11;
+      }
+
+      return weight > 0.0 ? sum / weight : Double.NaN;
+   }
+
+   private static FloatRaster readPngRaster(InputStream input) throws IOException {
+      BufferedImage image = ImageIO.read(input);
+      if (image == null) {
+         throw new IOException("Invalid Japan GSI PNG tile");
+      } else {
+         int width = image.getWidth();
+         int height = image.getHeight();
+         FloatRaster raster = FloatRaster.create(width, height);
+
+         for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+               int argb = image.getRGB(x, y);
+               int red = argb >> 16 & 0xFF;
+               int green = argb >> 8 & 0xFF;
+               int blue = argb & 0xFF;
+               if (red == GSI_NO_DATA_R && green == GSI_NO_DATA_G && blue == GSI_NO_DATA_B) {
+                  raster.set(x, y, Float.NaN);
+               } else {
+                  int encoded = red << 16 | green << 8 | blue;
+                  double elevation = encoded < 1 << 23 ? encoded * GSI_UNIT_METERS : (encoded - (1 << 24)) * GSI_UNIT_METERS;
+                  raster.set(x, y, (float)elevation);
+               }
+            }
+         }
+
+         return raster;
+      }
+   }
+
+   private static JapanGsiElevationSource.TileCoordinate tileCoordinateForLatLon(double lat, double lon, int zoom) {
+      if (!(lat >= MIN_LAT) || !(lat <= MAX_LAT) || !(lon >= MIN_LON) || !(lon <= MAX_LON)) {
+         return null;
+      } else {
+         double clampedLat = Mth.clamp(lat, MIN_LAT, MAX_LAT);
+         double clampedLon = Mth.clamp(lon, MIN_LON, MAX_LON);
+         double latRad = Math.toRadians(clampedLat);
+         double n = Math.pow(2.0, zoom);
+         double tileX = (clampedLon + 180.0) / 360.0 * n;
+         double tileY = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+         if (!(tileX >= 0.0) || !(tileY >= 0.0) || !(tileX < n) || !(tileY < n)) {
+            return null;
+         } else {
+            return new JapanGsiElevationSource.TileCoordinate(zoom, tileX, tileY, Mth.floor(tileX), Mth.floor(tileY));
+         }
+      }
+   }
+
+   private static int selectZoom(double resolutionMeters, int maxZoom) {
+      if (!(resolutionMeters > 0.0) || !Double.isFinite(resolutionMeters)) {
+         return maxZoom;
+      } else {
+         double zoom = Math.log(EQUATOR_CIRCUMFERENCE / (TILE_SIZE * resolutionMeters)) / Math.log(2.0);
+         return Mth.clamp((int)Math.round(zoom), MIN_ZOOM, maxZoom);
+      }
+   }
+
+   private static double resolveSampleResolutionMeters(double worldScale, double targetResolutionMeters) {
+      return targetResolutionMeters > 0.0 && Double.isFinite(targetResolutionMeters) ? targetResolutionMeters : worldScale;
+   }
+
+   private static JapanGsiElevationSource.TileLayer[] prefetchLayers(double sampleResolutionMeters) {
+      if (!(sampleResolutionMeters > 0.0) || !Double.isFinite(sampleResolutionMeters) || sampleResolutionMeters <= 1.5) {
+         return ALL_LAYERS;
+      } else {
+         return sampleResolutionMeters <= 6.0 ? MEDIUM_RES_LAYERS : COARSE_LAYERS;
+      }
+   }
+
+   private static JapanGsiElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0 ? new JapanGsiElevationSource.LatLon(lat, lon) : null;
+   }
+
+   private static boolean isInCoverageBox(double lat, double lon) {
+      return inBox(lat, lon, 30.0, 41.8, 129.0, 145.8)
+         || inBox(lat, lon, 41.0, 46.5, 139.0, 146.5)
+         || inBox(lat, lon, 24.0, 30.0, 123.0, 130.5)
+         || inBox(lat, lon, 23.0, 28.5, 141.0, 145.5)
+         || inBox(lat, lon, 25.2, 26.9, 130.5, 132.2);
+   }
+
+   private static boolean inBox(double lat, double lon, double minLat, double maxLat, double minLon, double maxLon) {
+      return lat >= minLat && lat <= maxLat && lon >= minLon && lon <= maxLon;
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.JAPANGSI;
+   }
+
+   @Override
+   public void clearCache() {
+      this.tileCache.invalidateAll();
+      this.tileCache.cleanUp();
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record TileCoordinate(int zoom, double tileCoordX, double tileCoordY, int tileX, int tileY) {
+      private double globalPixelX() {
+         return this.tileCoordX * TILE_SIZE;
+      }
+
+      private double globalPixelY() {
+         return this.tileCoordY * TILE_SIZE;
+      }
+   }
+
+   private record TileRecord(FloatRaster raster, boolean missing) {
+   }
+
+   private static final class MissingTileException extends IOException {
+      private static final long serialVersionUID = 1L;
+   }
+
+   private record TileKey(JapanGsiElevationSource.TileLayer layer, int zoom, int x, int y) {
+      private TileKey {
+         Objects.requireNonNull(layer, "layer");
+      }
+
+      private String url() {
+         return BASE_ENDPOINT + "/" + this.layer.pathSegment() + "/" + this.zoom + "/" + this.x + "/" + this.y + ".png";
+      }
+
+      private Path cachePath(Path cacheRoot) {
+         return cacheRoot.resolve(this.layer.pathSegment()).resolve(Integer.toString(this.zoom)).resolve(Integer.toString(this.x)).resolve(this.y + ".png");
+      }
+
+      private Path missingMarkerPath(Path cacheRoot) {
+         return cacheRoot.resolve(this.layer.pathSegment()).resolve(Integer.toString(this.zoom)).resolve(Integer.toString(this.x)).resolve(this.y + ".missing");
+      }
+   }
+
+   private static enum TileLayer {
+      DEM1A("dem1a_png", 17, 1.0),
+      DEM5A("dem5a_png", 15, 5.0),
+      DEM5B("dem5b_png", 15, 5.0),
+      DEM5C("dem5c_png", 15, 5.0),
+      DEM10B("dem_png", 14, 10.0);
+
+      private final String pathSegment;
+      private final int maxZoom;
+      private final double nominalResolutionMeters;
+
+      private TileLayer(String pathSegment, int maxZoom, double nominalResolutionMeters) {
+         this.pathSegment = pathSegment;
+         this.maxZoom = maxZoom;
+         this.nominalResolutionMeters = nominalResolutionMeters;
+      }
+
+      private String pathSegment() {
+         return this.pathSegment;
+      }
+
+      private int maxZoom() {
+         return this.maxZoom;
+      }
+
+      private double nominalResolutionMeters() {
+         return this.nominalResolutionMeters;
+      }
+   }
+
+   public record Sample(double elevation, TellusElevationSource.DemUsage usage, double resolutionMeters) {
+      private static JapanGsiElevationSource.Sample none() {
+         return new JapanGsiElevationSource.Sample(Double.NaN, null, Double.NaN);
+      }
+
+      public boolean usable() {
+         return this.usage != null && Double.isFinite(this.elevation);
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/NormalizedElevationCache.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/NormalizedElevationCache.java
@@ -1,0 +1,365 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.elevation.TellusElevationSource.DemUsage;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+final class NormalizedElevationCache implements TellusCacheHandle {
+   private static final int DEFAULT_MEMORY_TILES = intProperty("tellus.elevation.normalized.memoryTiles", 256);
+   private static final int DEFAULT_THREADS = intProperty(
+      "tellus.elevation.normalized.threads",
+      Math.max(1, Math.min(4, Math.max(1, Runtime.getRuntime().availableProcessors() / 2)))
+   );
+   private final Path root;
+   private final Cache<NormalizedElevationTileKey, NormalizedElevationTile> memoryCache;
+   private final ExecutorService builderExecutor;
+   private final ConcurrentHashMap<NormalizedElevationTileKey, CompletableFuture<NormalizedElevationTile>> inFlight = new ConcurrentHashMap<>();
+
+   NormalizedElevationCache() {
+      this(
+         FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-normalized"),
+         Executors.newFixedThreadPool(DEFAULT_THREADS, new BuilderThreadFactory()),
+         DEFAULT_MEMORY_TILES,
+         true
+      );
+   }
+
+   NormalizedElevationCache(Path baseRoot, ExecutorService builderExecutor, int maxMemoryTiles) {
+      this(baseRoot, builderExecutor, maxMemoryTiles, false);
+   }
+
+   private NormalizedElevationCache(Path baseRoot, ExecutorService builderExecutor, int maxMemoryTiles, boolean registerHandle) {
+      this.root = Objects.requireNonNull(baseRoot, "baseRoot").resolve(EarthProjection.projectionModeId()).resolve("v1");
+      this.builderExecutor = Objects.requireNonNull(builderExecutor, "builderExecutor");
+      this.memoryCache = CacheBuilder.newBuilder().maximumSize(Math.max(1, maxMemoryTiles)).build();
+      if (registerHandle) {
+         TellusCacheRegistry.register(this);
+      }
+   }
+
+   NormalizedElevationTileSample sample(
+      double projectedX,
+      double projectedZ,
+      double resolutionMeters,
+      EarthGeneratorSettings.DemSelection demSelection,
+      boolean highResOcean,
+      NormalizedElevationCache.TileBuilder builder
+   ) {
+      NormalizedElevationTileKey key = NormalizedElevationTileKey.forProjectedMeters(projectedX, projectedZ, resolutionMeters, demSelection, highResOcean);
+      double spacing = key.sampleResolutionMeters();
+      double sampleX = projectedX / spacing;
+      double sampleZ = projectedZ / spacing;
+      int x0 = Mth.floor(sampleX);
+      int z0 = Mth.floor(sampleZ);
+      int x1 = x0 + 1;
+      int z1 = z0 + 1;
+      double dx = sampleX - x0;
+      double dz = sampleZ - z0;
+      NormalizedElevationTile baseTile = this.getOrBuildBlocking(key, builder);
+      double v00 = this.sampleHeight(key, baseTile, x0, z0, builder);
+      double v10 = this.sampleHeight(key, baseTile, x1, z0, builder);
+      double v01 = this.sampleHeight(key, baseTile, x0, z1, builder);
+      double v11 = this.sampleHeight(key, baseTile, x1, z1, builder);
+      double lerpX0 = Mth.lerp(dx, v00, v10);
+      double lerpX1 = Mth.lerp(dx, v01, v11);
+      double elevation = Mth.lerp(dz, lerpX0, lerpX1);
+      int nearestSampleX = Mth.floor(sampleX + 0.5);
+      int nearestSampleZ = Mth.floor(sampleZ + 0.5);
+      TileSample provenanceSample = this.sampleProvenance(key, baseTile, nearestSampleX, nearestSampleZ, builder);
+      return new NormalizedElevationTileSample(elevation, provenanceSample.primaryProvider(), provenanceSample.providerMask(), spacing);
+   }
+
+   void prefetchRange(
+      double minProjectedX,
+      double minProjectedZ,
+      double maxProjectedX,
+      double maxProjectedZ,
+      double resolutionMeters,
+      EarthGeneratorSettings.DemSelection demSelection,
+      boolean highResOcean,
+      NormalizedElevationCache.TileBuilder builder
+   ) {
+      NormalizedElevationTileKey origin = NormalizedElevationTileKey.forProjectedMeters(
+         minProjectedX, minProjectedZ, resolutionMeters, demSelection, highResOcean
+      );
+      int tileSpanMeters = origin.tileSpanMeters();
+      int minTileX = Mth.floor(Math.min(minProjectedX, maxProjectedX) / tileSpanMeters);
+      int maxTileX = Mth.floor(Math.max(minProjectedX, maxProjectedX) / tileSpanMeters);
+      int minTileZ = Mth.floor(Math.min(minProjectedZ, maxProjectedZ) / tileSpanMeters);
+      int maxTileZ = Mth.floor(Math.max(minProjectedZ, maxProjectedZ) / tileSpanMeters);
+
+      for (int tileZ = minTileZ; tileZ <= maxTileZ; tileZ++) {
+         for (int tileX = minTileX; tileX <= maxTileX; tileX++) {
+            this.scheduleBuild(origin.withTile(tileX, tileZ), builder);
+         }
+      }
+   }
+
+   NormalizedElevationTile getOrBuildBlocking(NormalizedElevationTileKey key, NormalizedElevationCache.TileBuilder builder) {
+      NormalizedElevationTile cached = this.memoryCache.getIfPresent(key);
+      if (cached != null) {
+         return cached;
+      } else {
+         try {
+            return this.scheduleBuild(key, builder).join();
+         } catch (CompletionException error) {
+            Throwable cause = error.getCause();
+            if (cause instanceof RuntimeException runtime) {
+               throw runtime;
+            } else {
+               throw new RuntimeException("Failed to build normalized elevation tile " + key, cause);
+            }
+         }
+      }
+   }
+
+   Path root() {
+      return this.root;
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.NORMALIZED_TERRAIN;
+   }
+
+   @Override
+   public void clearCache() {
+      this.memoryCache.invalidateAll();
+      this.memoryCache.cleanUp();
+      for (CompletableFuture<NormalizedElevationTile> future : this.inFlight.values()) {
+         future.cancel(true);
+      }
+
+      this.inFlight.clear();
+   }
+
+   private CompletableFuture<NormalizedElevationTile> scheduleBuild(NormalizedElevationTileKey key, NormalizedElevationCache.TileBuilder builder) {
+      NormalizedElevationTile cached = this.memoryCache.getIfPresent(key);
+      if (cached != null) {
+         return CompletableFuture.completedFuture(cached);
+      } else {
+         return this.inFlight.computeIfAbsent(
+            key,
+            missing -> CompletableFuture.supplyAsync(() -> this.loadOrBuild(missing, builder), this.builderExecutor).whenComplete((tile, error) -> {
+                  this.inFlight.remove(missing);
+                  if (error == null && tile != null) {
+                     this.memoryCache.put(missing, tile);
+                  }
+               })
+         );
+      }
+   }
+
+   private NormalizedElevationTile loadOrBuild(NormalizedElevationTileKey key, NormalizedElevationCache.TileBuilder builder) {
+      NormalizedElevationTile diskTile = this.readTile(key);
+      if (diskTile != null) {
+         return diskTile;
+      } else {
+         try {
+            NormalizedElevationTile built = Objects.requireNonNull(builder.build(key), "normalizedElevationTile");
+            this.writeTile(key, built);
+            return built;
+         } catch (IOException error) {
+            throw new RuntimeException("Failed to build normalized elevation tile " + key, error);
+         }
+      }
+   }
+
+   private NormalizedElevationTile readTile(NormalizedElevationTileKey key) {
+      Path heightPath = this.heightPath(key);
+      Path provenancePath = this.provenancePath(key);
+      if (!Files.exists(heightPath) || !Files.exists(provenancePath)) {
+         return null;
+      } else {
+         try (InputStream heightIn = Files.newInputStream(heightPath); InputStream provenanceIn = Files.newInputStream(provenancePath)) {
+            ShortRaster heights = TellusRasterReader.readShortRaster(heightIn);
+            TellusElevationProvenance provenance = TellusElevationProvenanceCodec.read(provenanceIn);
+            return new NormalizedElevationTile(key, heights, provenance);
+         } catch (IOException | RuntimeException error) {
+            this.deleteCorruptTile(heightPath, provenancePath, key, error);
+            return null;
+         }
+      }
+   }
+
+   private void writeTile(NormalizedElevationTileKey key, NormalizedElevationTile tile) throws IOException {
+      Path heightPath = this.heightPath(key);
+      Path provenancePath = this.provenancePath(key);
+      Files.createDirectories(heightPath.getParent());
+      Files.createDirectories(provenancePath.getParent());
+      Path tempHeight = heightPath.resolveSibling(heightPath.getFileName() + ".tmp");
+      Path tempProvenance = provenancePath.resolveSibling(provenancePath.getFileName() + ".tmp");
+
+      try {
+         try (OutputStream heightOut = Files.newOutputStream(tempHeight)) {
+            TellusRasterWriter.writeShortRaster(heightOut, tile.heights());
+         }
+
+         try (OutputStream provenanceOut = Files.newOutputStream(tempProvenance)) {
+            TellusElevationProvenanceCodec.write(provenanceOut, tile.provenance());
+         }
+
+         moveAtomically(tempHeight, heightPath);
+         moveAtomically(tempProvenance, provenancePath);
+      } catch (IOException error) {
+         Files.deleteIfExists(tempHeight);
+         Files.deleteIfExists(tempProvenance);
+         throw error;
+      }
+   }
+
+   private double sampleHeight(NormalizedElevationTileKey baseKey, int globalSampleX, int globalSampleZ, NormalizedElevationCache.TileBuilder builder) {
+      int tileX = Math.floorDiv(globalSampleX, NormalizedElevationTileKey.TILE_SIZE);
+      int tileZ = Math.floorDiv(globalSampleZ, NormalizedElevationTileKey.TILE_SIZE);
+      int localX = Math.floorMod(globalSampleX, NormalizedElevationTileKey.TILE_SIZE);
+      int localZ = Math.floorMod(globalSampleZ, NormalizedElevationTileKey.TILE_SIZE);
+      NormalizedElevationTile tile = this.getOrBuildBlocking(baseKey.withTile(tileX, tileZ), builder);
+      return tile.heights().get(localX, localZ);
+   }
+
+   private double sampleHeight(
+      NormalizedElevationTileKey baseKey,
+      NormalizedElevationTile baseTile,
+      int globalSampleX,
+      int globalSampleZ,
+      NormalizedElevationCache.TileBuilder builder
+   ) {
+      if (isSampleInTile(baseKey, globalSampleX, globalSampleZ)) {
+         return baseTile.heights().get(localSampleCoordinate(baseKey.tileX(), globalSampleX), localSampleCoordinate(baseKey.tileZ(), globalSampleZ));
+      }
+
+      return this.sampleHeight(baseKey, globalSampleX, globalSampleZ, builder);
+   }
+
+   private TileSample sampleProvenance(
+      NormalizedElevationTileKey baseKey, int globalSampleX, int globalSampleZ, NormalizedElevationCache.TileBuilder builder
+   ) {
+      int tileX = Math.floorDiv(globalSampleX, NormalizedElevationTileKey.TILE_SIZE);
+      int tileZ = Math.floorDiv(globalSampleZ, NormalizedElevationTileKey.TILE_SIZE);
+      int localX = Math.floorMod(globalSampleX, NormalizedElevationTileKey.TILE_SIZE);
+      int localZ = Math.floorMod(globalSampleZ, NormalizedElevationTileKey.TILE_SIZE);
+      NormalizedElevationTile tile = this.getOrBuildBlocking(baseKey.withTile(tileX, tileZ), builder);
+      TellusElevationProvenance provenance = tile.provenance();
+      DemUsage primaryProvider = provenance.primaryProvider(localX, localZ);
+      int providerMask = provenance.isBlended(localX, localZ) ? provenance.providerMask() : primaryProvider.bit();
+      return new TileSample(primaryProvider, providerMask);
+   }
+
+   private TileSample sampleProvenance(
+      NormalizedElevationTileKey baseKey,
+      NormalizedElevationTile baseTile,
+      int globalSampleX,
+      int globalSampleZ,
+      NormalizedElevationCache.TileBuilder builder
+   ) {
+      if (isSampleInTile(baseKey, globalSampleX, globalSampleZ)) {
+         int localX = localSampleCoordinate(baseKey.tileX(), globalSampleX);
+         int localZ = localSampleCoordinate(baseKey.tileZ(), globalSampleZ);
+         TellusElevationProvenance provenance = baseTile.provenance();
+         DemUsage primaryProvider = provenance.primaryProvider(localX, localZ);
+         int providerMask = provenance.isBlended(localX, localZ) ? provenance.providerMask() : primaryProvider.bit();
+         return new TileSample(primaryProvider, providerMask);
+      }
+
+      return this.sampleProvenance(baseKey, globalSampleX, globalSampleZ, builder);
+   }
+
+   private Path heightPath(NormalizedElevationTileKey key) {
+      return this.resolveTileDirectory(key).resolve(Integer.toString(key.tileZ()) + ".raster");
+   }
+
+   private Path provenancePath(NormalizedElevationTileKey key) {
+      return this.resolveTileDirectory(key).resolve(Integer.toString(key.tileZ()) + ".prov");
+   }
+
+   private Path resolveTileDirectory(NormalizedElevationTileKey key) {
+      String oceanMode = key.highResOcean() ? "highres-ocean" : "standard-ocean";
+      return this.root.resolve(key.demSelectionFingerprint()).resolve(oceanMode).resolve("lod" + key.lod()).resolve(Integer.toString(key.tileX()));
+   }
+
+   private void deleteCorruptTile(Path heightPath, Path provenancePath, NormalizedElevationTileKey key, Throwable error) {
+      try {
+         Files.deleteIfExists(heightPath);
+      } catch (IOException ignored) {
+      }
+
+      try {
+         Files.deleteIfExists(provenancePath);
+      } catch (IOException ignored) {
+      }
+
+      Tellus.LOGGER.debug("Rebuilding corrupt normalized elevation tile {}", key, error);
+   }
+
+   private static void moveAtomically(Path source, Path target) throws IOException {
+      try {
+         Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException ignored) {
+         Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+      }
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException ignored) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static boolean isSampleInTile(NormalizedElevationTileKey key, int globalSampleX, int globalSampleZ) {
+      return Math.floorDiv(globalSampleX, NormalizedElevationTileKey.TILE_SIZE) == key.tileX()
+         && Math.floorDiv(globalSampleZ, NormalizedElevationTileKey.TILE_SIZE) == key.tileZ();
+   }
+
+   private static int localSampleCoordinate(int tileCoordinate, int globalSampleCoordinate) {
+      return globalSampleCoordinate - tileCoordinate * NormalizedElevationTileKey.TILE_SIZE;
+   }
+
+   @FunctionalInterface
+   interface TileBuilder {
+      NormalizedElevationTile build(NormalizedElevationTileKey key) throws IOException;
+   }
+
+   private static record TileSample(DemUsage primaryProvider, int providerMask) {
+   }
+
+   private static final class BuilderThreadFactory implements ThreadFactory {
+      private static final AtomicInteger NEXT_ID = new AtomicInteger(1);
+
+      @Override
+      public Thread newThread(Runnable task) {
+         Thread thread = new Thread(task, "Tellus-NormalizedElevation-" + NEXT_ID.getAndIncrement());
+         thread.setDaemon(true);
+         return thread;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/NorwayDtm1ElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/NorwayDtm1ElevationSource.java
@@ -1,0 +1,1421 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class NorwayDtm1ElevationSource implements TellusCacheHandle {
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final int MAX_FILE_CACHE = intProperty("tellus.norwaydtm1.cacheFiles", 8);
+   private static final int MAX_TILE_CACHE = intProperty("tellus.norwaydtm1.cacheTiles", 16);
+   private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("tellus.norwaydtm1.enabled", "true"));
+   private static final double DEFAULT_NO_DATA = -9999.0;
+   private static final double PROJ_A = 6378137.0;
+   private static final double PROJ_INV_F = 298.257222101;
+   private static final double PROJ_F = 1.0 / PROJ_INV_F;
+   private static final double PROJ_E2 = 2.0 * PROJ_F - PROJ_F * PROJ_F;
+   private static final double PROJ_E4 = PROJ_E2 * PROJ_E2;
+   private static final double PROJ_E6 = PROJ_E4 * PROJ_E2;
+   private static final double PROJ_EP2 = PROJ_E2 / (1.0 - PROJ_E2);
+   private static final double PROJ_K0 = 0.9996;
+   private static final double PROJ_LON_0 = Math.toRadians(15.0);
+   private static final double PROJ_FALSE_EASTING = 500000.0;
+   private static final double PROJ_FALSE_NORTHING = 0.0;
+   private final Path cacheRoot;
+   private final NorwayDtm1CoverageIndex coverageIndex = NorwayDtm1CoverageIndex.create();
+   private final LoadingCache<NorwayDtm1ElevationSource.TileCacheKey, NorwayDtm1ElevationSource.TileFile> fileCache;
+
+   public NorwayDtm1ElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-norway-dtm1");
+      this.fileCache = CacheBuilder.newBuilder().maximumSize(MAX_FILE_CACHE).build(new CacheLoader<NorwayDtm1ElevationSource.TileCacheKey, NorwayDtm1ElevationSource.TileFile>() {
+         public NorwayDtm1ElevationSource.TileFile load(NorwayDtm1ElevationSource.TileCacheKey key) throws Exception {
+            return NorwayDtm1ElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isLikelyInCoverage(double lat, double lon) {
+      return ENABLED && this.coverageIndex.available() && this.coverageIndex.findTile(lat, lon) != null;
+   }
+
+   public NorwayDtm1ElevationSource.Sample sample(double blockX, double blockZ, double worldScale) {
+      return this.sample(blockX, blockZ, worldScale, Double.NaN);
+   }
+
+   public NorwayDtm1ElevationSource.Sample sample(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return NorwayDtm1ElevationSource.Sample.none();
+      } else {
+         NorwayDtm1ElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? NorwayDtm1ElevationSource.Sample.none() : this.sampleAtLatLon(latLon.lat(), latLon.lon(), targetResolutionMeters);
+      }
+   }
+
+   public NorwayDtm1ElevationSource.Sample sampleLocalOnly(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return NorwayDtm1ElevationSource.Sample.none();
+      } else {
+         NorwayDtm1ElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? NorwayDtm1ElevationSource.Sample.none() : this.sampleAtLatLonLocalOnly(latLon.lat(), latLon.lon(), targetResolutionMeters);
+      }
+   }
+
+   public NorwayDtm1ElevationSource.Sample sample(double lat, double lon) {
+      return this.sampleAtLatLon(lat, lon, Double.NaN);
+   }
+
+   private NorwayDtm1ElevationSource.Sample sampleAtLatLon(double lat, double lon, double targetResolutionMeters) {
+      if (!this.canUse()) {
+         return NorwayDtm1ElevationSource.Sample.none();
+      } else {
+         NorwayDtm1CoverageIndex.TileReference tile = this.coverageIndex.findTile(lat, lon);
+         return tile == null
+            ? NorwayDtm1ElevationSource.Sample.none()
+            : this.sample(tile, lat, lon, TellusElevationSource.DemUsage.NORWAYDTM1, targetResolutionMeters);
+      }
+   }
+
+   private NorwayDtm1ElevationSource.Sample sampleAtLatLonLocalOnly(double lat, double lon, double targetResolutionMeters) {
+      if (!this.canUse()) {
+         return NorwayDtm1ElevationSource.Sample.none();
+      } else {
+         NorwayDtm1CoverageIndex.TileReference tile = this.coverageIndex.findTile(lat, lon);
+         return tile == null
+            ? NorwayDtm1ElevationSource.Sample.none()
+            : this.sampleLocalOnly(tile, lat, lon, TellusElevationSource.DemUsage.NORWAYDTM1, targetResolutionMeters);
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, Double.NaN);
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius, double targetResolutionMeters) {
+      if (!(worldScale <= 0.0) && radius > 0 && this.canUse()) {
+         LinkedHashSet<NorwayDtm1CoverageIndex.TileReference> refs = new LinkedHashSet<>();
+         double blockRadius = Math.max(1, radius) * 256.0;
+
+         for (int dz = -1; dz <= 1; dz++) {
+            for (int dx = -1; dx <= 1; dx++) {
+               NorwayDtm1ElevationSource.LatLon latLon = toLatLon(blockX + dx * blockRadius, blockZ + dz * blockRadius, worldScale);
+               if (latLon != null) {
+                  NorwayDtm1CoverageIndex.TileReference tile = this.coverageIndex.findTile(latLon.lat(), latLon.lon());
+                  if (tile != null) {
+                     refs.add(tile);
+                  }
+               }
+            }
+         }
+
+         for (NorwayDtm1CoverageIndex.TileReference ref : refs) {
+            this.prefetchTile(ref, targetResolutionMeters);
+         }
+      }
+   }
+
+   private NorwayDtm1ElevationSource.Sample sample(
+      NorwayDtm1CoverageIndex.TileReference tileRef,
+      double lat,
+      double lon,
+      TellusElevationSource.DemUsage usage,
+      double targetResolutionMeters
+   ) {
+      NorwayDtm1ElevationSource.Projection projection = project(lat, lon);
+      if (projection == null) {
+         return NorwayDtm1ElevationSource.Sample.none();
+      } else {
+         NorwayDtm1ElevationSource.TileFile tile = this.getTile(tileRef, usage, targetResolutionMeters);
+         if (tile == null) {
+            return NorwayDtm1ElevationSource.Sample.none();
+         } else {
+            double value = tile.sampleProjected(projection.x(), projection.y());
+            return Double.isFinite(value)
+               ? new NorwayDtm1ElevationSource.Sample(value, usage, tile.effectiveResolutionMeters())
+               : NorwayDtm1ElevationSource.Sample.none();
+         }
+      }
+   }
+
+   private NorwayDtm1ElevationSource.Sample sampleLocalOnly(
+      NorwayDtm1CoverageIndex.TileReference tileRef,
+      double lat,
+      double lon,
+      TellusElevationSource.DemUsage usage,
+      double targetResolutionMeters
+   ) {
+      NorwayDtm1ElevationSource.Projection projection = project(lat, lon);
+      if (projection == null) {
+         return NorwayDtm1ElevationSource.Sample.none();
+      } else {
+         NorwayDtm1ElevationSource.TileFile tile = this.getTileLocalOnly(tileRef, usage, targetResolutionMeters);
+         if (tile == null) {
+            return NorwayDtm1ElevationSource.Sample.none();
+         } else {
+            double value = tile.sampleProjected(projection.x(), projection.y());
+            return Double.isFinite(value)
+               ? new NorwayDtm1ElevationSource.Sample(value, usage, tile.effectiveResolutionMeters())
+               : NorwayDtm1ElevationSource.Sample.none();
+         }
+      }
+   }
+
+   private boolean canUse() {
+      return ENABLED && this.coverageIndex.available();
+   }
+
+   private void prefetchTile(NorwayDtm1CoverageIndex.TileReference tileRef, double targetResolutionMeters) {
+      NorwayDtm1ElevationSource.TileCacheKey cacheKey = NorwayDtm1ElevationSource.TileCacheKey.forTarget(tileRef, targetResolutionMeters);
+      if (this.fileCache.getIfPresent(cacheKey) == null) {
+         try {
+            this.fileCache.get(cacheKey);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch Norway DTM1 tile {}", tileRef.id(), error);
+         }
+      }
+   }
+
+   private NorwayDtm1ElevationSource.TileFile getTile(
+      NorwayDtm1CoverageIndex.TileReference tileRef, TellusElevationSource.DemUsage usage, double targetResolutionMeters
+   ) {
+      NorwayDtm1ElevationSource.TileCacheKey cacheKey = NorwayDtm1ElevationSource.TileCacheKey.forTarget(tileRef, targetResolutionMeters);
+      try {
+         return this.fileCache.get(cacheKey);
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load Norway DTM1 tile {}", tileRef.id(), error);
+         return null;
+      }
+   }
+
+   private NorwayDtm1ElevationSource.TileFile getTileLocalOnly(
+      NorwayDtm1CoverageIndex.TileReference tileRef, TellusElevationSource.DemUsage usage, double targetResolutionMeters
+   ) {
+      NorwayDtm1ElevationSource.TileCacheKey cacheKey = NorwayDtm1ElevationSource.TileCacheKey.forTarget(tileRef, targetResolutionMeters);
+      NorwayDtm1ElevationSource.TileFile cached = this.fileCache.getIfPresent(cacheKey);
+      if (cached != null) {
+         return cached;
+      } else {
+         Path cacheDir = this.cacheRoot.resolve(tileRef.cacheDirectory());
+         if (!Files.isDirectory(cacheDir)) {
+            return null;
+         } else {
+            try {
+               NorwayDtm1ElevationSource.TileFile opened = NorwayDtm1ElevationSource.TileFile.openLocalOnly(
+                  tileRef, cacheDir, targetResolutionMeters, nativeResolutionMeters(tileRef)
+               );
+               NorwayDtm1ElevationSource.TileFile raced = this.fileCache.asMap().putIfAbsent(cacheKey, opened);
+               return raced != null ? raced : opened;
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached Norway DTM1 tile {}", tileRef.id(), error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private NorwayDtm1ElevationSource.TileFile loadTile(NorwayDtm1ElevationSource.TileCacheKey cacheKey) throws Exception {
+      NorwayDtm1CoverageIndex.TileReference tileRef = cacheKey.tileRef();
+      return NorwayDtm1ElevationSource.TileFile.open(
+         tileRef,
+         this.cacheRoot.resolve(tileRef.cacheDirectory()),
+         cacheKey.targetResolutionMeters(),
+         nativeResolutionMeters(tileRef)
+      );
+   }
+
+   private static NorwayDtm1ElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0 ? new NorwayDtm1ElevationSource.LatLon(lat, lon) : null;
+   }
+
+   private static NorwayDtm1ElevationSource.Projection project(double latDeg, double lonDeg) {
+      if (!(latDeg >= -90.0) || !(latDeg <= 90.0) || !(lonDeg >= -180.0) || !(lonDeg <= 180.0)) {
+         return null;
+      } else {
+         double lat = Math.toRadians(latDeg);
+         double lon = Math.toRadians(lonDeg);
+         double deltaLon = normalizeLongitudeRadians(lon - PROJ_LON_0);
+         double sinLat = Math.sin(lat);
+         double cosLat = Math.cos(lat);
+         double tanLat = Math.tan(lat);
+         double n = PROJ_A / Math.sqrt(1.0 - PROJ_E2 * sinLat * sinLat);
+         double t = tanLat * tanLat;
+         double c = PROJ_EP2 * cosLat * cosLat;
+         double a = cosLat * deltaLon;
+         double m = meridionalArc(lat);
+         double a2 = a * a;
+         double a3 = a2 * a;
+         double a4 = a2 * a2;
+         double a5 = a4 * a;
+         double a6 = a4 * a2;
+         double x = PROJ_FALSE_EASTING
+            + PROJ_K0 * n * (a + (1.0 - t + c) * a3 / 6.0 + (5.0 - 18.0 * t + t * t + 72.0 * c - 58.0 * PROJ_EP2) * a5 / 120.0);
+         double y = PROJ_FALSE_NORTHING
+            + PROJ_K0
+               * (m + n * tanLat * (a2 / 2.0 + (5.0 - t + 9.0 * c + 4.0 * c * c) * a4 / 24.0
+                  + (61.0 - 58.0 * t + t * t + 600.0 * c - 330.0 * PROJ_EP2) * a6 / 720.0));
+         return new NorwayDtm1ElevationSource.Projection(x, y);
+      }
+   }
+
+   private static double meridionalArc(double lat) {
+      return PROJ_A
+         * ((1.0 - PROJ_E2 / 4.0 - 3.0 * PROJ_E4 / 64.0 - 5.0 * PROJ_E6 / 256.0) * lat
+            - (3.0 * PROJ_E2 / 8.0 + 3.0 * PROJ_E4 / 32.0 + 45.0 * PROJ_E6 / 1024.0) * Math.sin(2.0 * lat)
+            + (15.0 * PROJ_E4 / 256.0 + 45.0 * PROJ_E6 / 1024.0) * Math.sin(4.0 * lat)
+            - 35.0 * PROJ_E6 / 3072.0 * Math.sin(6.0 * lat));
+   }
+
+   private static double normalizeLongitudeRadians(double lon) {
+      double wrapped = lon;
+      while (wrapped <= -Math.PI) {
+         wrapped += Math.PI * 2.0;
+      }
+
+      while (wrapped > Math.PI) {
+         wrapped -= Math.PI * 2.0;
+      }
+
+      return wrapped;
+   }
+
+   private static HttpURLConnection openConnection(URI uri, String rangeHeader) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+      if (rangeHeader != null) {
+         connection.setRequestProperty("Range", rangeHeader);
+      }
+
+      return connection;
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static double nativeResolutionMeters(NorwayDtm1CoverageIndex.TileReference tileRef) {
+      return 1.0;
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.NORWAYDTM1;
+   }
+
+   @Override
+   public void clearCache() {
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record Projection(double x, double y) {
+   }
+
+   private record TileCacheKey(NorwayDtm1CoverageIndex.TileReference tileRef, int targetResolutionCentimeters) {
+      private TileCacheKey {
+         Objects.requireNonNull(tileRef, "tileRef");
+      }
+
+      private static NorwayDtm1ElevationSource.TileCacheKey base(NorwayDtm1CoverageIndex.TileReference tileRef) {
+         return new NorwayDtm1ElevationSource.TileCacheKey(tileRef, 0);
+      }
+
+      private static NorwayDtm1ElevationSource.TileCacheKey forTarget(NorwayDtm1CoverageIndex.TileReference tileRef, double targetResolutionMeters) {
+         if (!(targetResolutionMeters > 0.0) || !Double.isFinite(targetResolutionMeters)) {
+            return base(tileRef);
+         } else {
+            return new NorwayDtm1ElevationSource.TileCacheKey(tileRef, Math.max(1, (int)Math.round(targetResolutionMeters * 100.0)));
+         }
+      }
+
+      private double targetResolutionMeters() {
+         return this.targetResolutionCentimeters <= 0 ? Double.NaN : this.targetResolutionCentimeters / 100.0;
+      }
+   }
+
+   public record Sample(double elevation, TellusElevationSource.DemUsage usage, double resolutionMeters) {
+      private static NorwayDtm1ElevationSource.Sample none() {
+         return new NorwayDtm1ElevationSource.Sample(Double.NaN, null, Double.NaN);
+      }
+
+      public boolean usable() {
+         return this.usage != null && Double.isFinite(this.elevation);
+      }
+   }
+
+   private static final class CachedRangeReader {
+      private final NorwayDtm1CoverageIndex.TileReference tileRef;
+      private final Path cacheDir;
+      private final boolean localOnly;
+
+      private CachedRangeReader(NorwayDtm1CoverageIndex.TileReference tileRef, Path cacheDir) {
+         this(tileRef, cacheDir, false);
+      }
+
+      private CachedRangeReader(NorwayDtm1CoverageIndex.TileReference tileRef, Path cacheDir, boolean localOnly) {
+         this.tileRef = Objects.requireNonNull(tileRef, "tileRef");
+         this.cacheDir = Objects.requireNonNull(cacheDir, "cacheDir");
+         this.localOnly = localOnly;
+      }
+
+      private byte[] read(long offset, int length) throws IOException {
+         if (length <= 0) {
+            return new byte[0];
+         } else {
+            Path cachePath = this.cacheDir.resolve(offset + "-" + length + ".bin");
+            byte[] cached = this.readCachedRange(cachePath, length);
+            if (cached != null) {
+               return cached;
+            } else {
+               if (this.localOnly) {
+                  throw new EOFException("Norway DTM1 range not cached for " + this.tileRef.id());
+               }
+
+               byte[] data = this.readRemoteRange(offset, length);
+               this.writeCachedRange(cachePath, data);
+               return data;
+            }
+         }
+      }
+
+      private byte[] readCachedRange(Path cachePath, int expectedLength) throws IOException {
+         if (!Files.exists(cachePath)) {
+            return null;
+         } else {
+            byte[] data = Files.readAllBytes(cachePath);
+            if (data.length == expectedLength) {
+               return data;
+            } else {
+               Files.deleteIfExists(cachePath);
+               return null;
+            }
+         }
+      }
+
+      private byte[] readRemoteRange(long offset, int length) throws IOException {
+         String rangeHeader = "bytes=" + offset + "-" + (offset + length - 1L);
+         HttpURLConnection connection = NorwayDtm1ElevationSource.openConnection(URI.create(this.tileRef.url()), rangeHeader);
+
+         try {
+            int status = connection.getResponseCode();
+            if (status != 200 && status != 206) {
+               throw new IOException("Unexpected Norway DTM1 HTTP status " + status + " for " + this.tileRef.id());
+            } else {
+               DownloadProgressReporter.requestStarted((long)length);
+               try (InputStream input = connection.getInputStream()) {
+                  byte[] data = DownloadProgressReporter.readAllBytesWithProgress(input);
+                  if (data.length != length) {
+                     throw new EOFException("Unexpected Norway DTM1 range length " + data.length + " for " + this.tileRef.id());
+                  } else {
+                     return data;
+                  }
+               }
+            }
+         } finally {
+            DownloadProgressReporter.requestFinished();
+            connection.disconnect();
+         }
+      }
+
+      private void writeCachedRange(Path cachePath, byte[] data) {
+         try {
+            Files.createDirectories(cachePath.getParent());
+            Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+            Files.write(tempPath, data);
+            Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to cache Norway DTM1 range {}", cachePath, error);
+         }
+      }
+   }
+
+   private static final class TileFile {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_BITS_PER_SAMPLE = 258;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_STRIP_OFFSETS = 273;
+      private static final int TAG_SAMPLES_PER_PIXEL = 277;
+      private static final int TAG_ROWS_PER_STRIP = 278;
+      private static final int TAG_STRIP_BYTE_COUNTS = 279;
+      private static final int TAG_PREDICTOR = 317;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_SAMPLE_FORMAT = 339;
+      private static final int TAG_MODEL_PIXEL_SCALE = 33550;
+      private static final int TAG_MODEL_TIEPOINT = 33922;
+      private static final int TAG_GDAL_NODATA = 42113;
+      private static final int TYPE_BYTE = 1;
+      private static final int TYPE_ASCII = 2;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int TYPE_DOUBLE = 12;
+      private static final int TYPE_LONG8 = 16;
+      private static final int COMPRESSION_NONE = 1;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private final String tileId;
+      private final NorwayDtm1ElevationSource.CachedRangeReader reader;
+      private final ByteOrder order;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final int predictor;
+      private final int bytesPerSample;
+      private final int samplesPerPixel;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final double originX;
+      private final double originY;
+      private final double pixelSizeX;
+      private final double pixelSizeY;
+      private final float noData;
+      private final Map<Integer, float[]> tileCache;
+
+      private TileFile(
+         String tileId,
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         int predictor,
+         int bytesPerSample,
+         int samplesPerPixel,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         double originX,
+         double originY,
+         double pixelSizeX,
+         double pixelSizeY,
+         float noData
+      ) {
+         this.tileId = tileId;
+         this.reader = reader;
+         this.order = order;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.compression = compression;
+         this.predictor = predictor;
+         this.bytesPerSample = bytesPerSample;
+         this.samplesPerPixel = samplesPerPixel;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.originX = originX;
+         this.originY = originY;
+         this.pixelSizeX = pixelSizeX;
+         this.pixelSizeY = pixelSizeY;
+         this.noData = noData;
+         this.tileCache = new LinkedHashMap<Integer, float[]>(MAX_TILE_CACHE, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, float[]> eldest) {
+               return this.size() > MAX_TILE_CACHE;
+            }
+         };
+      }
+
+      private double sampleProjected(double x, double y) {
+         double globalX = (x - this.originX) / this.pixelSizeX;
+         double globalY = (this.originY - y) / this.pixelSizeY;
+         if (globalX < -1.0 || globalY < -1.0 || globalX > this.width || globalY > this.height) {
+            return Double.NaN;
+         } else {
+            int maxPixelX = this.width - 1;
+            int maxPixelY = this.height - 1;
+            double clampedX = Mth.clamp(globalX, 0.0, maxPixelX);
+            double clampedY = Mth.clamp(globalY, 0.0, maxPixelY);
+            int x0 = Mth.floor(clampedX);
+            int y0 = Mth.floor(clampedY);
+            int x1 = Math.min(x0 + 1, maxPixelX);
+            int y1 = Math.min(y0 + 1, maxPixelY);
+            double dx = clampedX - x0;
+            double dy = clampedY - y0;
+            float v00 = this.sampleValue(x0, y0);
+            float v10 = this.sampleValue(x1, y0);
+            float v01 = this.sampleValue(x0, y1);
+            float v11 = this.sampleValue(x1, y1);
+            return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+         }
+      }
+
+      private double effectiveResolutionMeters() {
+         return (Math.abs(this.pixelSizeX) + Math.abs(this.pixelSizeY)) * 0.5;
+      }
+
+      private float sampleValue(int pixelX, int pixelY) {
+         int clampedX = Mth.clamp(pixelX, 0, this.width - 1);
+         int clampedY = Mth.clamp(pixelY, 0, this.height - 1);
+         int tileX = clampedX / this.tileWidth;
+         int tileY = clampedY / this.tileHeight;
+         int tileIndex = tileY * this.tilesPerRow + tileX;
+
+         try {
+            float[] tile = this.getTile(tileIndex);
+            int localX = clampedX - tileX * this.tileWidth;
+            int localY = clampedY - tileY * this.tileHeight;
+            return tile[localX + localY * this.tileWidth];
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to read Norway DTM1 tile {} block from {}", tileIndex, this.tileId, error);
+            return Float.NaN;
+         }
+      }
+
+      private float[] getTile(int tileIndex) throws IOException {
+         synchronized(this.tileCache) {
+            float[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         float[] tile = this.readTile(tileIndex);
+         synchronized(this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private float[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = this.reader.read(offset, length);
+         int expectedSize = this.tileWidth * this.tileHeight * this.bytesPerSample * this.samplesPerPixel;
+         if (this.samplesPerPixel != 1) {
+            throw new IOException("Unsupported Norway DTM1 TIFF samples per pixel " + this.samplesPerPixel);
+         } else {
+            byte[] raw = switch (this.compression) {
+               case COMPRESSION_NONE -> compressed;
+               case COMPRESSION_LZW -> decompressLzw(compressed, expectedSize);
+               case COMPRESSION_DEFLATE -> inflate(compressed, expectedSize);
+               default -> throw new IOException("Unsupported Norway DTM1 TIFF compression " + this.compression);
+            };
+            if (raw.length != expectedSize) {
+               throw new IOException("Unexpected Norway DTM1 tile length " + raw.length + " for " + this.tileId);
+            } else {
+               if (this.predictor == 3) {
+                  applyFloatingPointPredictor(raw, this.tileWidth, this.tileHeight, this.bytesPerSample, this.samplesPerPixel, this.order);
+               } else if (this.predictor != 1) {
+                  throw new IOException("Unsupported Norway DTM1 TIFF predictor " + this.predictor);
+               }
+
+               float[] values = new float[this.tileWidth * this.tileHeight];
+               ByteBuffer buffer = ByteBuffer.wrap(raw).order(this.order);
+
+               for (int i = 0; i < values.length; i++) {
+                  float value = buffer.getFloat();
+                  values[i] = value <= this.noData + 1.0F ? Float.NaN : value;
+               }
+
+               return values;
+            }
+         }
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile open(
+         NorwayDtm1CoverageIndex.TileReference tileRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters
+      ) throws IOException {
+         return open(tileRef, cacheDir, targetResolutionMeters, nativeResolutionMeters, false);
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile openLocalOnly(
+         NorwayDtm1CoverageIndex.TileReference tileRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters
+      ) throws IOException {
+         return open(tileRef, cacheDir, targetResolutionMeters, nativeResolutionMeters, true);
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile open(
+         NorwayDtm1CoverageIndex.TileReference tileRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters, boolean localOnly
+      ) throws IOException {
+         NorwayDtm1ElevationSource.CachedRangeReader reader = new NorwayDtm1ElevationSource.CachedRangeReader(tileRef, cacheDir, localOnly);
+         byte[] header = reader.read(0L, 32);
+         ByteOrder order = switch (header[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid Norway DTM1 TIFF byte order for " + tileRef.id());
+         };
+         ByteBuffer headerBuf = ByteBuffer.wrap(header).order(order);
+         headerBuf.getShort();
+         short magic = headerBuf.getShort();
+         if (magic == 42) {
+            return openStandardTiff(tileRef, reader, order, headerBuf, targetResolutionMeters, nativeResolutionMeters);
+         } else if (magic == 43) {
+            return openBigTiff(tileRef, reader, order, headerBuf, targetResolutionMeters, nativeResolutionMeters);
+         } else {
+            throw new IOException("Unsupported Norway DTM1 TIFF magic " + magic + " for " + tileRef.id());
+         }
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile openStandardTiff(
+         NorwayDtm1CoverageIndex.TileReference tileRef,
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         ByteBuffer headerBuf,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         long firstIfdOffset = Integer.toUnsignedLong(headerBuf.getInt());
+         NorwayDtm1ElevationSource.TileFile.GeoReference baseGeoReference = readStandardGeoReference(reader, order, firstIfdOffset);
+         long ifdOffset = selectIfdOffset(reader, order, false, firstIfdOffset, targetResolutionMeters, nativeResolutionMeters);
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return buildTileFile(tileRef, reader, order, false, entryCount, entries, baseGeoReference);
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile openBigTiff(
+         NorwayDtm1CoverageIndex.TileReference tileRef,
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         ByteBuffer headerBuf,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         short offsetSize = headerBuf.getShort();
+         headerBuf.getShort();
+         if (offsetSize != 8) {
+            throw new IOException("Unsupported Norway DTM1 BigTIFF offset size " + offsetSize + " for " + tileRef.id());
+         } else {
+            long firstIfdOffset = headerBuf.getLong();
+            NorwayDtm1ElevationSource.TileFile.GeoReference baseGeoReference = readBigGeoReference(reader, order, firstIfdOffset);
+            long ifdOffset = selectIfdOffset(reader, order, true, firstIfdOffset, targetResolutionMeters, nativeResolutionMeters);
+            long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+            if (entryCount < 0L || entryCount > 1000000L) {
+               throw new IOException("Invalid Norway DTM1 BigTIFF entry count " + entryCount + " for " + tileRef.id());
+            } else {
+               byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+               ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+               return buildTileFile(tileRef, reader, order, true, entryCount, entries, baseGeoReference);
+            }
+         }
+      }
+
+      private static long selectIfdOffset(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long firstIfdOffset,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         if (!(targetResolutionMeters > 0.0) || !Double.isFinite(targetResolutionMeters) || !(nativeResolutionMeters > 0.0)) {
+            return firstIfdOffset;
+         } else {
+            long currentOffset = firstIfdOffset;
+            long bestOffset = firstIfdOffset;
+            int baseWidth = -1;
+            double bestResolution = nativeResolutionMeters;
+            double bestScore = Math.abs(Math.log(bestResolution / targetResolutionMeters));
+
+            for (int level = 0; currentOffset != 0L && level < 16; level++) {
+               NorwayDtm1ElevationSource.TileFile.IfdSummary summary = bigTiff
+                  ? readBigIfdSummary(reader, order, currentOffset)
+                  : readStandardIfdSummary(reader, order, currentOffset);
+               if (summary.width() <= 0) {
+                  break;
+               }
+
+               if (baseWidth < 0) {
+                  baseWidth = summary.width();
+               }
+
+               double candidateResolution = nativeResolutionMeters * ((double)baseWidth / (double)summary.width());
+               double candidateScore = Math.abs(Math.log(candidateResolution / targetResolutionMeters));
+               if (candidateScore < bestScore - 1.0E-9
+                  || Math.abs(candidateScore - bestScore) <= 1.0E-9 && candidateResolution < bestResolution) {
+                  bestOffset = currentOffset;
+                  bestResolution = candidateResolution;
+                  bestScore = candidateScore;
+               }
+
+               currentOffset = summary.nextIfdOffset();
+            }
+
+            return bestOffset;
+         }
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile.IfdSummary readStandardIfdSummary(
+         NorwayDtm1ElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] ifdBytes = reader.read(ifdOffset + 2L, entryCount * 12 + 4);
+         ByteBuffer entries = ByteBuffer.wrap(ifdBytes).order(order);
+         int width = -1;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[4];
+            entries.get(inlineBytes, 0, 4);
+            if (tag == TAG_IMAGE_WIDTH && count == 1L) {
+               width = readInlineDimension(inlineBytes, type, order);
+            }
+         }
+
+         long nextIfdOffset = Integer.toUnsignedLong(ByteBuffer.wrap(ifdBytes, entryCount * 12, 4).order(order).getInt());
+         return new NorwayDtm1ElevationSource.TileFile.IfdSummary(width, nextIfdOffset);
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile.IfdSummary readBigIfdSummary(
+         NorwayDtm1ElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+         if (entryCount < 0L || entryCount > 1000000L) {
+            throw new IOException("Invalid Norway DTM1 BigTIFF entry count " + entryCount);
+         } else {
+            byte[] ifdBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L + 8L));
+            ByteBuffer entries = ByteBuffer.wrap(ifdBytes).order(order);
+            int width = -1;
+
+            for (int i = 0; i < entryCount; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               long count = entries.getLong();
+               byte[] inlineBytes = new byte[8];
+               entries.get(inlineBytes);
+               if (tag == TAG_IMAGE_WIDTH && count == 1L) {
+                  width = readInlineDimension(inlineBytes, type, order);
+               }
+            }
+
+            long nextIfdOffset = ByteBuffer.wrap(ifdBytes, Math.toIntExact(entryCount * 20L), 8).order(order).getLong();
+            return new NorwayDtm1ElevationSource.TileFile.IfdSummary(width, nextIfdOffset);
+         }
+      }
+
+      private static int readInlineDimension(byte[] inlineBytes, int type, ByteOrder order) throws IOException {
+         ByteBuffer buffer = ByteBuffer.wrap(inlineBytes).order(order);
+         return switch (type) {
+            case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+            case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+            case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+            default -> throw new IOException("Unsupported TIFF dimension type " + type);
+         };
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile.GeoReference readStandardGeoReference(
+         NorwayDtm1ElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return readGeoReference(reader, order, false, entryCount, entries);
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile.GeoReference readBigGeoReference(
+         NorwayDtm1ElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+         if (entryCount < 0L || entryCount > 1000000L) {
+            throw new IOException("Invalid Norway DTM1 BigTIFF entry count " + entryCount);
+         } else {
+            byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+            ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+            return readGeoReference(reader, order, true, entryCount, entries);
+         }
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile.GeoReference readGeoReference(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            }
+         }
+
+         return width > 0 && height > 0 ? geoReferenceFromTags(width, height, pixelScale, tiePoints) : null;
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile buildTileFile(
+         NorwayDtm1CoverageIndex.TileReference tileRef,
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries,
+         NorwayDtm1ElevationSource.TileFile.GeoReference baseGeoReference
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         int tileWidth = -1;
+         int tileHeight = -1;
+         int compression = -1;
+         int predictor = 1;
+         int bitsPerSample = -1;
+         int sampleFormat = -1;
+         int samplesPerPixel = 1;
+         long[] tileOffsets = null;
+         int[] tileByteCounts = null;
+         int rowsPerStrip = -1;
+         long[] stripOffsets = null;
+         int[] stripByteCounts = null;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+         float noData = (float)DEFAULT_NO_DATA;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_BITS_PER_SAMPLE -> bitsPerSample = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_COMPRESSION -> compression = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_OFFSETS -> stripOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLES_PER_PIXEL -> samplesPerPixel = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_ROWS_PER_STRIP -> rowsPerStrip = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_BYTE_COUNTS -> stripByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_PREDICTOR -> predictor = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_WIDTH -> tileWidth = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_HEIGHT -> tileHeight = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_OFFSETS -> tileOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_BYTE_COUNTS -> tileByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLE_FORMAT -> sampleFormat = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_GDAL_NODATA -> noData = parseNoData(readAscii(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize));
+            }
+         }
+
+         if (width <= 0 || height <= 0) {
+            throw new IOException("Missing Norway DTM1 TIFF size tags for " + tileRef.id());
+         } else {
+            if ((tileOffsets == null || tileByteCounts == null) && stripOffsets != null && stripByteCounts != null && rowsPerStrip > 0) {
+               tileWidth = width;
+               tileHeight = rowsPerStrip;
+               tileOffsets = stripOffsets;
+               tileByteCounts = stripByteCounts;
+            }
+
+            if (tileWidth <= 0 || tileHeight <= 0) {
+               throw new IOException("Missing Norway DTM1 TIFF tile geometry for " + tileRef.id());
+            } else if (tileOffsets == null || tileByteCounts == null) {
+               throw new IOException("Missing Norway DTM1 TIFF tile offsets for " + tileRef.id());
+            } else if (bitsPerSample != 32 || sampleFormat != 3) {
+               throw new IOException("Unsupported Norway DTM1 TIFF sample format " + sampleFormat + " bits " + bitsPerSample);
+            } else {
+               NorwayDtm1ElevationSource.TileFile.GeoReference geoReference = geoReferenceFromTags(width, height, pixelScale, tiePoints);
+               if (geoReference == null && baseGeoReference != null) {
+                  // DTM1 overview IFDs can omit georeferencing; inherit the base transform and scale the pixel size.
+                  geoReference = baseGeoReference.scaledTo(width, height);
+               }
+
+               if (geoReference != null) {
+                  return new NorwayDtm1ElevationSource.TileFile(
+                     tileRef.id(),
+                     reader,
+                     order,
+                     width,
+                     height,
+                     tileWidth,
+                     tileHeight,
+                     compression,
+                     predictor,
+                     4,
+                     samplesPerPixel,
+                     tileOffsets,
+                     tileByteCounts,
+                     geoReference.originX(),
+                     geoReference.originY(),
+                     geoReference.pixelSizeX(),
+                     geoReference.pixelSizeY(),
+                     noData
+                  );
+               }
+
+               throw new IOException("Missing Norway DTM1 TIFF georeferencing tags for " + tileRef.id());
+            }
+         }
+      }
+
+      private static NorwayDtm1ElevationSource.TileFile.GeoReference geoReferenceFromTags(int width, int height, double[] pixelScale, double[] tiePoints) {
+         if (width <= 0 || height <= 0 || pixelScale == null || pixelScale.length < 2 || tiePoints == null || tiePoints.length < 6) {
+            return null;
+         } else {
+            double pixelSizeX = pixelScale[0];
+            double pixelSizeY = pixelScale[1];
+            double originX = tiePoints[3] - tiePoints[0] * pixelSizeX;
+            double originY = tiePoints[4] + tiePoints[1] * pixelSizeY;
+            return new NorwayDtm1ElevationSource.TileFile.GeoReference(width, height, originX, originY, pixelSizeX, pixelSizeY);
+         }
+      }
+
+      private static int readIntValue(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count != 1L) {
+            throw new IOException("Expected single TIFF value");
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            return switch (type) {
+               case TYPE_BYTE -> buffer.get() & 255;
+               case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+               case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+               case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+               default -> throw new IOException("Unsupported TIFF value type " + type);
+            };
+         }
+      }
+
+      private static long[] readLongArray(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new long[0];
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            long[] values = new long[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = switch (type) {
+                  case TYPE_BYTE -> buffer.get() & 255;
+                  case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+                  case TYPE_LONG -> Integer.toUnsignedLong(buffer.getInt());
+                  case TYPE_LONG8 -> buffer.getLong();
+                  default -> throw new IOException("Unsupported TIFF array type " + type);
+               };
+            }
+
+            return values;
+         }
+      }
+
+      private static int[] readIntArray(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         long[] values = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+         int[] output = new int[values.length];
+
+         for (int i = 0; i < values.length; i++) {
+            if (values[i] > 2147483647L) {
+               throw new IOException("TIFF byte count too large " + values[i]);
+            }
+
+            output[i] = (int)values[i];
+         }
+
+         return output;
+      }
+
+      private static double[] readDoubleArray(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new double[0];
+         } else if (type != TYPE_DOUBLE) {
+            throw new IOException("Unsupported TIFF double array type " + type);
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            double[] values = new double[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getDouble();
+            }
+
+            return values;
+         }
+      }
+
+      private static String readAscii(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return "";
+         } else if (type != TYPE_ASCII) {
+            throw new IOException("Unsupported TIFF ASCII type " + type);
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            int length = (int)Math.min(count, data.length);
+
+            while (length > 0 && data[length - 1] == 0) {
+               length--;
+            }
+
+            return new String(data, 0, length, StandardCharsets.US_ASCII);
+         }
+      }
+
+      private static byte[] readFieldData(
+         NorwayDtm1ElevationSource.CachedRangeReader reader,
+         long valueOrOffset,
+         byte[] inlineBytes,
+         long count,
+         int type,
+         ByteOrder order,
+         int inlineSize
+      ) throws IOException {
+         int size = typeSize(type);
+         if (size <= 0) {
+            throw new IOException("Unsupported TIFF field type " + type);
+         } else {
+            long byteSize = count * size;
+            if (byteSize <= inlineSize) {
+               byte[] data = new byte[(int)byteSize];
+               System.arraycopy(inlineBytes, 0, data, 0, (int)byteSize);
+               return data;
+            } else if (byteSize > Integer.MAX_VALUE) {
+               throw new IOException("TIFF field too large");
+            } else {
+               return reader.read(valueOrOffset, (int)byteSize);
+            }
+         }
+      }
+
+      private static float parseNoData(String value) {
+         if (value == null || value.isBlank()) {
+            return (float)DEFAULT_NO_DATA;
+         } else {
+            try {
+               return Float.parseFloat(value.trim());
+            } catch (NumberFormatException error) {
+               return (float)DEFAULT_NO_DATA;
+            }
+         }
+      }
+
+      private static int typeSize(int type) {
+         return switch (type) {
+            case TYPE_BYTE, TYPE_ASCII -> 1;
+            case TYPE_SHORT -> 2;
+            case TYPE_LONG -> 4;
+            case TYPE_DOUBLE, TYPE_LONG8 -> 8;
+            default -> 0;
+         };
+      }
+
+      private record IfdSummary(int width, long nextIfdOffset) {
+      }
+
+      private record GeoReference(int width, int height, double originX, double originY, double pixelSizeX, double pixelSizeY) {
+         private NorwayDtm1ElevationSource.TileFile.GeoReference scaledTo(int newWidth, int newHeight) {
+            if (this.width <= 0 || this.height <= 0 || newWidth <= 0 || newHeight <= 0) {
+               return null;
+            } else {
+               return new NorwayDtm1ElevationSource.TileFile.GeoReference(
+                  newWidth,
+                  newHeight,
+                  this.originX,
+                  this.originY,
+                  this.pixelSizeX * ((double)this.width / (double)newWidth),
+                  this.pixelSizeY * ((double)this.height / (double)newHeight)
+               );
+            }
+         }
+      }
+
+      private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+         double w00 = (1.0 - dx) * (1.0 - dy);
+         double w10 = dx * (1.0 - dy);
+         double w01 = (1.0 - dx) * dy;
+         double w11 = dx * dy;
+         double sum = 0.0;
+         double weight = 0.0;
+         if (Float.isFinite(v00)) {
+            sum += v00 * w00;
+            weight += w00;
+         }
+
+         if (Float.isFinite(v10)) {
+            sum += v10 * w10;
+            weight += w10;
+         }
+
+         if (Float.isFinite(v01)) {
+            sum += v01 * w01;
+            weight += w01;
+         }
+
+         if (Float.isFinite(v11)) {
+            sum += v11 * w11;
+            weight += w11;
+         }
+
+         return weight <= 0.0 ? Double.NaN : sum / weight;
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            } else {
+               return output;
+            }
+         }
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+         int outputPos = 0;
+         int bitPos = 0;
+         int codeSize = 9;
+         int clearCode = 256;
+         int endCode = 257;
+         int nextCode = 258;
+         byte[][] dictionary = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            dictionary[i] = new byte[]{(byte)i};
+         }
+
+         byte[] previous = null;
+
+         while (true) {
+            int code = readLzwCode(compressed, bitPos, codeSize);
+            bitPos += codeSize;
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 258; i < dictionary.length; i++) {
+                  dictionary[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else if (code == endCode) {
+               break;
+            } else {
+               byte[] entry;
+               if (code < nextCode && dictionary[code] != null) {
+                  entry = dictionary[code];
+               } else {
+                  if (previous == null) {
+                     throw new IOException("Invalid Norway DTM1 LZW stream");
+                  }
+
+                  entry = append(previous, previous[0]);
+               }
+
+               if (outputPos + entry.length > output.length) {
+                  throw new IOException("Norway DTM1 LZW output overflow");
+               }
+
+               System.arraycopy(entry, 0, output, outputPos, entry.length);
+               outputPos += entry.length;
+               if (previous != null && nextCode < dictionary.length) {
+                  dictionary[nextCode++] = append(previous, entry[0]);
+                  if (nextCode == 511 || nextCode == 1023 || nextCode == 2047) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+            }
+         }
+
+         if (outputPos != output.length) {
+            byte[] copy = new byte[outputPos];
+            System.arraycopy(output, 0, copy, 0, outputPos);
+            return copy;
+         } else {
+            return output;
+         }
+      }
+
+      private static void applyFloatingPointPredictor(byte[] data, int width, int height, int bytesPerSample, int samplesPerPixel, ByteOrder order)
+         throws IOException {
+         int rowBytes = width * bytesPerSample * samplesPerPixel;
+         if (rowBytes > 0) {
+            if (samplesPerPixel > 0 && rowBytes % (bytesPerSample * samplesPerPixel) == 0) {
+               int wordCount = rowBytes / bytesPerSample;
+               byte[] tmp = new byte[rowBytes];
+
+               for (int row = 0; row < height; row++) {
+                  int rowStart = row * rowBytes;
+                  int count = rowBytes;
+
+                  for (int offset = rowStart; count > samplesPerPixel; count -= samplesPerPixel) {
+                     for (int i = 0; i < samplesPerPixel; i++) {
+                        int target = offset + samplesPerPixel;
+                        int value = (data[target] & 255) + (data[offset] & 255);
+                        data[target] = (byte)value;
+                        offset++;
+                     }
+                  }
+
+                  System.arraycopy(data, rowStart, tmp, 0, rowBytes);
+
+                  for (int word = 0; word < wordCount; word++) {
+                     int base = rowStart + word * bytesPerSample;
+
+                     for (int byteIndex = 0; byteIndex < bytesPerSample; byteIndex++) {
+                        int sourceIndex = order == ByteOrder.BIG_ENDIAN ? byteIndex * wordCount + word : (bytesPerSample - byteIndex - 1) * wordCount + word;
+                        data[base + byteIndex] = tmp[sourceIndex];
+                     }
+                  }
+               }
+            } else {
+               throw new IOException("Invalid floating point predictor stride");
+            }
+         }
+      }
+
+      private static int readLzwCode(byte[] data, int bitPos, int codeSize) {
+         int totalBits = data.length * 8;
+         if (bitPos + codeSize > totalBits) {
+            return -1;
+         } else {
+            int code = 0;
+
+            for (int i = 0; i < codeSize; i++) {
+               int currentBit = bitPos + i;
+               int currentByte = data[currentBit >> 3] & 255;
+               int bit = currentByte >> 7 - (currentBit & 7) & 1;
+               code = code << 1 | bit;
+            }
+
+            return code;
+         }
+      }
+
+      private static byte[] append(byte[] prefix, byte suffix) {
+         byte[] out = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, out, 0, prefix.length);
+         out[prefix.length] = suffix;
+         return out;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/SwissAlti3dElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/SwissAlti3dElevationSource.java
@@ -1,0 +1,1403 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class SwissAlti3dElevationSource implements TellusCacheHandle {
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 8000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final int MAX_FILE_CACHE = intProperty("tellus.swissalti3d.cacheFiles", 32);
+   private static final int MAX_TILE_CACHE = intProperty("tellus.swissalti3d.cacheTiles", 16);
+   private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("tellus.swissalti3d.enabled", "true"));
+   private static final double DEFAULT_NO_DATA = -9999.0;
+   private static final double MIN_LAT = 45.0;
+   private static final double MAX_LAT = 49.0;
+   private static final double MIN_LON = 5.0;
+   private static final double MAX_LON = 11.5;
+   private final Path cacheRoot;
+   private final SwissAlti3dCoverageIndex coverageIndex = SwissAlti3dCoverageIndex.create();
+   private final LoadingCache<SwissAlti3dElevationSource.TileCacheKey, SwissAlti3dElevationSource.TileFile> fileCache;
+
+   public SwissAlti3dElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-swissalti3d");
+      this.fileCache = CacheBuilder.newBuilder()
+         .maximumSize(MAX_FILE_CACHE)
+         .build(new CacheLoader<SwissAlti3dElevationSource.TileCacheKey, SwissAlti3dElevationSource.TileFile>() {
+            public SwissAlti3dElevationSource.TileFile load(SwissAlti3dElevationSource.TileCacheKey key) throws Exception {
+               return SwissAlti3dElevationSource.this.loadTile(key);
+            }
+         });
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isLikelyInCoverage(double lat, double lon) {
+      if (!this.canUse()) {
+         return false;
+      } else {
+         SwissAlti3dElevationSource.Projection projection = project(lat, lon);
+         return projection != null && this.coverageIndex.find(projection.x(), projection.y()) != null;
+      }
+   }
+
+   public SwissAlti3dElevationSource.Sample sample(double blockX, double blockZ, double worldScale) {
+      return this.sample(blockX, blockZ, worldScale, Double.NaN);
+   }
+
+   public SwissAlti3dElevationSource.Sample sample(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return SwissAlti3dElevationSource.Sample.none();
+      } else {
+         SwissAlti3dElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null ? SwissAlti3dElevationSource.Sample.none() : this.sample(latLon.lat(), latLon.lon(), worldScale < 2.0, targetResolutionMeters);
+      }
+   }
+
+   public SwissAlti3dElevationSource.Sample sampleLocalOnly(double blockX, double blockZ, double worldScale, double targetResolutionMeters) {
+      if (!this.canUse() || worldScale <= 0.0) {
+         return SwissAlti3dElevationSource.Sample.none();
+      } else {
+         SwissAlti3dElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         return latLon == null
+            ? SwissAlti3dElevationSource.Sample.none()
+            : this.sampleLocalOnly(latLon.lat(), latLon.lon(), worldScale < 2.0, targetResolutionMeters);
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, Double.NaN);
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius, double targetResolutionMeters) {
+      if (!(worldScale <= 0.0) && radius > 0 && this.canUse()) {
+         boolean prefer05m = worldScale < 2.0;
+         LinkedHashSet<SwissAlti3dCoverageIndex.AssetReference> refs = new LinkedHashSet<>();
+         double blockRadius = Math.max(1, radius) * 256.0;
+
+         for (int dz = -1; dz <= 1; dz++) {
+            for (int dx = -1; dx <= 1; dx++) {
+               SwissAlti3dElevationSource.LatLon latLon = toLatLon(blockX + dx * blockRadius, blockZ + dz * blockRadius, worldScale);
+               if (latLon != null) {
+                  SwissAlti3dElevationSource.Projection projection = project(latLon.lat(), latLon.lon());
+                  if (projection != null) {
+                     SwissAlti3dCoverageIndex.TileReference ref = this.coverageIndex.find(projection.x(), projection.y());
+                     if (ref != null) {
+                        SwissAlti3dCoverageIndex.AssetReference preferred = ref.preferredAsset(prefer05m);
+                        if (preferred != null) {
+                           refs.add(preferred);
+                        }
+                     }
+                  }
+               }
+            }
+         }
+
+         for (SwissAlti3dCoverageIndex.AssetReference ref : refs) {
+            this.prefetchTile(ref, targetResolutionMeters);
+         }
+      }
+   }
+
+   private SwissAlti3dElevationSource.Sample sample(double lat, double lon, boolean prefer05m, double targetResolutionMeters) {
+      if (!this.canUse()) {
+         return SwissAlti3dElevationSource.Sample.none();
+      } else {
+         SwissAlti3dElevationSource.Projection projection = project(lat, lon);
+         if (projection == null) {
+            return SwissAlti3dElevationSource.Sample.none();
+         } else {
+            SwissAlti3dCoverageIndex.TileReference tileRef = this.coverageIndex.find(projection.x(), projection.y());
+            if (tileRef == null) {
+               return SwissAlti3dElevationSource.Sample.none();
+            } else {
+               SwissAlti3dCoverageIndex.AssetReference preferred = tileRef.preferredAsset(prefer05m);
+               TellusElevationSource.DemUsage preferredUsage = prefer05m
+                  ? TellusElevationSource.DemUsage.SWISSALTI3D_05M
+                  : TellusElevationSource.DemUsage.SWISSALTI3D_2M;
+               SwissAlti3dElevationSource.Sample preferredSample = this.sample(preferred, projection, preferredUsage, targetResolutionMeters);
+               if (preferredSample.usable()) {
+                  return preferredSample;
+               } else {
+                  SwissAlti3dCoverageIndex.AssetReference alternate = tileRef.alternateAsset(prefer05m);
+                  TellusElevationSource.DemUsage alternateUsage = prefer05m
+                     ? TellusElevationSource.DemUsage.SWISSALTI3D_2M
+                     : TellusElevationSource.DemUsage.SWISSALTI3D_05M;
+                  return this.sample(alternate, projection, alternateUsage, targetResolutionMeters);
+               }
+            }
+         }
+      }
+   }
+
+   private SwissAlti3dElevationSource.Sample sampleLocalOnly(double lat, double lon, boolean prefer05m, double targetResolutionMeters) {
+      if (!this.canUse()) {
+         return SwissAlti3dElevationSource.Sample.none();
+      } else {
+         SwissAlti3dElevationSource.Projection projection = project(lat, lon);
+         if (projection == null) {
+            return SwissAlti3dElevationSource.Sample.none();
+         } else {
+            SwissAlti3dCoverageIndex.TileReference tileRef = this.coverageIndex.find(projection.x(), projection.y());
+            if (tileRef == null) {
+               return SwissAlti3dElevationSource.Sample.none();
+            } else {
+               SwissAlti3dCoverageIndex.AssetReference preferred = tileRef.preferredAsset(prefer05m);
+               TellusElevationSource.DemUsage preferredUsage = prefer05m
+                  ? TellusElevationSource.DemUsage.SWISSALTI3D_05M
+                  : TellusElevationSource.DemUsage.SWISSALTI3D_2M;
+               SwissAlti3dElevationSource.Sample preferredSample = this.sampleLocalOnly(preferred, projection, preferredUsage, targetResolutionMeters);
+               if (preferredSample.usable()) {
+                  return preferredSample;
+               } else {
+                  SwissAlti3dCoverageIndex.AssetReference alternate = tileRef.alternateAsset(prefer05m);
+                  TellusElevationSource.DemUsage alternateUsage = prefer05m
+                     ? TellusElevationSource.DemUsage.SWISSALTI3D_2M
+                     : TellusElevationSource.DemUsage.SWISSALTI3D_05M;
+                  return this.sampleLocalOnly(alternate, projection, alternateUsage, targetResolutionMeters);
+               }
+            }
+         }
+      }
+   }
+
+   private SwissAlti3dElevationSource.Sample sample(
+      SwissAlti3dCoverageIndex.AssetReference assetRef,
+      SwissAlti3dElevationSource.Projection projection,
+      TellusElevationSource.DemUsage usage,
+      double targetResolutionMeters
+   ) {
+      if (assetRef == null) {
+         return SwissAlti3dElevationSource.Sample.none();
+      } else {
+         SwissAlti3dElevationSource.TileFile tile = this.getTile(assetRef, usage, targetResolutionMeters);
+         if (tile == null) {
+            return SwissAlti3dElevationSource.Sample.none();
+         } else {
+            double value = tile.sampleProjected(projection.x(), projection.y());
+            return Double.isFinite(value)
+               ? new SwissAlti3dElevationSource.Sample(value, usage, tile.effectiveResolutionMeters())
+               : SwissAlti3dElevationSource.Sample.none();
+         }
+      }
+   }
+
+   private SwissAlti3dElevationSource.Sample sampleLocalOnly(
+      SwissAlti3dCoverageIndex.AssetReference assetRef,
+      SwissAlti3dElevationSource.Projection projection,
+      TellusElevationSource.DemUsage usage,
+      double targetResolutionMeters
+   ) {
+      if (assetRef == null) {
+         return SwissAlti3dElevationSource.Sample.none();
+      } else {
+         SwissAlti3dElevationSource.TileFile tile = this.getTileLocalOnly(assetRef, usage, targetResolutionMeters);
+         if (tile == null) {
+            return SwissAlti3dElevationSource.Sample.none();
+         } else {
+            double value = tile.sampleProjected(projection.x(), projection.y());
+            return Double.isFinite(value)
+               ? new SwissAlti3dElevationSource.Sample(value, usage, tile.effectiveResolutionMeters())
+               : SwissAlti3dElevationSource.Sample.none();
+         }
+      }
+   }
+
+   private boolean canUse() {
+      return ENABLED && this.coverageIndex.available();
+   }
+
+   private void prefetchTile(SwissAlti3dCoverageIndex.AssetReference assetRef, double targetResolutionMeters) {
+      SwissAlti3dElevationSource.TileCacheKey cacheKey = SwissAlti3dElevationSource.TileCacheKey.forTarget(assetRef, targetResolutionMeters);
+      if (this.fileCache.getIfPresent(cacheKey) == null) {
+         try {
+            this.fileCache.get(cacheKey);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch swissALTI3D tile {}", assetRef.id(), error);
+         }
+      }
+   }
+
+   private SwissAlti3dElevationSource.TileFile getTile(
+      SwissAlti3dCoverageIndex.AssetReference assetRef, TellusElevationSource.DemUsage usage, double targetResolutionMeters
+   ) {
+      SwissAlti3dElevationSource.TileCacheKey cacheKey = SwissAlti3dElevationSource.TileCacheKey.forTarget(assetRef, targetResolutionMeters);
+      try {
+         return this.fileCache.get(cacheKey);
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load swissALTI3D tile {}", assetRef.id(), error);
+         return null;
+      }
+   }
+
+   private SwissAlti3dElevationSource.TileFile getTileLocalOnly(
+      SwissAlti3dCoverageIndex.AssetReference assetRef, TellusElevationSource.DemUsage usage, double targetResolutionMeters
+   ) {
+      SwissAlti3dElevationSource.TileCacheKey cacheKey = SwissAlti3dElevationSource.TileCacheKey.forTarget(assetRef, targetResolutionMeters);
+      SwissAlti3dElevationSource.TileFile cached = this.fileCache.getIfPresent(cacheKey);
+      if (cached != null) {
+         return cached;
+      } else {
+         Path cacheDir = this.cacheRoot.resolve(assetRef.cacheDirectory());
+         if (!Files.isDirectory(cacheDir)) {
+            return null;
+         } else {
+            try {
+               SwissAlti3dElevationSource.TileFile opened = SwissAlti3dElevationSource.TileFile.openLocalOnly(
+                  assetRef, cacheDir, targetResolutionMeters, nativeResolutionMeters(assetRef)
+               );
+               SwissAlti3dElevationSource.TileFile raced = this.fileCache.asMap().putIfAbsent(cacheKey, opened);
+               return raced != null ? raced : opened;
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached swissALTI3D tile {}", assetRef.id(), error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private SwissAlti3dElevationSource.TileFile loadTile(SwissAlti3dElevationSource.TileCacheKey cacheKey) throws Exception {
+      SwissAlti3dCoverageIndex.AssetReference assetRef = cacheKey.assetRef();
+      return SwissAlti3dElevationSource.TileFile.open(
+         assetRef,
+         this.cacheRoot.resolve(assetRef.cacheDirectory()),
+         cacheKey.targetResolutionMeters(),
+         nativeResolutionMeters(assetRef)
+      );
+   }
+
+   private static SwissAlti3dElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0 ? new SwissAlti3dElevationSource.LatLon(lat, lon) : null;
+   }
+
+   private static SwissAlti3dElevationSource.Projection project(double latDeg, double lonDeg) {
+      if (!(latDeg >= MIN_LAT) || !(latDeg <= MAX_LAT) || !(lonDeg >= MIN_LON) || !(lonDeg <= MAX_LON)) {
+         return null;
+      } else {
+         double latSeconds = latDeg * 3600.0;
+         double lonSeconds = lonDeg * 3600.0;
+         double phi = (latSeconds - 169028.66) / 10000.0;
+         double lambda = (lonSeconds - 26782.5) / 10000.0;
+         double eastLv03 = 600072.37 + 211455.93 * lambda - 10938.51 * lambda * phi - 0.36 * lambda * phi * phi - 44.54 * lambda * lambda * lambda;
+         double northLv03 = 200147.07
+            + 308807.95 * phi
+            + 3745.25 * lambda * lambda
+            + 76.63 * phi * phi
+            - 194.56 * lambda * lambda * phi
+            + 119.79 * phi * phi * phi;
+         return new SwissAlti3dElevationSource.Projection(eastLv03 + 2000000.0, northLv03 + 1000000.0);
+      }
+   }
+
+   private static HttpURLConnection openConnection(URI uri, String rangeHeader) throws IOException {
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+      if (rangeHeader != null) {
+         connection.setRequestProperty("Range", rangeHeader);
+      }
+
+      return connection;
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static double nativeResolutionMeters(SwissAlti3dCoverageIndex.AssetReference assetRef) {
+      return assetRef.id().endsWith("_05m") ? 0.5 : 2.0;
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.SWISSALTI3D;
+   }
+
+   @Override
+   public void clearCache() {
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record Projection(double x, double y) {
+   }
+
+   private record TileCacheKey(SwissAlti3dCoverageIndex.AssetReference assetRef, int targetResolutionCentimeters) {
+      private TileCacheKey {
+         Objects.requireNonNull(assetRef, "assetRef");
+      }
+
+      private static SwissAlti3dElevationSource.TileCacheKey base(SwissAlti3dCoverageIndex.AssetReference assetRef) {
+         return new SwissAlti3dElevationSource.TileCacheKey(assetRef, 0);
+      }
+
+      private static SwissAlti3dElevationSource.TileCacheKey forTarget(
+         SwissAlti3dCoverageIndex.AssetReference assetRef, double targetResolutionMeters
+      ) {
+         if (!(targetResolutionMeters > 0.0) || !Double.isFinite(targetResolutionMeters)) {
+            return base(assetRef);
+         } else {
+            return new SwissAlti3dElevationSource.TileCacheKey(assetRef, Math.max(1, (int)Math.round(targetResolutionMeters * 100.0)));
+         }
+      }
+
+      private double targetResolutionMeters() {
+         return this.targetResolutionCentimeters <= 0 ? Double.NaN : this.targetResolutionCentimeters / 100.0;
+      }
+   }
+
+   public record Sample(double elevation, TellusElevationSource.DemUsage usage, double resolutionMeters) {
+      private static SwissAlti3dElevationSource.Sample none() {
+         return new SwissAlti3dElevationSource.Sample(Double.NaN, null, Double.NaN);
+      }
+
+      public boolean usable() {
+         return this.usage != null && Double.isFinite(this.elevation);
+      }
+   }
+
+   private static final class CachedRangeReader {
+      private final SwissAlti3dCoverageIndex.AssetReference assetRef;
+      private final Path cacheDir;
+      private final boolean localOnly;
+      private final Map<Long, byte[]> cachedFiles = new LinkedHashMap<>(16, 0.75F, true) {
+         @Override
+         protected boolean removeEldestEntry(Entry<Long, byte[]> eldest) {
+            return this.size() > 32;
+         }
+      };
+
+      CachedRangeReader(SwissAlti3dCoverageIndex.AssetReference assetRef, Path cacheDir, boolean localOnly) {
+         this.assetRef = assetRef;
+         this.cacheDir = cacheDir;
+         this.localOnly = localOnly;
+      }
+
+      byte[] read(long offset, int length) throws IOException {
+         if (length < 0) {
+            throw new EOFException("Negative range length " + length);
+         } else if (length == 0) {
+            return new byte[0];
+         } else {
+            synchronized(this.cachedFiles) {
+               byte[] cached = this.cachedFiles.get(offset);
+               if (cached != null && cached.length == length) {
+                  return cached;
+               }
+            }
+
+            Path cacheFile = this.cacheDir.resolve(offset + "_" + length + ".bin");
+            if (Files.exists(cacheFile)) {
+               byte[] cached = Files.readAllBytes(cacheFile);
+               synchronized(this.cachedFiles) {
+                  this.cachedFiles.put(offset, cached);
+               }
+
+               return cached;
+            } else {
+               if (this.localOnly) {
+                  throw new EOFException("swissALTI3D range not cached for " + this.assetRef.id());
+               }
+
+               Files.createDirectories(this.cacheDir);
+               byte[] downloaded = this.download(offset, length);
+               Path tempFile = Files.createTempFile(this.cacheDir, "range_", ".bin");
+
+               try {
+                  Files.write(tempFile, downloaded);
+                  Files.move(tempFile, cacheFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+               } catch (IOException error) {
+                  Files.deleteIfExists(tempFile);
+                  throw error;
+               }
+
+               synchronized(this.cachedFiles) {
+                  this.cachedFiles.put(offset, downloaded);
+               }
+
+               return downloaded;
+            }
+         }
+      }
+
+      private byte[] download(long offset, int length) throws IOException {
+         long end = offset + length - 1L;
+         HttpURLConnection connection = openConnection(URI.create(this.assetRef.url()), "bytes=" + offset + "-" + end);
+
+         try {
+            int response = connection.getResponseCode();
+            if (response != 206 && response != 200) {
+               throw new IOException("Unexpected swissALTI3D response " + response + " for " + this.assetRef.id());
+            }
+
+            long expectedBytes = response == 206 ? (long)length : Math.max(0L, connection.getContentLengthLong());
+            DownloadProgressReporter.requestStarted(expectedBytes);
+
+            try (InputStream in = connection.getInputStream()) {
+               byte[] bytes = DownloadProgressReporter.readAllBytesWithProgress(in);
+               if (bytes.length < length && response == 206) {
+                  throw new EOFException("Short swissALTI3D read for " + this.assetRef.id() + ": expected " + length + ", got " + bytes.length);
+               } else if (response == 200 && bytes.length < end + 1L) {
+                  throw new EOFException("Short swissALTI3D full response for " + this.assetRef.id());
+               } else if (response == 200) {
+                  byte[] slice = new byte[length];
+                  System.arraycopy(bytes, (int)offset, slice, 0, length);
+                  return slice;
+               } else {
+                  return bytes;
+               }
+            }
+         } finally {
+            DownloadProgressReporter.requestFinished();
+            connection.disconnect();
+         }
+      }
+   }
+
+   private static final class TileFile {
+      private static final int COMPRESSION_NONE = 1;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_BITS_PER_SAMPLE = 258;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_STRIP_OFFSETS = 273;
+      private static final int TAG_SAMPLES_PER_PIXEL = 277;
+      private static final int TAG_ROWS_PER_STRIP = 278;
+      private static final int TAG_STRIP_BYTE_COUNTS = 279;
+      private static final int TAG_PREDICTOR = 317;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_SAMPLE_FORMAT = 339;
+      private static final int TAG_MODEL_PIXEL_SCALE = 33550;
+      private static final int TAG_MODEL_TIEPOINT = 33922;
+      private static final int TAG_GDAL_NODATA = 42113;
+      private static final int TYPE_BYTE = 1;
+      private static final int TYPE_ASCII = 2;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int TYPE_RATIONAL = 5;
+      private static final int TYPE_DOUBLE = 12;
+      private static final int TYPE_LONG8 = 16;
+      private final String tileId;
+      private final SwissAlti3dElevationSource.CachedRangeReader reader;
+      private final ByteOrder order;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final int predictor;
+      private final int bytesPerSample;
+      private final int samplesPerPixel;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final double originX;
+      private final double originY;
+      private final double pixelSizeX;
+      private final double pixelSizeY;
+      private final float noData;
+      private final Map<Integer, float[]> tileCache = new LinkedHashMap<>(16, 0.75F, true) {
+         @Override
+         protected boolean removeEldestEntry(Entry<Integer, float[]> eldest) {
+            return this.size() > MAX_TILE_CACHE;
+         }
+      };
+
+      private TileFile(
+         String tileId,
+         SwissAlti3dElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         int predictor,
+         int bytesPerSample,
+         int samplesPerPixel,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         double originX,
+         double originY,
+         double pixelSizeX,
+         double pixelSizeY,
+         float noData
+      ) {
+         this.tileId = tileId;
+         this.reader = reader;
+         this.order = order;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = Mth.positiveCeilDiv(width, tileWidth);
+         this.compression = compression;
+         this.predictor = predictor;
+         this.bytesPerSample = bytesPerSample;
+         this.samplesPerPixel = samplesPerPixel;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.originX = originX;
+         this.originY = originY;
+         this.pixelSizeX = pixelSizeX;
+         this.pixelSizeY = pixelSizeY;
+         this.noData = noData;
+      }
+
+      private double sampleProjected(double x, double y) {
+         double globalX = (x - this.originX) / this.pixelSizeX;
+         double globalY = (this.originY - y) / this.pixelSizeY;
+         if (globalX < -1.0 || globalY < -1.0 || globalX > this.width || globalY > this.height) {
+            return Double.NaN;
+         } else {
+            int maxPixelX = this.width - 1;
+            int maxPixelY = this.height - 1;
+            double clampedX = Mth.clamp(globalX, 0.0, maxPixelX);
+            double clampedY = Mth.clamp(globalY, 0.0, maxPixelY);
+            int x0 = Mth.floor(clampedX);
+            int y0 = Mth.floor(clampedY);
+            int x1 = Math.min(x0 + 1, maxPixelX);
+            int y1 = Math.min(y0 + 1, maxPixelY);
+            double dx = clampedX - x0;
+            double dy = clampedY - y0;
+            float v00 = this.sampleValue(x0, y0);
+            float v10 = this.sampleValue(x1, y0);
+            float v01 = this.sampleValue(x0, y1);
+            float v11 = this.sampleValue(x1, y1);
+            return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+         }
+      }
+
+      private double effectiveResolutionMeters() {
+         return (Math.abs(this.pixelSizeX) + Math.abs(this.pixelSizeY)) * 0.5;
+      }
+
+      private float sampleValue(int pixelX, int pixelY) {
+         int clampedX = Mth.clamp(pixelX, 0, this.width - 1);
+         int clampedY = Mth.clamp(pixelY, 0, this.height - 1);
+         int tileX = clampedX / this.tileWidth;
+         int tileY = clampedY / this.tileHeight;
+         int tileIndex = tileY * this.tilesPerRow + tileX;
+
+         try {
+            float[] tile = this.getTile(tileIndex);
+            int localX = clampedX - tileX * this.tileWidth;
+            int localY = clampedY - tileY * this.tileHeight;
+            return tile[localX + localY * this.tileWidth];
+         } catch (IOException error) {
+            Tellus.LOGGER.debug("Failed to read swissALTI3D tile {} block from {}", tileIndex, this.tileId, error);
+            return Float.NaN;
+         }
+      }
+
+      private float[] getTile(int tileIndex) throws IOException {
+         synchronized(this.tileCache) {
+            float[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         float[] tile = this.readTile(tileIndex);
+         synchronized(this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private float[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = this.reader.read(offset, length);
+         int expectedSize = this.tileWidth * this.tileHeight * this.bytesPerSample * this.samplesPerPixel;
+         if (this.samplesPerPixel != 1) {
+            throw new IOException("Unsupported swissALTI3D TIFF samples per pixel " + this.samplesPerPixel);
+         } else {
+            byte[] raw = switch (this.compression) {
+               case COMPRESSION_NONE -> compressed;
+               case COMPRESSION_LZW -> decompressLzw(compressed, expectedSize);
+               case COMPRESSION_DEFLATE -> inflate(compressed, expectedSize);
+               default -> throw new IOException("Unsupported swissALTI3D TIFF compression " + this.compression);
+            };
+            if (raw.length != expectedSize) {
+               throw new IOException("Unexpected swissALTI3D tile length " + raw.length + " for " + this.tileId);
+            } else {
+               if (this.predictor == 3) {
+                  applyFloatingPointPredictor(raw, this.tileWidth, this.tileHeight, this.bytesPerSample, this.samplesPerPixel, this.order);
+               } else if (this.predictor != 1) {
+                  throw new IOException("Unsupported swissALTI3D TIFF predictor " + this.predictor);
+               }
+
+               float[] values = new float[this.tileWidth * this.tileHeight];
+               ByteBuffer buffer = ByteBuffer.wrap(raw).order(this.order);
+
+               for (int i = 0; i < values.length; i++) {
+                  float value = buffer.getFloat();
+                  values[i] = value <= this.noData + 1.0F ? Float.NaN : value;
+               }
+
+               return values;
+            }
+         }
+      }
+
+      private static SwissAlti3dElevationSource.TileFile open(
+         SwissAlti3dCoverageIndex.AssetReference assetRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters
+      ) throws IOException {
+         return open(assetRef, cacheDir, targetResolutionMeters, nativeResolutionMeters, false);
+      }
+
+      private static SwissAlti3dElevationSource.TileFile openLocalOnly(
+         SwissAlti3dCoverageIndex.AssetReference assetRef, Path cacheDir, double targetResolutionMeters, double nativeResolutionMeters
+      ) throws IOException {
+         return open(assetRef, cacheDir, targetResolutionMeters, nativeResolutionMeters, true);
+      }
+
+      private static SwissAlti3dElevationSource.TileFile open(
+         SwissAlti3dCoverageIndex.AssetReference assetRef,
+         Path cacheDir,
+         double targetResolutionMeters,
+         double nativeResolutionMeters,
+         boolean localOnly
+      ) throws IOException {
+         SwissAlti3dElevationSource.CachedRangeReader reader = new SwissAlti3dElevationSource.CachedRangeReader(assetRef, cacheDir, localOnly);
+         byte[] header = reader.read(0L, 32);
+         ByteOrder order = switch (header[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid swissALTI3D TIFF byte order for " + assetRef.id());
+         };
+         ByteBuffer headerBuf = ByteBuffer.wrap(header).order(order);
+         headerBuf.getShort();
+         short magic = headerBuf.getShort();
+         if (magic == 42) {
+            return openStandardTiff(assetRef, reader, order, headerBuf, targetResolutionMeters, nativeResolutionMeters);
+         } else if (magic == 43) {
+            return openBigTiff(assetRef, reader, order, headerBuf, targetResolutionMeters, nativeResolutionMeters);
+         } else {
+            throw new IOException("Unsupported swissALTI3D TIFF magic " + magic + " for " + assetRef.id());
+         }
+      }
+
+      private static SwissAlti3dElevationSource.TileFile openStandardTiff(
+         SwissAlti3dCoverageIndex.AssetReference assetRef,
+         SwissAlti3dElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         ByteBuffer headerBuf,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         long firstIfdOffset = Integer.toUnsignedLong(headerBuf.getInt());
+         SwissAlti3dElevationSource.TileFile.GeoReference baseGeoReference = readStandardGeoReference(reader, order, firstIfdOffset);
+         long ifdOffset = selectIfdOffset(reader, order, false, firstIfdOffset, targetResolutionMeters, nativeResolutionMeters);
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return buildTileFile(assetRef, reader, order, false, entryCount, entries, baseGeoReference);
+      }
+
+      private static SwissAlti3dElevationSource.TileFile openBigTiff(
+         SwissAlti3dCoverageIndex.AssetReference assetRef,
+         SwissAlti3dElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         ByteBuffer headerBuf,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         short offsetSize = headerBuf.getShort();
+         headerBuf.getShort();
+         if (offsetSize != 8) {
+            throw new IOException("Unsupported swissALTI3D BigTIFF offset size " + offsetSize + " for " + assetRef.id());
+         } else {
+            long firstIfdOffset = headerBuf.getLong();
+            SwissAlti3dElevationSource.TileFile.GeoReference baseGeoReference = readBigGeoReference(reader, order, firstIfdOffset);
+            long ifdOffset = selectIfdOffset(reader, order, true, firstIfdOffset, targetResolutionMeters, nativeResolutionMeters);
+            long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+            if (entryCount < 0L || entryCount > 1000000L) {
+               throw new IOException("Invalid swissALTI3D BigTIFF entry count " + entryCount + " for " + assetRef.id());
+            } else {
+               byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+               ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+               return buildTileFile(assetRef, reader, order, true, entryCount, entries, baseGeoReference);
+            }
+         }
+      }
+
+      private static long selectIfdOffset(
+         SwissAlti3dElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long firstIfdOffset,
+         double targetResolutionMeters,
+         double nativeResolutionMeters
+      ) throws IOException {
+         if (!(targetResolutionMeters > 0.0) || !Double.isFinite(targetResolutionMeters) || !(nativeResolutionMeters > 0.0)) {
+            return firstIfdOffset;
+         } else {
+            long currentOffset = firstIfdOffset;
+            long bestOffset = firstIfdOffset;
+            int baseWidth = -1;
+            double bestResolution = nativeResolutionMeters;
+            double bestScore = Math.abs(Math.log(bestResolution / targetResolutionMeters));
+
+            for (int level = 0; currentOffset != 0L && level < 16; level++) {
+               SwissAlti3dElevationSource.TileFile.IfdSummary summary = bigTiff
+                  ? readBigIfdSummary(reader, order, currentOffset)
+                  : readStandardIfdSummary(reader, order, currentOffset);
+               if (summary.width() <= 0) {
+                  break;
+               }
+
+               if (baseWidth < 0) {
+                  baseWidth = summary.width();
+               }
+
+               double candidateResolution = nativeResolutionMeters * ((double)baseWidth / (double)summary.width());
+               double candidateScore = Math.abs(Math.log(candidateResolution / targetResolutionMeters));
+               if (candidateScore < bestScore - 1.0E-9
+                  || Math.abs(candidateScore - bestScore) <= 1.0E-9 && candidateResolution < bestResolution) {
+                  bestOffset = currentOffset;
+                  bestResolution = candidateResolution;
+                  bestScore = candidateScore;
+               }
+
+               currentOffset = summary.nextIfdOffset();
+            }
+
+            return bestOffset;
+         }
+      }
+
+      private static SwissAlti3dElevationSource.TileFile.IfdSummary readStandardIfdSummary(
+         SwissAlti3dElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] ifdBytes = reader.read(ifdOffset + 2L, entryCount * 12 + 4);
+         ByteBuffer entries = ByteBuffer.wrap(ifdBytes).order(order);
+         int width = -1;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[4];
+            entries.get(inlineBytes, 0, 4);
+            if (tag == TAG_IMAGE_WIDTH && count == 1L) {
+               width = readInlineDimension(inlineBytes, type, order);
+            }
+         }
+
+         long nextIfdOffset = Integer.toUnsignedLong(ByteBuffer.wrap(ifdBytes, entryCount * 12, 4).order(order).getInt());
+         return new SwissAlti3dElevationSource.TileFile.IfdSummary(width, nextIfdOffset);
+      }
+
+      private static SwissAlti3dElevationSource.TileFile.IfdSummary readBigIfdSummary(
+         SwissAlti3dElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+         if (entryCount < 0L || entryCount > 1000000L) {
+            throw new IOException("Invalid swissALTI3D BigTIFF entry count " + entryCount);
+         } else {
+            byte[] ifdBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L + 8L));
+            ByteBuffer entries = ByteBuffer.wrap(ifdBytes).order(order);
+            int width = -1;
+
+            for (int i = 0; i < entryCount; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               long count = entries.getLong();
+               byte[] inlineBytes = new byte[8];
+               entries.get(inlineBytes);
+               if (tag == TAG_IMAGE_WIDTH && count == 1L) {
+                  width = readInlineDimension(inlineBytes, type, order);
+               }
+            }
+
+            long nextIfdOffset = ByteBuffer.wrap(ifdBytes, Math.toIntExact(entryCount * 20L), 8).order(order).getLong();
+            return new SwissAlti3dElevationSource.TileFile.IfdSummary(width, nextIfdOffset);
+         }
+      }
+
+      private static int readInlineDimension(byte[] inlineBytes, int type, ByteOrder order) throws IOException {
+         ByteBuffer buffer = ByteBuffer.wrap(inlineBytes).order(order);
+         return switch (type) {
+            case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+            case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+            case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+            default -> throw new IOException("Unsupported TIFF dimension type " + type);
+         };
+      }
+
+      private static SwissAlti3dElevationSource.TileFile.GeoReference readStandardGeoReference(
+         SwissAlti3dElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         int entryCount = Short.toUnsignedInt(ByteBuffer.wrap(reader.read(ifdOffset, 2)).order(order).getShort());
+         byte[] entryBytes = reader.read(ifdOffset + 2L, entryCount * 12);
+         ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+         return readGeoReference(reader, order, false, entryCount, entries);
+      }
+
+      private static SwissAlti3dElevationSource.TileFile.GeoReference readBigGeoReference(
+         SwissAlti3dElevationSource.CachedRangeReader reader, ByteOrder order, long ifdOffset
+      ) throws IOException {
+         long entryCount = ByteBuffer.wrap(reader.read(ifdOffset, 8)).order(order).getLong();
+         if (entryCount < 0L || entryCount > 1000000L) {
+            throw new IOException("Invalid swissALTI3D BigTIFF entry count " + entryCount);
+         } else {
+            byte[] entryBytes = reader.read(ifdOffset + 8L, Math.toIntExact(entryCount * 20L));
+            ByteBuffer entries = ByteBuffer.wrap(entryBytes).order(order);
+            return readGeoReference(reader, order, true, entryCount, entries);
+         }
+      }
+
+      private static SwissAlti3dElevationSource.TileFile.GeoReference readGeoReference(
+         SwissAlti3dElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            }
+         }
+
+         return width > 0 && height > 0 ? geoReferenceFromTags(width, height, pixelScale, tiePoints) : null;
+      }
+
+      private static SwissAlti3dElevationSource.TileFile buildTileFile(
+         SwissAlti3dCoverageIndex.AssetReference assetRef,
+         SwissAlti3dElevationSource.CachedRangeReader reader,
+         ByteOrder order,
+         boolean bigTiff,
+         long entryCount,
+         ByteBuffer entries,
+         SwissAlti3dElevationSource.TileFile.GeoReference baseGeoReference
+      ) throws IOException {
+         int inlineSize = bigTiff ? 8 : 4;
+         int width = -1;
+         int height = -1;
+         int tileWidth = -1;
+         int tileHeight = -1;
+         int compression = -1;
+         int predictor = 1;
+         int bitsPerSample = -1;
+         int sampleFormat = -1;
+         int samplesPerPixel = 1;
+         long[] tileOffsets = null;
+         int[] tileByteCounts = null;
+         int rowsPerStrip = -1;
+         long[] stripOffsets = null;
+         int[] stripByteCounts = null;
+         double[] pixelScale = null;
+         double[] tiePoints = null;
+         float noData = (float)DEFAULT_NO_DATA;
+
+         for (int i = 0; i < entryCount; i++) {
+            int tag = Short.toUnsignedInt(entries.getShort());
+            int type = Short.toUnsignedInt(entries.getShort());
+            long count = bigTiff ? entries.getLong() : Integer.toUnsignedLong(entries.getInt());
+            byte[] inlineBytes = new byte[inlineSize];
+            if (bigTiff) {
+               entries.get(inlineBytes);
+            } else {
+               entries.get(inlineBytes, 0, 4);
+            }
+
+            long valueOrOffset = bigTiff
+               ? ByteBuffer.wrap(inlineBytes).order(order).getLong()
+               : Integer.toUnsignedLong(ByteBuffer.wrap(inlineBytes).order(order).getInt());
+            switch (tag) {
+               case TAG_IMAGE_WIDTH -> width = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_IMAGE_HEIGHT -> height = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_BITS_PER_SAMPLE -> bitsPerSample = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_COMPRESSION -> compression = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_OFFSETS -> stripOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLES_PER_PIXEL -> samplesPerPixel = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_ROWS_PER_STRIP -> rowsPerStrip = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_STRIP_BYTE_COUNTS -> stripByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_PREDICTOR -> predictor = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_WIDTH -> tileWidth = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_HEIGHT -> tileHeight = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_OFFSETS -> tileOffsets = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_TILE_BYTE_COUNTS -> tileByteCounts = readIntArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_SAMPLE_FORMAT -> sampleFormat = readIntValue(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_PIXEL_SCALE -> pixelScale = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_MODEL_TIEPOINT -> tiePoints = readDoubleArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+               case TAG_GDAL_NODATA -> noData = parseNoData(readAscii(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize));
+            }
+         }
+
+         if (width <= 0 || height <= 0) {
+            throw new IOException("Missing swissALTI3D TIFF size tags for " + assetRef.id());
+         } else {
+            if ((tileOffsets == null || tileByteCounts == null) && stripOffsets != null && stripByteCounts != null && rowsPerStrip > 0) {
+               tileWidth = width;
+               tileHeight = rowsPerStrip;
+               tileOffsets = stripOffsets;
+               tileByteCounts = stripByteCounts;
+            }
+
+            if (tileWidth <= 0 || tileHeight <= 0) {
+               throw new IOException("Missing swissALTI3D TIFF tile geometry for " + assetRef.id());
+            } else if (tileOffsets == null || tileByteCounts == null) {
+               throw new IOException("Missing swissALTI3D TIFF tile offsets for " + assetRef.id());
+            } else if (bitsPerSample != 32 || sampleFormat != 3) {
+               throw new IOException("Unsupported swissALTI3D TIFF sample format " + sampleFormat + " bits " + bitsPerSample);
+            } else {
+               SwissAlti3dElevationSource.TileFile.GeoReference geoReference = geoReferenceFromTags(width, height, pixelScale, tiePoints);
+               if (geoReference == null && baseGeoReference != null) {
+                  // swissALTI3D COG overviews omit georeferencing tags; inherit the base transform and scale the pixel size.
+                  geoReference = baseGeoReference.scaledTo(width, height);
+               }
+
+               if (geoReference != null) {
+                  double originX = geoReference.originX();
+                  double originY = geoReference.originY();
+                  double pixelSizeX = geoReference.pixelSizeX();
+                  double pixelSizeY = geoReference.pixelSizeY();
+                  return new SwissAlti3dElevationSource.TileFile(
+                     assetRef.id(),
+                     reader,
+                     order,
+                     width,
+                     height,
+                     tileWidth,
+                     tileHeight,
+                     compression,
+                     predictor,
+                     4,
+                     samplesPerPixel,
+                     tileOffsets,
+                     tileByteCounts,
+                     originX,
+                     originY,
+                     pixelSizeX,
+                     pixelSizeY,
+                     noData
+                  );
+               }
+
+               throw new IOException("Missing swissALTI3D TIFF georeferencing tags for " + assetRef.id());
+            }
+         }
+      }
+
+      private static SwissAlti3dElevationSource.TileFile.GeoReference geoReferenceFromTags(
+         int width, int height, double[] pixelScale, double[] tiePoints
+      ) {
+         if (width <= 0 || height <= 0 || pixelScale == null || pixelScale.length < 2 || tiePoints == null || tiePoints.length < 6) {
+            return null;
+         } else {
+            double pixelSizeX = pixelScale[0];
+            double pixelSizeY = pixelScale[1];
+            double originX = tiePoints[3] - tiePoints[0] * pixelSizeX;
+            double originY = tiePoints[4] + tiePoints[1] * pixelSizeY;
+            return new SwissAlti3dElevationSource.TileFile.GeoReference(width, height, originX, originY, pixelSizeX, pixelSizeY);
+         }
+      }
+
+      private static int readIntValue(
+         SwissAlti3dElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count != 1L) {
+            throw new IOException("Expected single TIFF value");
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            return switch (type) {
+               case TYPE_BYTE -> buffer.get() & 255;
+               case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+               case TYPE_LONG -> Math.toIntExact(Integer.toUnsignedLong(buffer.getInt()));
+               case TYPE_LONG8 -> Math.toIntExact(buffer.getLong());
+               default -> throw new IOException("Unsupported TIFF value type " + type);
+            };
+         }
+      }
+
+      private static long[] readLongArray(
+         SwissAlti3dElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new long[0];
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            long[] values = new long[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = switch (type) {
+                  case TYPE_BYTE -> buffer.get() & 255;
+                  case TYPE_SHORT -> Short.toUnsignedInt(buffer.getShort());
+                  case TYPE_LONG -> Integer.toUnsignedLong(buffer.getInt());
+                  case TYPE_LONG8 -> buffer.getLong();
+                  default -> throw new IOException("Unsupported TIFF array type " + type);
+               };
+            }
+
+            return values;
+         }
+      }
+
+      private static int[] readIntArray(
+         SwissAlti3dElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         long[] values = readLongArray(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+         int[] output = new int[values.length];
+
+         for (int i = 0; i < values.length; i++) {
+            if (values[i] > 2147483647L) {
+               throw new IOException("TIFF byte count too large " + values[i]);
+            }
+
+            output[i] = (int)values[i];
+         }
+
+         return output;
+      }
+
+      private static double[] readDoubleArray(
+         SwissAlti3dElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (count <= 0L) {
+            return new double[0];
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            ByteBuffer buffer = ByteBuffer.wrap(data).order(order);
+            double[] values = new double[(int)count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = switch (type) {
+                  case TYPE_SHORT -> buffer.getShort();
+                  case TYPE_LONG -> buffer.getInt();
+                  case TYPE_RATIONAL -> {
+                     long numerator = Integer.toUnsignedLong(buffer.getInt());
+                     long denominator = Integer.toUnsignedLong(buffer.getInt());
+                     yield denominator == 0L ? 0.0 : (double)numerator / (double)denominator;
+                  }
+                  case TYPE_DOUBLE -> buffer.getDouble();
+                  default -> throw new IOException("Unsupported TIFF double array type " + type);
+               };
+            }
+
+            return values;
+         }
+      }
+
+      private static String readAscii(
+         SwissAlti3dElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         if (type != TYPE_ASCII) {
+            throw new IOException("Expected ASCII TIFF field");
+         } else {
+            byte[] data = readFieldData(reader, valueOrOffset, inlineBytes, count, type, order, inlineSize);
+            int length = data.length;
+
+            while (length > 0 && data[length - 1] == 0) {
+               length--;
+            }
+
+            return new String(data, 0, length, StandardCharsets.US_ASCII);
+         }
+      }
+
+      private static byte[] readFieldData(
+         SwissAlti3dElevationSource.CachedRangeReader reader, long valueOrOffset, byte[] inlineBytes, long count, int type, ByteOrder order, int inlineSize
+      ) throws IOException {
+         int valueSize = switch (type) {
+            case TYPE_BYTE, TYPE_ASCII -> 1;
+            case TYPE_SHORT -> 2;
+            case TYPE_LONG -> 4;
+            case TYPE_RATIONAL, TYPE_DOUBLE, TYPE_LONG8 -> 8;
+            default -> throw new IOException("Unsupported TIFF field type " + type);
+         };
+         long totalSize = count * valueSize;
+         if (totalSize < 0L || totalSize > 2147483647L) {
+            throw new IOException("Unsupported TIFF field size " + totalSize);
+         } else if (totalSize <= inlineSize) {
+            byte[] inline = new byte[(int)totalSize];
+            System.arraycopy(inlineBytes, 0, inline, 0, (int)totalSize);
+            return inline;
+         } else {
+            return reader.read(valueOrOffset, (int)totalSize);
+         }
+      }
+
+      private static float parseNoData(String ascii) {
+         if (ascii == null || ascii.isBlank()) {
+            return (float)DEFAULT_NO_DATA;
+         } else {
+            try {
+               return Float.parseFloat(ascii.trim());
+            } catch (NumberFormatException error) {
+               return (float)DEFAULT_NO_DATA;
+            }
+         }
+      }
+
+      private record IfdSummary(int width, long nextIfdOffset) {
+      }
+
+      private record GeoReference(int width, int height, double originX, double originY, double pixelSizeX, double pixelSizeY) {
+         private SwissAlti3dElevationSource.TileFile.GeoReference scaledTo(int targetWidth, int targetHeight) {
+            if (targetWidth <= 0 || targetHeight <= 0) {
+               return null;
+            } else if (targetWidth == this.width && targetHeight == this.height) {
+               return this;
+            } else {
+               double scaleX = (double)this.width / (double)targetWidth;
+               double scaleY = (double)this.height / (double)targetHeight;
+               return new SwissAlti3dElevationSource.TileFile.GeoReference(
+                  targetWidth,
+                  targetHeight,
+                  this.originX,
+                  this.originY,
+                  this.pixelSizeX * scaleX,
+                  this.pixelSizeY * scaleY
+               );
+            }
+         }
+      }
+
+      private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+         double sum = 0.0;
+         double weight = 0.0;
+         if (Float.isFinite(v00)) {
+            double w = (1.0 - dx) * (1.0 - dy);
+            sum += v00 * w;
+            weight += w;
+         }
+
+         if (Float.isFinite(v10)) {
+            double w = dx * (1.0 - dy);
+            sum += v10 * w;
+            weight += w;
+         }
+
+         if (Float.isFinite(v01)) {
+            double w = (1.0 - dx) * dy;
+            sum += v01 * w;
+            weight += w;
+         }
+
+         if (Float.isFinite(v11)) {
+            double w = dx * dy;
+            sum += v11 * w;
+            weight += w;
+         }
+
+         return weight > 0.0 ? sum / weight : Double.NaN;
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         try (InputStream in = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            byte[] raw = in.readAllBytes();
+            if (raw.length < expectedSize) {
+               throw new EOFException("Unexpected DEFLATE length " + raw.length + " expected " + expectedSize);
+            } else if (raw.length == expectedSize) {
+               return raw;
+            } else {
+               byte[] copy = new byte[expectedSize];
+               System.arraycopy(raw, 0, copy, 0, expectedSize);
+               return copy;
+            }
+         }
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+         int outputPos = 0;
+         int bitPos = 0;
+         int codeSize = 9;
+         int clearCode = 256;
+         int endCode = 257;
+         int nextCode = 258;
+         byte[][] dictionary = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            dictionary[i] = new byte[]{(byte)i};
+         }
+
+         byte[] previous = null;
+
+         while (true) {
+            int code = readLzwCode(compressed, bitPos, codeSize);
+            bitPos += codeSize;
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 258; i < dictionary.length; i++) {
+                  dictionary[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else if (code == endCode) {
+               break;
+            } else {
+               byte[] entry;
+               if (code < nextCode && dictionary[code] != null) {
+                  entry = dictionary[code];
+               } else {
+                  if (previous == null) {
+                     throw new IOException("Invalid swissALTI3D LZW stream");
+                  }
+
+                  entry = append(previous, previous[0]);
+               }
+
+               if (outputPos + entry.length > output.length) {
+                  throw new IOException("swissALTI3D LZW output overflow");
+               }
+
+               System.arraycopy(entry, 0, output, outputPos, entry.length);
+               outputPos += entry.length;
+               if (previous != null && nextCode < dictionary.length) {
+                  dictionary[nextCode++] = append(previous, entry[0]);
+                  if (nextCode == 511 || nextCode == 1023 || nextCode == 2047) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+            }
+         }
+
+         if (outputPos != output.length) {
+            byte[] copy = new byte[outputPos];
+            System.arraycopy(output, 0, copy, 0, outputPos);
+            return copy;
+         } else {
+            return output;
+         }
+      }
+
+      private static int readLzwCode(byte[] data, int bitPos, int codeSize) {
+         int totalBits = data.length * 8;
+         if (bitPos + codeSize > totalBits) {
+            return -1;
+         } else {
+            int code = 0;
+
+            for (int i = 0; i < codeSize; i++) {
+               int currentBit = bitPos + i;
+               int currentByte = data[currentBit >> 3] & 255;
+               int bit = currentByte >> 7 - (currentBit & 7) & 1;
+               code = code << 1 | bit;
+            }
+
+            return code;
+         }
+      }
+
+      private static byte[] append(byte[] prefix, byte suffix) {
+         byte[] out = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, out, 0, prefix.length);
+         out[prefix.length] = suffix;
+         return out;
+      }
+
+      private static void applyFloatingPointPredictor(byte[] raw, int width, int height, int bytesPerSample, int samplesPerPixel, ByteOrder order)
+         throws IOException {
+         int stride = width * bytesPerSample * samplesPerPixel;
+         byte[] row = new byte[stride];
+
+         for (int y = 0; y < height; y++) {
+            int rowOffset = y * stride;
+
+            for (int i = 0; i < stride; i++) {
+               row[i] = raw[rowOffset + i];
+            }
+
+            for (int i = bytesPerSample * samplesPerPixel; i < stride; i++) {
+               row[i] = (byte)(row[i] + row[i - bytesPerSample * samplesPerPixel]);
+            }
+
+            for (int x = 0; x < width; x++) {
+               int sampleOffset = x * bytesPerSample * samplesPerPixel;
+               if (order == ByteOrder.LITTLE_ENDIAN) {
+                  for (int b = 0; b < bytesPerSample; b++) {
+                     raw[rowOffset + sampleOffset + b] = row[sampleOffset + bytesPerSample - 1 - b];
+                  }
+               } else {
+                  System.arraycopy(row, sampleOffset, raw, rowOffset + sampleOffset, bytesPerSample);
+               }
+            }
+         }
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/TellusElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/TellusElevationSource.java
@@ -1,0 +1,2359 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.world.data.mask.TellusLandMaskSource;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import com.yucareux.tellus.worldgen.TellusWorldgenSources;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.imageio.ImageIO;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+
+public final class TellusElevationSource implements TellusCacheHandle {
+   private static final double EQUATOR_CIRCUMFERENCE = 4.0075017E7;
+   private static final int TILE_SIZE = 256;
+   private static final int MIN_ZOOM = 0;
+   private static final int LAND_MAX_ZOOM = 15;
+   private static final int OCEAN_MAX_ZOOM = 10;
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final double POLAR_NORTH_MIN_LAT = 60.0;
+   private static final double POLAR_SOUTH_MAX_LAT = -60.0;
+   private static final double RESOLUTION_METERS = 30.0;
+   private static final String ENDPOINT = "https://s3.amazonaws.com/elevation-tiles-prod/terrarium";
+   private static final int MAX_CACHE_TILES = intProperty("tellus.elevation.cacheTiles", 512);
+   // The normalized cache currently incurs a very expensive first-build path on cache misses.
+   // Keep it opt-in until the ingest/build cost is low enough for preview and spawn-time terrain reads.
+   private static final boolean NORMALIZED_ENABLED = booleanProperty("tellus.elevation.normalized.enabled", false);
+   private static final boolean NORMALIZED_COMPARE = booleanProperty("tellus.elevation.normalized.compare", false);
+   private static final int NORMALIZED_COMPARE_LOG_LIMIT = intProperty("tellus.elevation.normalized.compareLogLimit", 100);
+   private static final boolean DEBUG_DEM = Boolean.getBoolean("tellus.debug.dem");
+   private static final ShortRaster MISSING_RASTER = ShortRaster.create(1, 1);
+   private static final NormalizedElevationCache NORMALIZED_CACHE = NORMALIZED_ENABLED ? new NormalizedElevationCache() : null;
+   private static final AtomicInteger NORMALIZED_COMPARE_LOGGED = new AtomicInteger();
+   private final Path cacheRoot;
+   private final LoadingCache<TellusElevationSource.TileKey, ShortRaster> cache;
+   private final ArcticDemElevationSource arcticDem = new ArcticDemElevationSource();
+   private final RemaElevationSource rema = new RemaElevationSource();
+   private final SwissAlti3dElevationSource swissAlti3d = new SwissAlti3dElevationSource();
+   private final AhnElevationSource ahn = new AhnElevationSource();
+   private final CanElevationSource canElevation = new CanElevationSource();
+   private final NorwayDtm1ElevationSource norwayDtm1 = new NorwayDtm1ElevationSource();
+   private final JapanGsiElevationSource japanGsi = new JapanGsiElevationSource();
+   private final Usgs3depElevationSource usgs = new Usgs3depElevationSource();
+   private final CopernicusDemElevationSource copernicus = new CopernicusDemElevationSource();
+   private final TerrainTilesResolutionIndex terrainResolutionIndex = TerrainTilesResolutionIndex.create();
+   private final TellusLandMaskSource landMask = TellusWorldgenSources.landMask();
+   private volatile EarthGeneratorSettings.DemSelection lastLoggedSelection;
+
+   public TellusElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-tellus");
+      this.cache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_TILES).build(new CacheLoader<TellusElevationSource.TileKey, ShortRaster>() {
+         public ShortRaster load( TellusElevationSource.TileKey key) throws Exception {
+            return TellusElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public double sampleElevationMeters(double blockX, double blockZ, double worldScale) {
+      return this.sampleElevationMeters(blockX, blockZ, worldScale, true, EarthGeneratorSettings.DEFAULT.demSelection());
+   }
+
+   public double sampleElevationMeters(double blockX, double blockZ, double worldScale, boolean highResOcean) {
+      return this.sampleElevationMeters(blockX, blockZ, worldScale, highResOcean, EarthGeneratorSettings.DEFAULT.demSelection());
+   }
+
+   public double sampleElevationMeters(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection
+   ) {
+      return this.sampleElevationMeters(blockX, blockZ, worldScale, highResOcean, demSelection, worldScale);
+   }
+
+   public double samplePreviewElevationMeters(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      return this.sampleElevationMeters(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   public double samplePreviewElevationMetersLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (worldScale <= 0.0) {
+         return 0.0;
+      } else {
+         return this.sampleElevationMetersFromProvidersLocalOnly(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+      }
+   }
+
+   public double samplePreviewElevationMetersMemoryOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (worldScale <= 0.0) {
+         return Double.NaN;
+      } else {
+         return this.sampleElevationMetersFromProvidersMemoryOnly(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+      }
+   }
+
+   public double samplePreviewTerrainTilesMetersLocalOnly(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters
+   ) {
+      return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+   }
+
+   private double sampleElevationMeters(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (worldScale <= 0.0) {
+         return 0.0;
+      } else {
+         if (DEBUG_DEM && !Objects.equals(demSelection, this.lastLoggedSelection)) {
+            this.lastLoggedSelection = demSelection;
+            Tellus.LOGGER.info(
+               "DEM selection set to automatic={} providers={}.",
+               demSelection.automatic(),
+               String.join(",", demSelection.enabledProviderIds())
+            );
+         }
+
+         if (NORMALIZED_ENABLED) {
+            try {
+               TellusElevationSource.ElevationDiagnostic normalized = this.sampleDiagnosticFromNormalizedCache(
+                  blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters
+               );
+               this.compareNormalizedElevation(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters, normalized.elevation());
+               return normalized.elevation();
+            } catch (RuntimeException error) {
+               Tellus.LOGGER.debug("Falling back to direct DEM sampling for normalized cache miss at {},{}", blockX, blockZ, error);
+            }
+         }
+
+         return this.sampleElevationMetersFromProviders(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+      }
+   }
+
+   private double sampleElevationMetersFromProviders(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      return demSelection.isAllEnabled()
+         ? this.sampleElevationMetersFromLegacyProvider(
+            blockX, blockZ, worldScale, highResOcean, EarthGeneratorSettings.DemProvider.AUTO, previewResolutionMeters
+         )
+         : this.sampleFilteredElevationMeters(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private double sampleElevationMetersFromProvidersLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      return demSelection.isAllEnabled()
+         ? this.sampleElevationMetersFromLegacyProviderLocalOnly(
+            blockX, blockZ, worldScale, highResOcean, EarthGeneratorSettings.DemProvider.AUTO, previewResolutionMeters
+         )
+         : this.sampleFilteredElevationMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private double sampleElevationMetersFromProvidersMemoryOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      return this.sampleTerrariumMetersMemoryOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+   }
+
+   private double sampleElevationMetersFromLegacyProvider(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemProvider demProvider,
+      double previewResolutionMeters
+   ) {
+      return switch (demProvider) {
+            case AUTO -> this.sampleAutomaticMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            case SWISSALTI3D -> {
+               SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield swiss.usable() ? swiss.elevation() : this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case AHN -> {
+               AhnElevationSource.Sample ahn = this.ahn.sample(blockX, blockZ, worldScale);
+               yield ahn.usable() ? ahn.elevation() : this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case CANELEVATION -> {
+               CanElevationSource.Sample canada = this.canElevation.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield canada.usable() ? canada.elevation() : this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case NORWAYDTM1 -> {
+               NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield norway.usable() ? norway.elevation() : this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case JAPANGSI -> {
+               JapanGsiElevationSource.Sample japan = this.japanGsi.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield japan.usable()
+                  ? japan.elevation()
+                  : this.sampleAutomaticMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters, false);
+            }
+            case USGS -> this.sampleUsgsMetersWithFallback(blockX, blockZ, worldScale, highResOcean);
+            case COPERNICUS -> this.sampleCopernicusPreferredMeters(blockX, blockZ, worldScale, highResOcean);
+            case ARCTICDEM -> {
+               TellusElevationSource.PolarDemSample polar = this.samplePolarDem(blockX, blockZ, worldScale);
+               yield polar.usable() ? polar.elevation() : this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case TERRARIUM -> this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+         };
+   }
+
+   private double sampleElevationMetersFromLegacyProviderLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemProvider demProvider,
+      double previewResolutionMeters
+   ) {
+      return switch (demProvider) {
+            case AUTO -> this.sampleAutomaticMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            case SWISSALTI3D -> {
+               SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield swiss.usable()
+                  ? swiss.elevation()
+                  : this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case AHN -> {
+               AhnElevationSource.Sample ahn = this.ahn.sampleLocalOnly(blockX, blockZ, worldScale);
+               yield ahn.usable()
+                  ? ahn.elevation()
+                  : this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case CANELEVATION -> {
+               CanElevationSource.Sample canada = this.canElevation.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield canada.usable()
+                  ? canada.elevation()
+                  : this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case NORWAYDTM1 -> {
+               NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield norway.usable()
+                  ? norway.elevation()
+                  : this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case JAPANGSI -> {
+               JapanGsiElevationSource.Sample japan = this.japanGsi.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield japan.usable()
+                  ? japan.elevation()
+                  : this.sampleAutomaticMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters, false);
+            }
+            case USGS -> this.sampleUsgsMetersWithFallbackLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            case COPERNICUS -> this.sampleCopernicusPreferredMetersLocalOnly(
+               blockX, blockZ, worldScale, highResOcean, previewResolutionMeters
+            );
+            case ARCTICDEM -> {
+               TellusElevationSource.PolarDemSample polar = this.samplePolarDemLocalOnly(blockX, blockZ, worldScale);
+               yield polar.usable()
+                  ? polar.elevation()
+                  : this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case TERRARIUM -> this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+         };
+   }
+
+   public TellusElevationSource.ElevationDiagnostic sampleDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, EarthGeneratorSettings.DemSelection demSelection
+   ) {
+      return this.sampleDiagnostic(blockX, blockZ, worldScale, highResOcean, demSelection, worldScale);
+   }
+
+   public TellusElevationSource.ElevationDiagnostic samplePreviewDiagnostic(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      return this.sampleDiagnostic(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleDiagnostic(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (worldScale <= 0.0) {
+         return diagnostic(0.0, TellusElevationSource.DemUsage.TERRAIN_TILES);
+      } else {
+         if (NORMALIZED_ENABLED) {
+            try {
+               TellusElevationSource.ElevationDiagnostic normalized = this.sampleDiagnosticFromNormalizedCache(
+                  blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters
+               );
+               this.compareNormalizedElevation(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters, normalized.elevation());
+               return normalized;
+            } catch (RuntimeException error) {
+               Tellus.LOGGER.debug("Falling back to direct DEM diagnostics for normalized cache miss at {},{}", blockX, blockZ, error);
+            }
+         }
+
+         return this.sampleDiagnosticFromProviders(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+      }
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleDiagnosticFromProviders(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      return demSelection.isAllEnabled()
+         ? this.sampleDiagnosticFromLegacyProvider(
+            blockX, blockZ, worldScale, highResOcean, EarthGeneratorSettings.DemProvider.AUTO, previewResolutionMeters
+         )
+         : this.sampleFilteredDiagnostic(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleDiagnosticFromLegacyProvider(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemProvider demProvider,
+      double previewResolutionMeters
+   ) {
+      return switch (demProvider) {
+            case AUTO -> this.sampleAutomaticDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            case SWISSALTI3D -> {
+               SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield swiss.usable()
+                  ? diagnostic(swiss.elevation(), swiss.usage(), swiss.usage().bit(), swiss.resolutionMeters())
+                  : this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case AHN -> {
+               AhnElevationSource.Sample ahn = this.ahn.sample(blockX, blockZ, worldScale);
+               yield ahn.usable()
+                  ? diagnostic(ahn.elevation(), ahn.usage(), ahn.usage().bit(), ahn.resolutionMeters())
+                  : this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case CANELEVATION -> {
+               CanElevationSource.Sample canada = this.canElevation.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield canada.usable()
+                  ? diagnostic(canada.elevation(), canada.usage(), canada.usage().bit(), canada.resolutionMeters())
+                  : this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case NORWAYDTM1 -> {
+               NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield norway.usable()
+                  ? diagnostic(norway.elevation(), norway.usage(), norway.usage().bit(), norway.resolutionMeters())
+                  : this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case JAPANGSI -> {
+               JapanGsiElevationSource.Sample japan = this.japanGsi.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+               yield japan.usable()
+                  ? diagnostic(japan.elevation(), japan.usage(), japan.usage().bit(), japan.resolutionMeters())
+                  : this.sampleAutomaticDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters, false);
+            }
+            case USGS -> this.sampleUsgsMetersWithFallbackDiagnostic(blockX, blockZ, worldScale, highResOcean);
+            case COPERNICUS -> this.sampleCopernicusPreferredDiagnostic(blockX, blockZ, worldScale, highResOcean);
+            case ARCTICDEM -> {
+               TellusElevationSource.PolarDemSample polar = this.samplePolarDem(blockX, blockZ, worldScale);
+               yield polar.usable()
+                  ? diagnostic(polar.elevation(), polar.usage())
+                  : this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+            }
+            case TERRARIUM -> this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+         };
+   }
+
+   private double sampleFilteredElevationMeters(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.SWISSALTI3D)) {
+         SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (swiss.usable()) {
+            return swiss.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.AHN)) {
+         AhnElevationSource.Sample ahn = this.ahn.sample(blockX, blockZ, worldScale);
+         if (ahn.usable()) {
+            return ahn.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.CANELEVATION)) {
+         CanElevationSource.Sample canada = this.canElevation.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (canada.usable()) {
+            return canada.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.NORWAYDTM1)) {
+         NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (norway.usable()) {
+            return norway.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.JAPANGSI)) {
+         JapanGsiElevationSource.Sample japan = this.japanGsi.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (japan.usable()) {
+            return japan.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.ARCTICDEM)) {
+         TellusElevationSource.PolarDemSample polar = this.samplePolarDem(blockX, blockZ, worldScale);
+         if (polar.usable()) {
+            return polar.elevation();
+         }
+      }
+
+      TellusElevationSource.AutoDecision decision = this.autoDecision(blockX, blockZ, worldScale);
+      if (decision.preferUsgs()) {
+         if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.USGS)) {
+            double usgsSample = this.sampleUsgsPreferredMeters(blockX, blockZ, worldScale, highResOcean, decision.landMaskSample());
+            if (!Double.isNaN(usgsSample)) {
+               return usgsSample;
+            }
+         }
+
+         if (demSelection.copernicusEnabled()) {
+            double copernicusSample = this.sampleCopernicusPreferredMeters(
+               blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), demSelection.terrainTilesEnabled()
+            );
+            if (!Double.isNaN(copernicusSample)) {
+               return copernicusSample;
+            }
+         }
+      } else if (decision.preferCopernicus() && demSelection.copernicusEnabled()) {
+         double copernicusSample = this.sampleCopernicusPreferredMeters(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), demSelection.terrainTilesEnabled()
+         );
+         if (!Double.isNaN(copernicusSample)) {
+            return copernicusSample;
+         }
+      }
+
+      return this.sampleFinalFallbackMeters(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private double sampleFilteredElevationMetersLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.SWISSALTI3D)) {
+         SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (swiss.usable()) {
+            return swiss.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.AHN)) {
+         AhnElevationSource.Sample ahn = this.ahn.sampleLocalOnly(blockX, blockZ, worldScale);
+         if (ahn.usable()) {
+            return ahn.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.CANELEVATION)) {
+         CanElevationSource.Sample canada = this.canElevation.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (canada.usable()) {
+            return canada.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.NORWAYDTM1)) {
+         NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (norway.usable()) {
+            return norway.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.JAPANGSI)) {
+         JapanGsiElevationSource.Sample japan = this.japanGsi.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (japan.usable()) {
+            return japan.elevation();
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.ARCTICDEM)) {
+         TellusElevationSource.PolarDemSample polar = this.samplePolarDemLocalOnly(blockX, blockZ, worldScale);
+         if (polar.usable()) {
+            return polar.elevation();
+         }
+      }
+
+      TellusElevationSource.AutoDecision decision = this.autoDecisionLocalOnly(blockX, blockZ, worldScale);
+      if (decision.preferUsgs()) {
+         if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.USGS)) {
+            double usgsSample = this.sampleUsgsPreferredMetersLocalOnly(
+               blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), previewResolutionMeters
+            );
+            if (!Double.isNaN(usgsSample)) {
+               return usgsSample;
+            }
+         }
+
+         if (demSelection.copernicusEnabled()) {
+            double copernicusSample = this.sampleCopernicusPreferredMetersLocalOnly(
+               blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), demSelection.terrainTilesEnabled(), previewResolutionMeters
+            );
+            if (!Double.isNaN(copernicusSample)) {
+               return copernicusSample;
+            }
+         }
+      } else if (decision.preferCopernicus() && demSelection.copernicusEnabled()) {
+         double copernicusSample = this.sampleCopernicusPreferredMetersLocalOnly(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), demSelection.terrainTilesEnabled(), previewResolutionMeters
+         );
+         if (!Double.isNaN(copernicusSample)) {
+            return copernicusSample;
+         }
+      }
+
+      return this.sampleFinalFallbackMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleFilteredDiagnostic(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.SWISSALTI3D)) {
+         SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (swiss.usable()) {
+            return diagnostic(swiss.elevation(), swiss.usage(), swiss.usage().bit(), swiss.resolutionMeters());
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.AHN)) {
+         AhnElevationSource.Sample ahn = this.ahn.sample(blockX, blockZ, worldScale);
+         if (ahn.usable()) {
+            return diagnostic(ahn.elevation(), ahn.usage(), ahn.usage().bit(), ahn.resolutionMeters());
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.CANELEVATION)) {
+         CanElevationSource.Sample canada = this.canElevation.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (canada.usable()) {
+            return diagnostic(canada.elevation(), canada.usage(), canada.usage().bit(), canada.resolutionMeters());
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.NORWAYDTM1)) {
+         NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (norway.usable()) {
+            return diagnostic(norway.elevation(), norway.usage(), norway.usage().bit(), norway.resolutionMeters());
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.JAPANGSI)) {
+         JapanGsiElevationSource.Sample japan = this.japanGsi.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (japan.usable()) {
+            return diagnostic(japan.elevation(), japan.usage(), japan.usage().bit(), japan.resolutionMeters());
+         }
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.ARCTICDEM)) {
+         TellusElevationSource.PolarDemSample polar = this.samplePolarDem(blockX, blockZ, worldScale);
+         if (polar.usable()) {
+            return diagnostic(polar.elevation(), polar.usage());
+         }
+      }
+
+      TellusElevationSource.AutoDecision decision = this.autoDecision(blockX, blockZ, worldScale);
+      if (decision.preferUsgs()) {
+         if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.USGS)) {
+            TellusElevationSource.ElevationDiagnostic usgsSample = this.sampleUsgsPreferredDiagnostic(
+               blockX, blockZ, worldScale, highResOcean, decision.landMaskSample()
+            );
+            if (!Double.isNaN(usgsSample.elevation())) {
+               return usgsSample;
+            }
+         }
+
+         if (demSelection.copernicusEnabled()) {
+            TellusElevationSource.ElevationDiagnostic copernicusSample = this.sampleCopernicusPreferredDiagnostic(
+               blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), demSelection.terrainTilesEnabled()
+            );
+            if (!Double.isNaN(copernicusSample.elevation())) {
+               return copernicusSample;
+            }
+         }
+      } else if (decision.preferCopernicus() && demSelection.copernicusEnabled()) {
+         TellusElevationSource.ElevationDiagnostic copernicusSample = this.sampleCopernicusPreferredDiagnostic(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), demSelection.terrainTilesEnabled()
+         );
+         if (!Double.isNaN(copernicusSample.elevation())) {
+            return copernicusSample;
+         }
+      }
+
+      return this.sampleFinalFallbackDiagnostic(blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters);
+   }
+
+   private double sampleFinalFallbackMeters(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.terrainTilesEnabled()) {
+         return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+      }
+
+      if (demSelection.copernicusEnabled()) {
+         return this.sampleCopernicusPreferredMeters(
+            blockX, blockZ, worldScale, highResOcean, this.landMask.sampleLandMask(blockX, blockZ, worldScale), false
+         );
+      }
+
+      return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+   }
+
+   private double sampleFinalFallbackMetersLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.terrainTilesEnabled()) {
+         return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+      }
+
+      if (demSelection.copernicusEnabled()) {
+         double copernicusSample = this.sampleCopernicusPreferredMetersLocalOnly(
+            blockX,
+            blockZ,
+            worldScale,
+            highResOcean,
+            this.landMask.sampleLandMaskLocalOnly(blockX, blockZ, worldScale),
+            false,
+            previewResolutionMeters
+         );
+         if (!Double.isNaN(copernicusSample)) {
+            return copernicusSample;
+         }
+      }
+
+      return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleFinalFallbackDiagnostic(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.terrainTilesEnabled()) {
+         return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+      }
+
+      if (demSelection.copernicusEnabled()) {
+         return this.sampleCopernicusPreferredDiagnostic(
+            blockX, blockZ, worldScale, highResOcean, this.landMask.sampleLandMask(blockX, blockZ, worldScale), false
+         );
+      }
+
+      return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, EarthGeneratorSettings.DEFAULT.demSelection());
+   }
+
+   public void prefetchTiles(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      int radius,
+      EarthGeneratorSettings.DemSelection demSelection
+   ) {
+      this.prefetchTiles(blockX, blockZ, worldScale, radius, demSelection, worldScale);
+   }
+
+   public void prefetchTiles(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      int radius,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (!(worldScale <= 0.0)) {
+         if (NORMALIZED_ENABLED) {
+            this.prefetchNormalizedTiles(blockX, blockZ, worldScale, radius, demSelection, previewResolutionMeters);
+            return;
+         }
+
+         this.prefetchTilesFromProviders(blockX, blockZ, worldScale, radius, demSelection, previewResolutionMeters);
+      }
+   }
+
+   private void prefetchTilesFromProviders(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      int radius,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.isAllEnabled()) {
+         this.prefetchTilesFromLegacyProvider(
+            blockX, blockZ, worldScale, radius, EarthGeneratorSettings.DemProvider.AUTO, previewResolutionMeters
+         );
+         return;
+      }
+
+      this.prefetchFilteredTiles(blockX, blockZ, worldScale, radius, demSelection, previewResolutionMeters);
+   }
+
+   private void prefetchTilesFromLegacyProvider(
+      double blockX, double blockZ, double worldScale, int radius, EarthGeneratorSettings.DemProvider demProvider, double previewResolutionMeters
+   ) {
+         TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+         boolean manualSwissAlti3d = demProvider == EarthGeneratorSettings.DemProvider.SWISSALTI3D;
+         boolean autoSwissAlti3d = demProvider == EarthGeneratorSettings.DemProvider.AUTO && this.shouldPreferSwissAlti3d(blockX, blockZ, worldScale);
+         if (manualSwissAlti3d || autoSwissAlti3d) {
+            this.swissAlti3d.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+         }
+
+         if (manualSwissAlti3d) {
+            return;
+         }
+
+         boolean manualAhn = demProvider == EarthGeneratorSettings.DemProvider.AHN;
+         boolean autoAhn = !autoSwissAlti3d && demProvider == EarthGeneratorSettings.DemProvider.AUTO && this.shouldPreferAhn(blockX, blockZ, worldScale);
+         if (manualAhn || autoAhn) {
+            this.ahn.prefetchTiles(blockX, blockZ, worldScale, radius);
+         }
+
+         if (manualAhn) {
+            return;
+         }
+
+         boolean manualCanElevation = demProvider == EarthGeneratorSettings.DemProvider.CANELEVATION;
+         boolean autoCanElevation = !autoSwissAlti3d
+            && !autoAhn
+            && demProvider == EarthGeneratorSettings.DemProvider.AUTO
+            && this.shouldPreferCanElevation(blockX, blockZ, worldScale);
+         if (manualCanElevation || autoCanElevation) {
+            this.canElevation.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+         }
+
+         if (manualCanElevation) {
+            return;
+         }
+
+         boolean manualNorwayDtm1 = demProvider == EarthGeneratorSettings.DemProvider.NORWAYDTM1;
+         boolean autoNorwayDtm1 = !autoSwissAlti3d
+            && !autoAhn
+            && !autoCanElevation
+            && demProvider == EarthGeneratorSettings.DemProvider.AUTO
+            && this.shouldPreferNorwayDtm1(blockX, blockZ, worldScale);
+         if (manualNorwayDtm1 || autoNorwayDtm1) {
+            this.norwayDtm1.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+         }
+
+         if (manualNorwayDtm1) {
+            return;
+         }
+
+         boolean manualJapanGsi = demProvider == EarthGeneratorSettings.DemProvider.JAPANGSI;
+         boolean autoJapanGsi = !autoSwissAlti3d
+            && !autoAhn
+            && !autoCanElevation
+            && !autoNorwayDtm1
+            && demProvider == EarthGeneratorSettings.DemProvider.AUTO
+            && this.shouldPreferJapanGsi(blockX, blockZ, worldScale);
+         if (manualJapanGsi || autoJapanGsi) {
+            this.japanGsi.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+         }
+
+         if (manualJapanGsi) {
+            return;
+         }
+
+         TellusElevationSource.AutoDecision autoDecision = demProvider == EarthGeneratorSettings.DemProvider.AUTO
+            ? this.autoDecision(blockX, blockZ, worldScale)
+            : TellusElevationSource.AutoDecision.DO_NOT_PREFER;
+         if (autoSwissAlti3d || autoAhn || autoCanElevation || autoNorwayDtm1 || autoJapanGsi) {
+            autoDecision = TellusElevationSource.AutoDecision.DO_NOT_PREFER;
+         }
+
+         if (demProvider == EarthGeneratorSettings.DemProvider.ARCTICDEM || demProvider == EarthGeneratorSettings.DemProvider.AUTO) {
+            if (!autoSwissAlti3d && !autoAhn && !autoCanElevation && !autoNorwayDtm1 && !autoJapanGsi) {
+               this.prefetchPolarDem(blockX, blockZ, worldScale, radius);
+            }
+         }
+
+         if (!autoSwissAlti3d
+            && !autoAhn
+            && !autoCanElevation
+            && !autoNorwayDtm1
+            && !autoJapanGsi
+            && (demProvider == EarthGeneratorSettings.DemProvider.USGS || autoDecision.preferUsgs())) {
+            this.usgs.prefetchTiles(blockX, blockZ, worldScale, radius);
+         }
+
+         if (!autoSwissAlti3d
+            && !autoAhn
+            && !autoCanElevation
+            && !autoNorwayDtm1
+            && !autoJapanGsi
+            && (demProvider == EarthGeneratorSettings.DemProvider.COPERNICUS || autoDecision.preferCopernicus() && !autoDecision.preferUsgs())) {
+            this.copernicus.prefetchTiles(blockX, blockZ, worldScale, radius);
+         }
+
+         boolean autoPolar = demProvider == EarthGeneratorSettings.DemProvider.AUTO && latLon != null && isPolarCoverage(latLon.lat());
+         boolean skipTerrainPrefetch = switch (demProvider) {
+            case SWISSALTI3D, AHN, CANELEVATION, NORWAYDTM1, JAPANGSI, ARCTICDEM, USGS, COPERNICUS -> true;
+            case AUTO -> autoSwissAlti3d || autoAhn || autoCanElevation || autoNorwayDtm1 || autoJapanGsi || autoPolar || autoDecision.preferUsgs()
+               || autoDecision.preferCopernicus();
+            default -> false;
+         };
+         boolean prefetchFallbackTerrain = switch (demProvider) {
+            case SWISSALTI3D, AHN, CANELEVATION, NORWAYDTM1, JAPANGSI, ARCTICDEM, USGS, COPERNICUS -> true;
+            case AUTO -> autoSwissAlti3d
+               || autoAhn
+               || autoCanElevation
+               || autoNorwayDtm1
+               || autoJapanGsi
+               || autoPolar
+               || autoDecision.preferUsgs()
+               || autoDecision.preferCopernicus();
+            default -> false;
+         };
+         if (!skipTerrainPrefetch || prefetchFallbackTerrain) {
+            this.prefetchTerrainTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+         }
+   }
+
+   private void prefetchFilteredTiles(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      int radius,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.SWISSALTI3D) && this.shouldPreferSwissAlti3d(blockX, blockZ, worldScale)) {
+         this.swissAlti3d.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.AHN) && this.shouldPreferAhn(blockX, blockZ, worldScale)) {
+         this.ahn.prefetchTiles(blockX, blockZ, worldScale, radius);
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.CANELEVATION) && this.shouldPreferCanElevation(blockX, blockZ, worldScale)) {
+         this.canElevation.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.NORWAYDTM1) && this.shouldPreferNorwayDtm1(blockX, blockZ, worldScale)) {
+         this.norwayDtm1.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.JAPANGSI) && this.shouldPreferJapanGsi(blockX, blockZ, worldScale)) {
+         this.japanGsi.prefetchTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+      }
+
+      if (demSelection.isEnabled(EarthGeneratorSettings.DemProvider.ARCTICDEM)) {
+         this.prefetchPolarDem(blockX, blockZ, worldScale, radius);
+      }
+
+      TellusElevationSource.AutoDecision autoDecision = this.autoDecision(blockX, blockZ, worldScale);
+      if (autoDecision.preferUsgs() && demSelection.isEnabled(EarthGeneratorSettings.DemProvider.USGS)) {
+         this.usgs.prefetchTiles(blockX, blockZ, worldScale, radius);
+      }
+
+      boolean shouldPrefetchCopernicus = demSelection.copernicusEnabled()
+         && (!demSelection.terrainTilesEnabled() || autoDecision.preferUsgs() || autoDecision.preferCopernicus());
+      if (shouldPrefetchCopernicus) {
+         this.copernicus.prefetchTiles(blockX, blockZ, worldScale, radius);
+      }
+
+      this.prefetchTerrainTiles(blockX, blockZ, worldScale, radius, previewResolutionMeters);
+   }
+
+   private void prefetchTerrainTiles(double blockX, double blockZ, double worldScale, int radius, double previewResolutionMeters) {
+      int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+      if (step > 1) {
+         blockX = downsampleBlock(blockX, step);
+         blockZ = downsampleBlock(blockZ, step);
+      }
+
+      int zoom = Mth.clamp(selectZoom(worldScale), MIN_ZOOM, LAND_MAX_ZOOM);
+      TellusElevationSource.TileKey center = tileKeyForBlock(blockX, blockZ, worldScale, zoom);
+      if (center == null) {
+         return;
+      }
+
+      int tilesPerAxis = 1 << zoom;
+      int clampedRadius = Math.max(0, radius);
+      int minX = Math.max(0, center.x() - clampedRadius);
+      int maxX = Math.min(tilesPerAxis - 1, center.x() + clampedRadius);
+      int minY = Math.max(0, center.y() - clampedRadius);
+      int maxY = Math.min(tilesPerAxis - 1, center.y() + clampedRadius);
+
+      for (int tileY = minY; tileY <= maxY; tileY++) {
+         for (int tileX = minX; tileX <= maxX; tileX++) {
+            this.prefetchTile(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+         }
+      }
+   }
+
+   private void prefetchNormalizedTiles(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      int radius,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      double effectiveResolutionMeters = effectiveSampleResolutionMeters(worldScale, previewResolutionMeters);
+      double projectedX = blockX * worldScale;
+      double projectedZ = blockZ * worldScale;
+      double projectedRadius = Math.max(1, radius) * TILE_SIZE * worldScale;
+      NORMALIZED_CACHE.prefetchRange(
+         projectedX - projectedRadius,
+         projectedZ - projectedRadius,
+         projectedX + projectedRadius,
+         projectedZ + projectedRadius,
+         effectiveResolutionMeters,
+         demSelection,
+         true,
+         this::buildNormalizedTile
+      );
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleDiagnosticFromNormalizedCache(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters
+   ) {
+      double effectiveResolutionMeters = effectiveSampleResolutionMeters(worldScale, previewResolutionMeters);
+      NormalizedElevationTileSample sample = NORMALIZED_CACHE.sample(
+         blockX * worldScale, blockZ * worldScale, effectiveResolutionMeters, demSelection, highResOcean, this::buildNormalizedTile
+      );
+      return diagnostic(sample.elevationMeters(), sample.primaryProvider(), sample.providerMask(), sample.resolutionMeters());
+   }
+
+   private NormalizedElevationTile buildNormalizedTile(NormalizedElevationTileKey key) {
+      this.prefetchNormalizedIngestSources(key);
+      ShortRaster heights = ShortRaster.create(NormalizedElevationTileKey.TILE_SIZE, NormalizedElevationTileKey.TILE_SIZE);
+      int sampleCount = NormalizedElevationTileKey.TILE_SIZE * NormalizedElevationTileKey.TILE_SIZE;
+      byte[] primaryProviders = new byte[sampleCount];
+      byte[] blendedFlags = new byte[TellusElevationProvenance.bitSetLength(sampleCount)];
+      int providerMask = 0;
+      double sampleResolutionMeters = key.sampleResolutionMeters();
+
+      for (int localZ = 0; localZ < NormalizedElevationTileKey.TILE_SIZE; localZ++) {
+         for (int localX = 0; localX < NormalizedElevationTileKey.TILE_SIZE; localX++) {
+            double projectedX = key.sampleProjectedX(localX);
+            double projectedZ = key.sampleProjectedZ(localZ);
+            double pseudoBlockX = projectedX / sampleResolutionMeters;
+            double pseudoBlockZ = projectedZ / sampleResolutionMeters;
+            TellusElevationSource.ElevationDiagnostic diagnostic = this.sampleDiagnosticFromProviders(
+               pseudoBlockX, pseudoBlockZ, sampleResolutionMeters, key.highResOcean(), key.demSelection(), sampleResolutionMeters
+            );
+            int sampleIndex = localX + localZ * NormalizedElevationTileKey.TILE_SIZE;
+            double elevationMeters = Double.isFinite(diagnostic.elevation()) ? diagnostic.elevation() : 0.0;
+            int roundedElevation = Mth.clamp((int)Math.round(elevationMeters), (int)Short.MIN_VALUE, (int)Short.MAX_VALUE);
+            heights.set(localX, localZ, (short)roundedElevation);
+            primaryProviders[sampleIndex] = (byte)diagnostic.primaryProvider().ordinal();
+            providerMask |= diagnostic.providerMask();
+            if (diagnostic.usesMultipleProviders()) {
+               blendedFlags[sampleIndex >> 3] = (byte)(blendedFlags[sampleIndex >> 3] | 1 << (sampleIndex & 7));
+            }
+         }
+      }
+
+      return new NormalizedElevationTile(
+         key,
+         heights,
+         new TellusElevationProvenance(
+            NormalizedElevationTileKey.TILE_SIZE, NormalizedElevationTileKey.TILE_SIZE, providerMask, primaryProviders, blendedFlags
+         )
+      );
+   }
+
+   private void prefetchNormalizedIngestSources(NormalizedElevationTileKey key) {
+      double sampleResolutionMeters = key.sampleResolutionMeters();
+      double centerBlockX = key.sampleProjectedX(NormalizedElevationTileKey.TILE_SIZE / 2) / sampleResolutionMeters;
+      double centerBlockZ = key.sampleProjectedZ(NormalizedElevationTileKey.TILE_SIZE / 2) / sampleResolutionMeters;
+
+      try {
+         this.prefetchTilesFromProviders(centerBlockX, centerBlockZ, sampleResolutionMeters, 1, key.demSelection(), sampleResolutionMeters);
+      } catch (RuntimeException error) {
+         Tellus.LOGGER.debug("Failed to prefetch ingest sources for normalized elevation tile {}", key, error);
+      }
+   }
+
+   private void compareNormalizedElevation(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters,
+      double normalizedElevationMeters
+   ) {
+      if (!NORMALIZED_COMPARE) {
+         return;
+      }
+
+      double providerElevationMeters = this.sampleElevationMetersFromProviders(
+         blockX, blockZ, worldScale, highResOcean, demSelection, previewResolutionMeters
+      );
+      if (Math.abs(providerElevationMeters - normalizedElevationMeters) > 1.0) {
+         this.logNormalizedMismatch(blockX, blockZ, worldScale, demSelection, previewResolutionMeters, normalizedElevationMeters, providerElevationMeters);
+      }
+   }
+
+   private void logNormalizedMismatch(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      EarthGeneratorSettings.DemSelection demSelection,
+      double previewResolutionMeters,
+      double normalizedElevationMeters,
+      double providerElevationMeters
+   ) {
+      int logged = NORMALIZED_COMPARE_LOGGED.getAndIncrement();
+      if (logged < NORMALIZED_COMPARE_LOG_LIMIT) {
+         Tellus.LOGGER.warn(
+            "Normalized elevation mismatch at {},{} scale={} selection={} resolution={} normalized={} provider={}",
+            new Object[]{
+               blockX,
+               blockZ,
+               worldScale,
+               demSelection.fingerprint(),
+               previewResolutionMeters,
+               normalizedElevationMeters,
+               providerElevationMeters
+            }
+         );
+      }
+   }
+
+   public static boolean usesPolarDem(EarthGeneratorSettings.DemSelection demSelection) {
+      return demSelection != null && demSelection.usesPolarDem();
+   }
+
+   public static double remaBoundaryBlockZ(double worldScale) {
+      return worldScale > 0.0 ? EarthProjection.latToBlockZ(POLAR_SOUTH_MAX_LAT, worldScale) : Double.POSITIVE_INFINITY;
+   }
+
+   private double sampleAutomaticMeters(double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters) {
+      return this.sampleAutomaticMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters, true);
+   }
+
+   private double sampleAutomaticMeters(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters, boolean allowJapanGsi
+   ) {
+      SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (swiss.usable()) {
+         return swiss.elevation();
+      }
+
+      AhnElevationSource.Sample ahn = this.ahn.sample(blockX, blockZ, worldScale);
+      if (ahn.usable()) {
+         return ahn.elevation();
+      }
+
+      CanElevationSource.Sample canada = this.canElevation.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (canada.usable()) {
+         return canada.elevation();
+      }
+
+      NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (norway.usable()) {
+         return norway.elevation();
+      }
+
+      if (allowJapanGsi) {
+         JapanGsiElevationSource.Sample japan = this.japanGsi.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (japan.usable()) {
+            return japan.elevation();
+         }
+      }
+
+      TellusElevationSource.PolarDemSample polar = this.samplePolarDem(blockX, blockZ, worldScale);
+      if (polar.usable()) {
+         return polar.elevation();
+      }
+
+      TellusElevationSource.AutoDecision decision = this.autoDecision(blockX, blockZ, worldScale);
+      if (decision.preferUsgs()) {
+         double usgsSample = this.sampleUsgsMetersWithFallback(blockX, blockZ, worldScale, highResOcean, decision.landMaskSample());
+         if (!Double.isNaN(usgsSample)) {
+            return usgsSample;
+         }
+      }
+
+      if (decision.preferTerrainTiles()) {
+         return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean);
+      }
+
+      if (decision.preferCopernicus()) {
+         double copernicusSample = this.sampleCopernicusPreferredMeters(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), false
+         );
+         if (!Double.isNaN(copernicusSample)) {
+            return copernicusSample;
+         }
+      }
+
+      return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean);
+   }
+
+   private double sampleAutomaticMetersLocalOnly(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters
+   ) {
+      return this.sampleAutomaticMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters, true);
+   }
+
+   private double sampleAutomaticMetersLocalOnly(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters, boolean allowJapanGsi
+   ) {
+      SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (swiss.usable()) {
+         return swiss.elevation();
+      }
+
+      AhnElevationSource.Sample ahn = this.ahn.sampleLocalOnly(blockX, blockZ, worldScale);
+      if (ahn.usable()) {
+         return ahn.elevation();
+      }
+
+      CanElevationSource.Sample canada = this.canElevation.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (canada.usable()) {
+         return canada.elevation();
+      }
+
+      NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (norway.usable()) {
+         return norway.elevation();
+      }
+
+      if (allowJapanGsi) {
+         JapanGsiElevationSource.Sample japan = this.japanGsi.sampleLocalOnly(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (japan.usable()) {
+            return japan.elevation();
+         }
+      }
+
+      TellusElevationSource.PolarDemSample polar = this.samplePolarDemLocalOnly(blockX, blockZ, worldScale);
+      if (polar.usable()) {
+         return polar.elevation();
+      }
+
+      TellusElevationSource.AutoDecision decision = this.autoDecisionLocalOnly(blockX, blockZ, worldScale);
+      if (decision.preferUsgs()) {
+         double usgsSample = this.sampleUsgsMetersWithFallbackLocalOnly(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), previewResolutionMeters
+         );
+         if (!Double.isNaN(usgsSample)) {
+            return usgsSample;
+         }
+      }
+
+      if (decision.preferTerrainTiles()) {
+         return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+      }
+
+      if (decision.preferCopernicus()) {
+         double copernicusSample = this.sampleCopernicusPreferredMetersLocalOnly(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), false, previewResolutionMeters
+         );
+         if (!Double.isNaN(copernicusSample)) {
+            return copernicusSample;
+         }
+      }
+
+      return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleAutomaticDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters
+   ) {
+      return this.sampleAutomaticDiagnostic(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters, true);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleAutomaticDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters, boolean allowJapanGsi
+   ) {
+      SwissAlti3dElevationSource.Sample swiss = this.swissAlti3d.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (swiss.usable()) {
+         return diagnostic(swiss.elevation(), swiss.usage(), swiss.usage().bit(), swiss.resolutionMeters());
+      }
+
+      AhnElevationSource.Sample ahn = this.ahn.sample(blockX, blockZ, worldScale);
+      if (ahn.usable()) {
+         return diagnostic(ahn.elevation(), ahn.usage(), ahn.usage().bit(), ahn.resolutionMeters());
+      }
+
+      CanElevationSource.Sample canada = this.canElevation.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (canada.usable()) {
+         return diagnostic(canada.elevation(), canada.usage(), canada.usage().bit(), canada.resolutionMeters());
+      }
+
+      NorwayDtm1ElevationSource.Sample norway = this.norwayDtm1.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+      if (norway.usable()) {
+         return diagnostic(norway.elevation(), norway.usage(), norway.usage().bit(), norway.resolutionMeters());
+      }
+
+      if (allowJapanGsi) {
+         JapanGsiElevationSource.Sample japan = this.japanGsi.sample(blockX, blockZ, worldScale, previewResolutionMeters);
+         if (japan.usable()) {
+            return diagnostic(japan.elevation(), japan.usage(), japan.usage().bit(), japan.resolutionMeters());
+         }
+      }
+
+      TellusElevationSource.PolarDemSample polar = this.samplePolarDem(blockX, blockZ, worldScale);
+      if (polar.usable()) {
+         return diagnostic(polar.elevation(), polar.usage());
+      }
+
+      TellusElevationSource.AutoDecision decision = this.autoDecision(blockX, blockZ, worldScale);
+      if (decision.preferUsgs()) {
+         TellusElevationSource.ElevationDiagnostic usgsSample = this.sampleUsgsMetersWithFallbackDiagnostic(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample()
+         );
+         if (!Double.isNaN(usgsSample.elevation())) {
+            return usgsSample;
+         }
+      }
+
+      if (decision.preferTerrainTiles()) {
+         return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean);
+      }
+
+      if (decision.preferCopernicus()) {
+         TellusElevationSource.ElevationDiagnostic copernicusSample = this.sampleCopernicusPreferredDiagnostic(
+            blockX, blockZ, worldScale, highResOcean, decision.landMaskSample(), false
+         );
+         if (!Double.isNaN(copernicusSample.elevation())) {
+            return copernicusSample;
+         }
+      }
+
+      return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean);
+   }
+
+   private boolean shouldPreferSwissAlti3d(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      return latLon != null && this.swissAlti3d.isLikelyInCoverage(latLon.lat(), latLon.lon());
+   }
+
+   private boolean shouldPreferAhn(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      return latLon != null && this.ahn.isLikelyInCoverage(latLon.lat(), latLon.lon());
+   }
+
+   private boolean shouldPreferCanElevation(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      return latLon != null && this.canElevation.isLikelyInCoverage(latLon.lat(), latLon.lon());
+   }
+
+   private boolean shouldPreferNorwayDtm1(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      return latLon != null && this.norwayDtm1.isLikelyInCoverage(latLon.lat(), latLon.lon());
+   }
+
+   private boolean shouldPreferJapanGsi(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      return latLon != null && this.japanGsi.isLikelyInCoverage(latLon.lat(), latLon.lon());
+   }
+
+   private boolean shouldPreferTerrainTilesOverCopernicus(double lat, double lon) {
+      double terrainResolutionMeters = this.terrainResolutionIndex.lookupResolutionMeters(lat, lon);
+      return Double.isFinite(terrainResolutionMeters) && terrainResolutionMeters > 0.0 && terrainResolutionMeters < RESOLUTION_METERS;
+   }
+
+   private TellusElevationSource.PolarDemSample samplePolarDem(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      if (latLon == null) {
+         return TellusElevationSource.PolarDemSample.none();
+      } else if (latLon.lat() >= POLAR_NORTH_MIN_LAT) {
+         double arctic = this.arcticDem.sampleElevationMeters(blockX, blockZ, worldScale);
+         return !Double.isNaN(arctic)
+            ? new TellusElevationSource.PolarDemSample(arctic, TellusElevationSource.DemUsage.ARCTICDEM)
+            : TellusElevationSource.PolarDemSample.none();
+      } else if (latLon.lat() <= POLAR_SOUTH_MAX_LAT) {
+         double rema = this.rema.sampleElevationMeters(blockX, blockZ, worldScale);
+         return !Double.isNaN(rema)
+            ? new TellusElevationSource.PolarDemSample(rema, TellusElevationSource.DemUsage.REMA)
+            : TellusElevationSource.PolarDemSample.none();
+      } else {
+         return TellusElevationSource.PolarDemSample.none();
+      }
+   }
+
+   private TellusElevationSource.PolarDemSample samplePolarDemLocalOnly(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      if (latLon == null) {
+         return TellusElevationSource.PolarDemSample.none();
+      } else if (latLon.lat() >= POLAR_NORTH_MIN_LAT) {
+         double arctic = this.arcticDem.sampleElevationMetersLocalOnly(blockX, blockZ, worldScale);
+         return !Double.isNaN(arctic)
+            ? new TellusElevationSource.PolarDemSample(arctic, TellusElevationSource.DemUsage.ARCTICDEM)
+            : TellusElevationSource.PolarDemSample.none();
+      } else if (latLon.lat() <= POLAR_SOUTH_MAX_LAT) {
+         double rema = this.rema.sampleElevationMetersLocalOnly(blockX, blockZ, worldScale);
+         return !Double.isNaN(rema)
+            ? new TellusElevationSource.PolarDemSample(rema, TellusElevationSource.DemUsage.REMA)
+            : TellusElevationSource.PolarDemSample.none();
+      } else {
+         return TellusElevationSource.PolarDemSample.none();
+      }
+   }
+
+   private void prefetchPolarDem(double blockX, double blockZ, double worldScale, int radius) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      if (latLon != null) {
+         if (latLon.lat() >= POLAR_NORTH_MIN_LAT) {
+            this.arcticDem.prefetchTiles(blockX, blockZ, worldScale, radius);
+         } else if (latLon.lat() <= POLAR_SOUTH_MAX_LAT) {
+            this.rema.prefetchTiles(blockX, blockZ, worldScale, radius);
+         }
+      }
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleUsgsMetersWithFallbackDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean
+   ) {
+      TellusLandMaskSource.LandMaskSample landMaskSample = this.landMask.sampleLandMask(blockX, blockZ, worldScale);
+      return this.sampleUsgsMetersWithFallbackDiagnostic(blockX, blockZ, worldScale, highResOcean, landMaskSample);
+   }
+
+   private double sampleUsgsMetersWithFallback(double blockX, double blockZ, double worldScale, boolean highResOcean) {
+      TellusLandMaskSource.LandMaskSample landMaskSample = this.landMask.sampleLandMask(blockX, blockZ, worldScale);
+      return this.sampleUsgsMetersWithFallback(blockX, blockZ, worldScale, highResOcean, landMaskSample);
+   }
+
+   private double sampleUsgsMetersWithFallbackLocalOnly(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters
+   ) {
+      TellusLandMaskSource.LandMaskSample landMaskSample = this.landMask.sampleLandMaskLocalOnly(blockX, blockZ, worldScale);
+      return this.sampleUsgsMetersWithFallbackLocalOnly(blockX, blockZ, worldScale, highResOcean, landMaskSample, previewResolutionMeters);
+   }
+
+   private double sampleUsgsMetersWithFallback(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, TellusLandMaskSource.LandMaskSample landMaskSample
+   ) {
+      double sample = this.sampleUsgsPreferredMeters(blockX, blockZ, worldScale, highResOcean, landMaskSample);
+      return !Double.isNaN(sample)
+         ? sample
+         : this.sampleCopernicusPreferredMeters(blockX, blockZ, worldScale, highResOcean, landMaskSample, true);
+   }
+
+   private double sampleUsgsMetersWithFallbackLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      TellusLandMaskSource.LandMaskSample landMaskSample,
+      double previewResolutionMeters
+   ) {
+      double sample = this.sampleUsgsPreferredMetersLocalOnly(
+         blockX, blockZ, worldScale, highResOcean, landMaskSample, previewResolutionMeters
+      );
+      return !Double.isNaN(sample)
+         ? sample
+         : this.sampleCopernicusPreferredMetersLocalOnly(
+            blockX, blockZ, worldScale, highResOcean, landMaskSample, true, previewResolutionMeters
+         );
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleUsgsMetersWithFallbackDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, TellusLandMaskSource.LandMaskSample landMaskSample
+   ) {
+      TellusElevationSource.ElevationDiagnostic sample = this.sampleUsgsPreferredDiagnostic(blockX, blockZ, worldScale, highResOcean, landMaskSample);
+      return !Double.isNaN(sample.elevation())
+         ? sample
+         : this.sampleCopernicusPreferredDiagnostic(blockX, blockZ, worldScale, highResOcean, landMaskSample, true);
+   }
+
+   private double sampleUsgsPreferredMeters(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, TellusLandMaskSource.LandMaskSample landMaskSample
+   ) {
+      if (landMaskSample.known() && !landMaskSample.land()) {
+         return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean);
+      } else {
+         double sample = this.usgs.sampleElevationMeters(blockX, blockZ, worldScale);
+         if (Double.isNaN(sample)) {
+            return Double.NaN;
+         } else if (sample <= 0.0 && highResOcean && !landMaskSample.known()) {
+            return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean);
+         } else {
+            return sample;
+         }
+      }
+   }
+
+   private double sampleUsgsPreferredMetersLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      TellusLandMaskSource.LandMaskSample landMaskSample,
+      double previewResolutionMeters
+   ) {
+      if (landMaskSample.known() && !landMaskSample.land()) {
+         return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+      } else {
+         double sample = this.usgs.sampleElevationMetersLocalOnly(blockX, blockZ, worldScale);
+         if (Double.isNaN(sample)) {
+            return Double.NaN;
+         } else if (sample <= 0.0 && highResOcean && !landMaskSample.known()) {
+            return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+         } else {
+            return sample;
+         }
+      }
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleUsgsPreferredDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, TellusLandMaskSource.LandMaskSample landMaskSample
+   ) {
+      if (landMaskSample.known() && !landMaskSample.land()) {
+         return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean);
+      } else {
+         double sample = this.usgs.sampleElevationMeters(blockX, blockZ, worldScale);
+         if (Double.isNaN(sample)) {
+            return diagnostic(Double.NaN, TellusElevationSource.DemUsage.USGS);
+         } else if (sample <= 0.0 && highResOcean && !landMaskSample.known()) {
+            return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean);
+         } else {
+            return diagnostic(sample, TellusElevationSource.DemUsage.USGS);
+         }
+      }
+   }
+
+   private double sampleCopernicusPreferredMeters(double blockX, double blockZ, double worldScale, boolean highResOcean) {
+      return this.sampleCopernicusPreferredMeters(
+         blockX, blockZ, worldScale, highResOcean, this.landMask.sampleLandMask(blockX, blockZ, worldScale), true
+      );
+   }
+
+   private double sampleCopernicusPreferredMetersLocalOnly(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters
+   ) {
+      return this.sampleCopernicusPreferredMetersLocalOnly(
+         blockX, blockZ, worldScale, highResOcean, this.landMask.sampleLandMaskLocalOnly(blockX, blockZ, worldScale), true, previewResolutionMeters
+      );
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleCopernicusPreferredDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean
+   ) {
+      return this.sampleCopernicusPreferredDiagnostic(
+         blockX, blockZ, worldScale, highResOcean, this.landMask.sampleLandMask(blockX, blockZ, worldScale), true
+      );
+   }
+
+   private double sampleCopernicusPreferredMeters(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      TellusLandMaskSource.LandMaskSample landMaskSample,
+      boolean terrainLandFallback
+   ) {
+      if (landMaskSample.known() && !landMaskSample.land()) {
+         return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean);
+      } else {
+         double sample = this.copernicus.sampleElevationMeters(blockX, blockZ, worldScale);
+         if (Double.isNaN(sample)) {
+            return terrainLandFallback ? this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean) : Double.NaN;
+         } else if (sample <= 0.0 && highResOcean && !landMaskSample.known()) {
+            return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean);
+         } else {
+            return sample;
+         }
+      }
+   }
+
+   private double sampleCopernicusPreferredMetersLocalOnly(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      TellusLandMaskSource.LandMaskSample landMaskSample,
+      boolean terrainLandFallback,
+      double previewResolutionMeters
+   ) {
+      if (landMaskSample.known() && !landMaskSample.land()) {
+         return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+      } else {
+         double sample = this.copernicus.sampleElevationMetersLocalOnly(blockX, blockZ, worldScale);
+         if (Double.isNaN(sample)) {
+            return terrainLandFallback ? this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters) : Double.NaN;
+         } else if (sample <= 0.0 && highResOcean && !landMaskSample.known()) {
+            return this.sampleTerrariumMetersLocalOnly(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters);
+         } else {
+            return sample;
+         }
+      }
+   }
+
+   private TellusElevationSource.ElevationDiagnostic sampleCopernicusPreferredDiagnostic(
+      double blockX,
+      double blockZ,
+      double worldScale,
+      boolean highResOcean,
+      TellusLandMaskSource.LandMaskSample landMaskSample,
+      boolean terrainLandFallback
+   ) {
+      if (landMaskSample.known() && !landMaskSample.land()) {
+         return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean);
+      } else {
+         double sample = this.copernicus.sampleElevationMeters(blockX, blockZ, worldScale);
+         if (Double.isNaN(sample)) {
+            return terrainLandFallback
+               ? this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean)
+               : diagnostic(Double.NaN, TellusElevationSource.DemUsage.COPERNICUS);
+         } else if (sample <= 0.0 && highResOcean && !landMaskSample.known()) {
+            return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean);
+         } else {
+            return diagnostic(sample, TellusElevationSource.DemUsage.COPERNICUS);
+         }
+      }
+   }
+
+   private TellusElevationSource.AutoDecision autoDecision(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      if (latLon == null) {
+         return TellusElevationSource.AutoDecision.DO_NOT_PREFER;
+      } else {
+         boolean inUsgsRegion = isUsgsPreferredRegion(latLon.lat(), latLon.lon());
+         boolean preferTerrainTiles = this.shouldPreferTerrainTilesOverCopernicus(latLon.lat(), latLon.lon());
+         boolean preferUsgs = inUsgsRegion;
+         boolean preferCopernicus = !preferUsgs && !preferTerrainTiles;
+
+         TellusLandMaskSource.LandMaskSample landMaskSample = this.landMask.sampleLandMask(blockX, blockZ, worldScale);
+         return !landMaskSample.known() || landMaskSample.land()
+            ? new TellusElevationSource.AutoDecision(preferUsgs, preferTerrainTiles, preferCopernicus, landMaskSample)
+            : TellusElevationSource.AutoDecision.DO_NOT_PREFER;
+      }
+   }
+
+   private TellusElevationSource.AutoDecision autoDecisionLocalOnly(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      if (latLon == null) {
+         return TellusElevationSource.AutoDecision.DO_NOT_PREFER;
+      } else {
+         boolean inUsgsRegion = isUsgsPreferredRegion(latLon.lat(), latLon.lon());
+         boolean preferTerrainTiles = this.shouldPreferTerrainTilesOverCopernicus(latLon.lat(), latLon.lon());
+         boolean preferUsgs = inUsgsRegion;
+         boolean preferCopernicus = !preferUsgs && !preferTerrainTiles;
+
+         TellusLandMaskSource.LandMaskSample landMaskSample = this.landMask.sampleLandMaskLocalOnly(blockX, blockZ, worldScale);
+         return !landMaskSample.known() || landMaskSample.land()
+            ? new TellusElevationSource.AutoDecision(preferUsgs, preferTerrainTiles, preferCopernicus, landMaskSample)
+            : TellusElevationSource.AutoDecision.DO_NOT_PREFER;
+      }
+   }
+
+   private static boolean isUsgsPreferredRegion(double lat, double lon) {
+      return isContiguousUsRegion(lat, lon) || isAlaskaRegion(lat, lon) || isHawaiiRegion(lat, lon) || isPuertoRicoRegion(lat, lon);
+   }
+
+   private static boolean isContiguousUsRegion(double lat, double lon) {
+      return lat >= 24.0 && lat <= 49.8 && lon >= -125.0 && lon <= -66.0;
+   }
+
+   private static boolean isAlaskaRegion(double lat, double lon) {
+      return lat >= 51.0 && lat <= 72.8 && lon >= -170.5 && lon <= -129.0;
+   }
+
+   private static boolean isHawaiiRegion(double lat, double lon) {
+      return lat >= 18.5 && lat <= 22.7 && lon >= -160.8 && lon <= -154.2;
+   }
+
+   private static boolean isPuertoRicoRegion(double lat, double lon) {
+      return lat >= 17.7 && lat <= 18.7 && lon >= -67.5 && lon <= -65.0;
+   }
+
+   private static boolean isPolarCoverage(double lat) {
+      return lat >= POLAR_NORTH_MIN_LAT || lat <= POLAR_SOUTH_MAX_LAT;
+   }
+
+   private double sampleTerrariumMeters(double blockX, double blockZ, double worldScale, boolean highResOcean) {
+      return this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, worldScale);
+   }
+
+   private double sampleTerrariumMetersLocalOnly(double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters) {
+      int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+      if (step > 1) {
+         blockX = downsampleBlock(blockX, step);
+         blockZ = downsampleBlock(blockZ, step);
+      }
+
+      int zoom = Mth.clamp(selectZoom(worldScale), MIN_ZOOM, LAND_MAX_ZOOM);
+      double sample = this.sampleAtZoomLocalOnly(blockX, blockZ, worldScale, zoom);
+      if (!Double.isNaN(sample)) {
+         if (sample <= 0.0 && highResOcean) {
+            double oceanSample = this.sampleAtZoomLocalOnly(blockX, blockZ, worldScale, OCEAN_MAX_ZOOM);
+            if (!Double.isNaN(oceanSample)) {
+               return oceanSample;
+            }
+         }
+
+         return sample;
+      } else {
+         double oceanSample = this.sampleAtZoomLocalOnly(blockX, blockZ, worldScale, OCEAN_MAX_ZOOM);
+         return !Double.isNaN(oceanSample) ? oceanSample : 0.0;
+      }
+   }
+
+   private double sampleTerrariumMetersMemoryOnly(double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters) {
+      int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+      if (step > 1) {
+         blockX = downsampleBlock(blockX, step);
+         blockZ = downsampleBlock(blockZ, step);
+      }
+
+      int zoom = Mth.clamp(selectZoom(worldScale), MIN_ZOOM, LAND_MAX_ZOOM);
+      double sample = this.sampleAtZoomMemoryOnly(blockX, blockZ, worldScale, zoom);
+      if (!Double.isNaN(sample)) {
+         if (sample <= 0.0 && highResOcean) {
+            double oceanSample = this.sampleAtZoomMemoryOnly(blockX, blockZ, worldScale, OCEAN_MAX_ZOOM);
+            if (!Double.isNaN(oceanSample)) {
+               return oceanSample;
+            }
+         }
+
+         return sample;
+      } else {
+         double oceanSample = this.sampleAtZoomMemoryOnly(blockX, blockZ, worldScale, OCEAN_MAX_ZOOM);
+         return oceanSample;
+      }
+   }
+
+   private TellusElevationSource.ElevationDiagnostic terrainTilesDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean
+   ) {
+      return this.terrainTilesDiagnostic(blockX, blockZ, worldScale, highResOcean, worldScale);
+   }
+
+   private TellusElevationSource.ElevationDiagnostic terrainTilesDiagnostic(
+      double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters
+   ) {
+      return diagnostic(
+         this.sampleTerrariumMeters(blockX, blockZ, worldScale, highResOcean, previewResolutionMeters),
+         TellusElevationSource.DemUsage.TERRAIN_TILES,
+         TellusElevationSource.DemUsage.TERRAIN_TILES.bit(),
+         this.terrainTilesResolutionMeters(blockX, blockZ, worldScale)
+      );
+   }
+
+   private double terrainTilesResolutionMeters(double blockX, double blockZ, double worldScale) {
+      TellusElevationSource.LatLon latLon = toLatLon(blockX, blockZ, worldScale);
+      if (latLon == null) {
+         return TellusElevationSource.DemUsage.TERRAIN_TILES.nominalResolutionMeters();
+      } else {
+         double resolutionMeters = this.terrainResolutionIndex.lookupResolutionMeters(latLon.lat(), latLon.lon());
+         return Double.isFinite(resolutionMeters) && resolutionMeters > 0.0
+            ? resolutionMeters
+            : TellusElevationSource.DemUsage.TERRAIN_TILES.nominalResolutionMeters();
+      }
+   }
+
+   private double sampleTerrariumMeters(double blockX, double blockZ, double worldScale, boolean highResOcean, double previewResolutionMeters) {
+      int step = downsampleStep(worldScale, RESOLUTION_METERS, previewResolutionMeters);
+      if (step > 1) {
+         blockX = downsampleBlock(blockX, step);
+         blockZ = downsampleBlock(blockZ, step);
+      }
+
+      int zoom = Mth.clamp(selectZoom(worldScale), MIN_ZOOM, LAND_MAX_ZOOM);
+      double sample = this.sampleAtZoom(blockX, blockZ, worldScale, zoom);
+      if (!Double.isNaN(sample)) {
+         if (sample <= 0.0 && highResOcean) {
+            double oceanSample = this.sampleAtZoom(blockX, blockZ, worldScale, OCEAN_MAX_ZOOM);
+            if (!Double.isNaN(oceanSample)) {
+               return oceanSample;
+            }
+         }
+
+         return sample;
+      } else {
+         double oceanSample = this.sampleAtZoom(blockX, blockZ, worldScale, OCEAN_MAX_ZOOM);
+         return !Double.isNaN(oceanSample) ? oceanSample : 0.0;
+      }
+   }
+
+   private double sampleAtZoom(double blockX, double blockZ, double worldScale, int zoom) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      if (!(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON)) {
+         double latRad = Math.toRadians(lat);
+         double n = Math.pow(2.0, zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+         if (!(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n)) {
+            int tileX = Mth.floor(x);
+            int tileY = Mth.floor(y);
+            ShortRaster raster = this.getTile(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+            if (raster == null) {
+               return Double.NaN;
+            } else {
+               double globalX = x * TILE_SIZE;
+               double globalY = y * TILE_SIZE;
+               return this.sampleBilinearAcrossTiles(zoom, globalX, globalY, tileX, tileY, raster);
+            }
+         } else {
+            return Double.NaN;
+         }
+      } else {
+         return Double.NaN;
+      }
+   }
+
+   private double sampleAtZoomLocalOnly(double blockX, double blockZ, double worldScale, int zoom) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      if (!(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON)) {
+         double latRad = Math.toRadians(lat);
+         double n = Math.pow(2.0, zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+         if (!(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n)) {
+            int tileX = Mth.floor(x);
+            int tileY = Mth.floor(y);
+            ShortRaster raster = this.getTileLocalOnly(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+            if (raster == null) {
+               return Double.NaN;
+            } else {
+               double globalX = x * TILE_SIZE;
+               double globalY = y * TILE_SIZE;
+               return this.sampleBilinearAcrossTilesLocalOnly(zoom, globalX, globalY, tileX, tileY, raster);
+            }
+         } else {
+            return Double.NaN;
+         }
+      } else {
+         return Double.NaN;
+      }
+   }
+
+   private double sampleAtZoomMemoryOnly(double blockX, double blockZ, double worldScale, int zoom) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      if (!(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON)) {
+         double latRad = Math.toRadians(lat);
+         double n = Math.pow(2.0, zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+         if (!(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n)) {
+            int tileX = Mth.floor(x);
+            int tileY = Mth.floor(y);
+            ShortRaster raster = this.getTileMemoryOnly(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+            if (raster == null) {
+               return Double.NaN;
+            } else {
+               double globalX = x * TILE_SIZE;
+               double globalY = y * TILE_SIZE;
+               return this.sampleBilinearAcrossTilesMemoryOnly(zoom, globalX, globalY, tileX, tileY, raster);
+            }
+         } else {
+            return Double.NaN;
+         }
+      } else {
+         return Double.NaN;
+      }
+   }
+
+   private static int downsampleStep(double worldScale, double resolutionMeters, double previewResolutionMeters) {
+      if (!(worldScale > 0.0)) {
+         return 1;
+      } else if (!(effectiveSampleResolutionMeters(worldScale, previewResolutionMeters) >= resolutionMeters)) {
+         return 1;
+      } else {
+         return Math.max(1, Mth.floor(resolutionMeters / worldScale));
+      }
+   }
+
+   private static double downsampleBlock(double blockCoord, int step) {
+      if (step <= 1) {
+         return blockCoord;
+      } else {
+         int block = Mth.floor(blockCoord);
+         int snapped = Math.floorDiv(block, step) * step;
+         return snapped + step * 0.5;
+      }
+   }
+
+   private static TellusElevationSource.TileKey tileKeyForBlock(double blockX, double blockZ, double worldScale, int zoom) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      if (!(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON)) {
+         double latRad = Math.toRadians(lat);
+         double n = Math.pow(2.0, zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+         if (!(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n)) {
+            int tileX = Mth.floor(x);
+            int tileY = Mth.floor(y);
+            return new TellusElevationSource.TileKey(zoom, tileX, tileY);
+         } else {
+            return null;
+         }
+      } else {
+         return null;
+      }
+   }
+
+   private static double effectiveSampleResolutionMeters(double worldScale, double previewResolutionMeters) {
+      return Double.isFinite(previewResolutionMeters) && previewResolutionMeters > 0.0 ? Math.max(worldScale, previewResolutionMeters) : worldScale;
+   }
+
+   private static TellusElevationSource.LatLon toLatLon(double blockX, double blockZ, double worldScale) {
+      double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+      double lon = blockX / blocksPerDegree;
+      double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+      return !(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON) ? new TellusElevationSource.LatLon(lat, lon) : null;
+   }
+
+   private void prefetchTile( TellusElevationSource.TileKey key) {
+      if (this.cache.getIfPresent(key) == null) {
+         try {
+            this.cache.get(key);
+         } catch (Exception var3) {
+            Tellus.LOGGER.debug("Failed to prefetch elevation tile {}", key, var3);
+         }
+      }
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException var4) {
+            return defaultValue;
+         }
+      }
+   }
+
+   private static boolean booleanProperty(String key, boolean defaultValue) {
+      String value = System.getProperty(key);
+      return value == null ? defaultValue : Boolean.parseBoolean(value);
+   }
+
+   private ShortRaster getTile( TellusElevationSource.TileKey key) {
+      try {
+         ShortRaster raster = (ShortRaster)this.cache.get(key);
+         return raster == MISSING_RASTER ? null : raster;
+      } catch (Exception var3) {
+         Tellus.LOGGER.warn("Failed to load elevation tile {}", key, var3);
+         return null;
+      }
+   }
+
+   private ShortRaster getTileLocalOnly(TellusElevationSource.TileKey key) {
+      ShortRaster cached = (ShortRaster)this.cache.getIfPresent(key);
+      if (cached != null) {
+         return cached == MISSING_RASTER ? null : cached;
+      } else {
+         Path cachePath = this.cachePath(key);
+         if (!Files.exists(cachePath)) {
+            return null;
+         } else {
+            try (InputStream input = Files.newInputStream(cachePath)) {
+               ShortRaster raster = readPngRaster(input);
+               this.cache.put(key, raster);
+               return raster;
+            } catch (IOException error) {
+               this.handleInvalidTile(cachePath, key, error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private ShortRaster getTileMemoryOnly(TellusElevationSource.TileKey key) {
+      ShortRaster cached = (ShortRaster)this.cache.getIfPresent(key);
+      return cached == null || cached == MISSING_RASTER ? null : cached;
+   }
+
+   private ShortRaster loadTile( TellusElevationSource.TileKey key) {
+      Path cachePath = this.cachePath(key);
+      if (Files.exists(cachePath)) {
+         try {
+            ShortRaster var15;
+            try (InputStream input = Files.newInputStream(cachePath)) {
+               var15 = readPngRaster(input);
+            }
+
+            return var15;
+         } catch (IOException var13) {
+            this.handleInvalidTile(cachePath, key, var13);
+         }
+      }
+
+      byte[] data;
+      try {
+         data = this.downloadTile(key);
+      } catch (IOException var10) {
+         Tellus.LOGGER.debug("Failed to download elevation tile {}", key, var10);
+         return MISSING_RASTER;
+      }
+
+      if (data == null) {
+         return MISSING_RASTER;
+      } else {
+         this.cacheTile(cachePath, data);
+
+         try {
+            ShortRaster var5;
+            try (InputStream input = new ByteArrayInputStream(data)) {
+               var5 = readPngRaster(input);
+            }
+
+            return var5;
+         } catch (IOException var9) {
+            this.handleInvalidTile(cachePath, key, var9);
+            return MISSING_RASTER;
+         }
+      }
+   }
+
+   private byte[] downloadTile(TellusElevationSource.TileKey key) throws IOException {
+      URI uri = URI.create(String.format("%s/%d/%d/%d.png", ENDPOINT, key.zoom(), key.x(), key.y()));
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      try {
+         connection.setConnectTimeout(8000);
+         connection.setReadTimeout(8000);
+         connection.setRequestProperty("User-Agent", "Tellus/1.0 (Minecraft Mod)");
+         if (connection.getResponseCode() == 404) {
+            return null;
+         } else {
+            DownloadProgressReporter.requestStarted(connection.getContentLengthLong());
+
+            byte[] var5;
+            try (InputStream input = Objects.requireNonNull(connection.getInputStream(), "elevationTileResponse")) {
+               var5 = DownloadProgressReporter.readAllBytesWithProgress(input);
+            } finally {
+               DownloadProgressReporter.requestFinished();
+            }
+
+            return var5;
+         }
+      } finally {
+         connection.disconnect();
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] data) {
+      try {
+         Files.createDirectories(cachePath.getParent());
+         Files.write(cachePath, data);
+      } catch (IOException var4) {
+         Tellus.LOGGER.warn("Failed to cache elevation tile {}", cachePath, var4);
+      }
+   }
+
+   private Path cachePath(TellusElevationSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".png");
+   }
+
+   private void handleInvalidTile(Path cachePath, TellusElevationSource.TileKey key, IOException cause) {
+      try {
+         Files.deleteIfExists(cachePath);
+      } catch (IOException var5) {
+         Tellus.LOGGER.debug("Failed to delete invalid elevation tile cache {}", cachePath, var5);
+      }
+
+      Tellus.LOGGER.debug("Ignoring invalid elevation tile {} at {}", new Object[]{key, cachePath, cause});
+   }
+
+   private double sampleBilinearAcrossTiles(int zoom, double globalX, double globalY, int baseTileX, int baseTileY, ShortRaster baseRaster) {
+      int tilesPerAxis = 1 << zoom;
+      int maxPixel = tilesPerAxis * TILE_SIZE - 1;
+      double clampedX = Mth.clamp(globalX, 0.0, maxPixel);
+      double clampedY = Mth.clamp(globalY, 0.0, maxPixel);
+      int x0 = Mth.floor(clampedX);
+      int y0 = Mth.floor(clampedY);
+      int x1 = Math.min(x0 + 1, maxPixel);
+      int y1 = Math.min(y0 + 1, maxPixel);
+      double dx = clampedX - x0;
+      double dy = clampedY - y0;
+      double v00 = this.samplePixel(zoom, x0, y0, baseTileX, baseTileY, baseRaster);
+      double v10 = this.samplePixel(zoom, x1, y0, baseTileX, baseTileY, baseRaster);
+      double v01 = this.samplePixel(zoom, x0, y1, baseTileX, baseTileY, baseRaster);
+      double v11 = this.samplePixel(zoom, x1, y1, baseTileX, baseTileY, baseRaster);
+      if (!Double.isNaN(v00) && !Double.isNaN(v10) && !Double.isNaN(v01) && !Double.isNaN(v11)) {
+         double lerpX0 = Mth.lerp(dx, v00, v10);
+         double lerpX1 = Mth.lerp(dx, v01, v11);
+         return Mth.lerp(dy, lerpX0, lerpX1);
+      } else {
+         double localX = clampedX - baseTileX * TILE_SIZE;
+         double localY = clampedY - baseTileY * TILE_SIZE;
+         return sampleBilinearLocal(baseRaster, localX, localY);
+      }
+   }
+
+   private double sampleBilinearAcrossTilesLocalOnly(int zoom, double globalX, double globalY, int baseTileX, int baseTileY, ShortRaster baseRaster) {
+      int tilesPerAxis = 1 << zoom;
+      int maxPixel = tilesPerAxis * TILE_SIZE - 1;
+      double clampedX = Mth.clamp(globalX, 0.0, maxPixel);
+      double clampedY = Mth.clamp(globalY, 0.0, maxPixel);
+      int x0 = Mth.floor(clampedX);
+      int y0 = Mth.floor(clampedY);
+      int x1 = Math.min(x0 + 1, maxPixel);
+      int y1 = Math.min(y0 + 1, maxPixel);
+      double dx = clampedX - x0;
+      double dy = clampedY - y0;
+      double v00 = this.samplePixelLocalOnly(zoom, x0, y0, baseTileX, baseTileY, baseRaster);
+      double v10 = this.samplePixelLocalOnly(zoom, x1, y0, baseTileX, baseTileY, baseRaster);
+      double v01 = this.samplePixelLocalOnly(zoom, x0, y1, baseTileX, baseTileY, baseRaster);
+      double v11 = this.samplePixelLocalOnly(zoom, x1, y1, baseTileX, baseTileY, baseRaster);
+      if (!Double.isNaN(v00) && !Double.isNaN(v10) && !Double.isNaN(v01) && !Double.isNaN(v11)) {
+         double lerpX0 = Mth.lerp(dx, v00, v10);
+         double lerpX1 = Mth.lerp(dx, v01, v11);
+         return Mth.lerp(dy, lerpX0, lerpX1);
+      } else {
+         double localX = clampedX - baseTileX * TILE_SIZE;
+         double localY = clampedY - baseTileY * TILE_SIZE;
+         return sampleBilinearLocal(baseRaster, localX, localY);
+      }
+   }
+
+   private double sampleBilinearAcrossTilesMemoryOnly(int zoom, double globalX, double globalY, int baseTileX, int baseTileY, ShortRaster baseRaster) {
+      int tilesPerAxis = 1 << zoom;
+      int maxPixel = tilesPerAxis * TILE_SIZE - 1;
+      double clampedX = Mth.clamp(globalX, 0.0, maxPixel);
+      double clampedY = Mth.clamp(globalY, 0.0, maxPixel);
+      int x0 = Mth.floor(clampedX);
+      int y0 = Mth.floor(clampedY);
+      int x1 = Math.min(x0 + 1, maxPixel);
+      int y1 = Math.min(y0 + 1, maxPixel);
+      double dx = clampedX - x0;
+      double dy = clampedY - y0;
+      double v00 = this.samplePixelMemoryOnly(zoom, x0, y0, baseTileX, baseTileY, baseRaster);
+      double v10 = this.samplePixelMemoryOnly(zoom, x1, y0, baseTileX, baseTileY, baseRaster);
+      double v01 = this.samplePixelMemoryOnly(zoom, x0, y1, baseTileX, baseTileY, baseRaster);
+      double v11 = this.samplePixelMemoryOnly(zoom, x1, y1, baseTileX, baseTileY, baseRaster);
+      if (!Double.isNaN(v00) && !Double.isNaN(v10) && !Double.isNaN(v01) && !Double.isNaN(v11)) {
+         double lerpX0 = Mth.lerp(dx, v00, v10);
+         double lerpX1 = Mth.lerp(dx, v01, v11);
+         return Mth.lerp(dy, lerpX0, lerpX1);
+      } else {
+         return Double.NaN;
+      }
+   }
+
+   private double samplePixel(int zoom, int pixelX, int pixelY, int baseTileX, int baseTileY, ShortRaster baseRaster) {
+      int tileX = Math.floorDiv(pixelX, TILE_SIZE);
+      int tileY = Math.floorDiv(pixelY, TILE_SIZE);
+      ShortRaster raster = tileX == baseTileX && tileY == baseTileY ? baseRaster : this.getTile(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+      if (raster == null) {
+         return Double.NaN;
+      } else {
+         int localX = pixelX - tileX * TILE_SIZE;
+         int localY = pixelY - tileY * TILE_SIZE;
+         return raster.get(localX, localY);
+      }
+   }
+
+   private double samplePixelLocalOnly(int zoom, int pixelX, int pixelY, int baseTileX, int baseTileY, ShortRaster baseRaster) {
+      int tileX = Math.floorDiv(pixelX, TILE_SIZE);
+      int tileY = Math.floorDiv(pixelY, TILE_SIZE);
+      ShortRaster raster = tileX == baseTileX && tileY == baseTileY
+         ? baseRaster
+         : this.getTileLocalOnly(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+      if (raster == null) {
+         return Double.NaN;
+      } else {
+         int localX = pixelX - tileX * TILE_SIZE;
+         int localY = pixelY - tileY * TILE_SIZE;
+         return raster.get(localX, localY);
+      }
+   }
+
+   private double samplePixelMemoryOnly(int zoom, int pixelX, int pixelY, int baseTileX, int baseTileY, ShortRaster baseRaster) {
+      int tileX = Math.floorDiv(pixelX, TILE_SIZE);
+      int tileY = Math.floorDiv(pixelY, TILE_SIZE);
+      ShortRaster raster = tileX == baseTileX && tileY == baseTileY
+         ? baseRaster
+         : this.getTileMemoryOnly(new TellusElevationSource.TileKey(zoom, tileX, tileY));
+      if (raster == null) {
+         return Double.NaN;
+      } else {
+         int localX = pixelX - tileX * TILE_SIZE;
+         int localY = pixelY - tileY * TILE_SIZE;
+         return raster.get(localX, localY);
+      }
+   }
+
+   private static double sampleBilinearLocal(ShortRaster raster, double x, double y) {
+      int maxX = raster.width() - 1;
+      int maxY = raster.height() - 1;
+      int x0 = Mth.clamp(Mth.floor(x), 0, maxX);
+      int y0 = Mth.clamp(Mth.floor(y), 0, maxY);
+      int x1 = Math.min(x0 + 1, maxX);
+      int y1 = Math.min(y0 + 1, maxY);
+      double dx = x - x0;
+      double dy = y - y0;
+      double v00 = raster.get(x0, y0);
+      double v10 = raster.get(x1, y0);
+      double v01 = raster.get(x0, y1);
+      double v11 = raster.get(x1, y1);
+      double lerpX0 = Mth.lerp(dx, v00, v10);
+      double lerpX1 = Mth.lerp(dx, v01, v11);
+      return Mth.lerp(dy, lerpX0, lerpX1);
+   }
+
+   private static int selectZoom(double worldScale) {
+      double zoom = zoomForScale(worldScale);
+      return Math.max((int)Math.round(zoom), 0);
+   }
+
+   private static TellusElevationSource.ElevationDiagnostic diagnostic(double elevation, TellusElevationSource.DemUsage provider) {
+      return new TellusElevationSource.ElevationDiagnostic(elevation, provider, provider.bit(), provider.nominalResolutionMeters());
+   }
+
+   private static TellusElevationSource.ElevationDiagnostic diagnostic(
+      double elevation, TellusElevationSource.DemUsage primaryProvider, int providerMask, double sourceResolutionMeters
+   ) {
+      double resolvedResolution = Double.isFinite(sourceResolutionMeters) && sourceResolutionMeters > 0.0
+         ? sourceResolutionMeters
+         : primaryProvider.nominalResolutionMeters();
+      return new TellusElevationSource.ElevationDiagnostic(elevation, primaryProvider, providerMask, resolvedResolution);
+   }
+
+   private static double zoomForScale(double meters) {
+      return Math.log(EQUATOR_CIRCUMFERENCE / (TILE_SIZE * meters)) / Math.log(2.0);
+   }
+
+   private static ShortRaster readPngRaster(InputStream input) throws IOException {
+      BufferedImage image = ImageIO.read(input);
+      if (image == null) {
+         throw new IOException("Invalid tellus PNG tile");
+      } else {
+         int width = image.getWidth();
+         int height = image.getHeight();
+         ShortRaster raster = ShortRaster.create(width, height);
+
+         for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+               int argb = image.getRGB(x, y);
+               int red = argb >> 16 & 0xFF;
+               int green = argb >> 8 & 0xFF;
+               int blue = argb & 0xFF;
+               double elevation = red * TILE_SIZE + green + blue / (double)TILE_SIZE - 32768.0;
+               raster.set(x, y, (short)Math.round(elevation));
+            }
+         }
+
+         return raster;
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.TERRAIN;
+   }
+
+   @Override
+   public void clearCache() {
+      this.cache.invalidateAll();
+      this.cache.cleanUp();
+   }
+
+   private record TileKey(int zoom, int x, int y) {
+   }
+
+   private record LatLon(double lat, double lon) {
+   }
+
+   private record PolarDemSample(double elevation, TellusElevationSource.DemUsage usage) {
+      private static TellusElevationSource.PolarDemSample none() {
+         return new TellusElevationSource.PolarDemSample(Double.NaN, null);
+      }
+
+      private boolean usable() {
+         return this.usage != null && !Double.isNaN(this.elevation);
+      }
+   }
+
+   public static enum DemUsage {
+      TERRAIN_TILES("terrarium", 1),
+      SWISSALTI3D_05M("swissalti3d_05m", 1 << 1),
+      SWISSALTI3D_2M("swissalti3d_2m", 1 << 2),
+      AHN("ahn", 1 << 3),
+      CANELEVATION_2M("canelevation_2m", 1 << 4),
+      CANELEVATION_30M("canelevation_30m", 1 << 5),
+      NORWAYDTM1("norwaydtm1", 1 << 6),
+      USGS("usgs", 1 << 7),
+      COPERNICUS("copernicus", 1 << 8),
+      HMA("hma", 1 << 9),
+      ARCTICDEM("arcticdem", 1 << 10),
+      REMA("rema", 1 << 11),
+      JAPANGSI("japangsi", 1 << 12);
+
+      private final String providerId;
+      private final int bit;
+
+      private DemUsage(String providerId, int bit) {
+         this.providerId = Objects.requireNonNull(providerId, "providerId");
+         this.bit = bit;
+      }
+
+      public int bit() {
+         return this.bit;
+      }
+
+      public String providerId() {
+         return this.providerId;
+      }
+
+      public double nominalResolutionMeters() {
+         return switch (this) {
+            case TERRAIN_TILES -> 30.0;
+            case SWISSALTI3D_05M -> 0.5;
+            case SWISSALTI3D_2M -> 2.0;
+            case AHN -> 0.5;
+            case CANELEVATION_2M -> 2.0;
+            case CANELEVATION_30M -> 30.0;
+            case NORWAYDTM1 -> 1.0;
+            case USGS -> 10.0;
+            case COPERNICUS -> 30.0;
+            case HMA -> 8.0;
+            case ARCTICDEM -> 2.0;
+            case REMA -> 8.0;
+            case JAPANGSI -> Double.NaN;
+         };
+      }
+
+      public Component label() {
+         return Component.translatable("property.tellus.dem_provider.value." + this.providerId);
+      }
+   }
+
+   public record ElevationDiagnostic(
+      double elevation, TellusElevationSource.DemUsage primaryProvider, int providerMask, double sourceResolutionMeters
+   ) {
+      public ElevationDiagnostic(
+         double elevation, TellusElevationSource.DemUsage primaryProvider, int providerMask, double sourceResolutionMeters
+      ) {
+         this.elevation = elevation;
+         this.primaryProvider = Objects.requireNonNull(primaryProvider, "primaryProvider");
+         this.providerMask = providerMask;
+         this.sourceResolutionMeters = sourceResolutionMeters;
+      }
+
+      public boolean usesMultipleProviders() {
+         return Integer.bitCount(this.providerMask) > 1;
+      }
+
+      public double displayResolutionMeters() {
+         return Double.isFinite(this.sourceResolutionMeters) && this.sourceResolutionMeters > 0.0
+            ? this.sourceResolutionMeters
+            : this.primaryProvider.nominalResolutionMeters();
+      }
+   }
+
+   private record AutoDecision(
+      boolean preferUsgs,
+      boolean preferTerrainTiles,
+      boolean preferCopernicus,
+      TellusLandMaskSource.LandMaskSample landMaskSample
+   ) {
+      private static final TellusElevationSource.AutoDecision DO_NOT_PREFER = new TellusElevationSource.AutoDecision(
+         false, false, false, TellusLandMaskSource.LandMaskSample.unknown()
+      );
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/Usgs3depElevationSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/elevation/Usgs3depElevationSource.java
@@ -1,0 +1,649 @@
+package com.yucareux.tellus.world.data.elevation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.world.data.source.DownloadProgressReporter;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class Usgs3depElevationSource implements TellusCacheHandle {
+   private static final String ENDPOINT = "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer/exportImage";
+   private static final int HTTP_CONNECT_TIMEOUT = 8000;
+   private static final int HTTP_READ_TIMEOUT = 30000;
+   private static final String HTTP_USER_AGENT = "Tellus/1.0 (Minecraft Mod)";
+   private static final double MERCATOR_LIMIT = 20037508.342789244;
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final float FLOAT_NODATA_SENTINEL = -3.0E37F;
+   private static final int TILE_PIXELS = 512;
+   private static final int TAG_IMAGE_WIDTH = 256;
+   private static final int TAG_IMAGE_HEIGHT = 257;
+   private static final int TAG_BITS_PER_SAMPLE = 258;
+   private static final int TAG_COMPRESSION = 259;
+   private static final int TAG_STRIP_OFFSETS = 273;
+   private static final int TAG_SAMPLES_PER_PIXEL = 277;
+   private static final int TAG_ROWS_PER_STRIP = 278;
+   private static final int TAG_STRIP_BYTE_COUNTS = 279;
+   private static final int TAG_TILE_WIDTH = 322;
+   private static final int TAG_TILE_HEIGHT = 323;
+   private static final int TAG_TILE_OFFSETS = 324;
+   private static final int TAG_TILE_BYTE_COUNTS = 325;
+   private static final int TAG_SAMPLE_FORMAT = 339;
+   private static final int TAG_GDAL_NODATA = 42113;
+   private static final int TYPE_ASCII = 2;
+   private static final int TYPE_SHORT = 3;
+   private static final int TYPE_LONG = 4;
+   private static final int TYPE_RATIONAL = 5;
+   private static final int TYPE_FLOAT = 11;
+   private static final int COMPRESSION_NONE = 1;
+   private static final int SAMPLE_FORMAT_IEEE_FLOAT = 3;
+   private static final int MAX_FILE_CACHE = intProperty("tellus.usgs.cacheFiles", 24);
+   private final Path cacheRoot;
+   private final LoadingCache<Usgs3depElevationSource.TileKey, Usgs3depElevationSource.TileRaster> fileCache;
+
+   public Usgs3depElevationSource() {
+      this.cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/elevation-usgs3dep");
+      this.fileCache = CacheBuilder.newBuilder().maximumSize(MAX_FILE_CACHE).build(new CacheLoader<Usgs3depElevationSource.TileKey, Usgs3depElevationSource.TileRaster>() {
+         public Usgs3depElevationSource.TileRaster load(Usgs3depElevationSource.TileKey key) throws Exception {
+            return Usgs3depElevationSource.this.loadTile(key);
+         }
+      });
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean isLikelyInCoverage(double lat, double lon) {
+      return lat >= 14.0 && lat <= 72.6 && lon >= -170.0 && lon <= -60.0;
+   }
+
+   public double sampleElevationMeters(double blockX, double blockZ, double worldScale) {
+      if (worldScale <= 0.0) {
+         return Double.NaN;
+      } else {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleLatLonElevationMeters(lat, lon, worldScale);
+      }
+   }
+
+   public double sampleElevationMetersLocalOnly(double blockX, double blockZ, double worldScale) {
+      if (worldScale <= 0.0) {
+         return Double.NaN;
+      } else {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return this.sampleLatLonElevationMetersLocalOnly(lat, lon, worldScale);
+      }
+   }
+
+   public double sampleLatLonElevationMeters(double lat, double lon, double worldScale) {
+      if (!(lat >= MIN_LAT) || !(lat <= MAX_LAT) || !(lon >= MIN_LON) || !(lon <= MAX_LON)) {
+         return Double.NaN;
+      } else {
+         Usgs3depElevationSource.ResolutionLevel level = Usgs3depElevationSource.ResolutionLevel.forWorldScale(worldScale);
+         double clampedLat = Mth.clamp(lat, MIN_LAT, MAX_LAT);
+         double clampedLon = Mth.clamp(lon, MIN_LON, MAX_LON);
+         double mercatorX = lonToMercatorX(clampedLon);
+         double mercatorY = latToMercatorY(clampedLat);
+         Usgs3depElevationSource.TileKey key = Usgs3depElevationSource.TileKey.forMercator(level, mercatorX, mercatorY);
+         Usgs3depElevationSource.TileRaster tile = this.getTile(key);
+         return tile == null ? Double.NaN : sampleBilinear(tile, mercatorX, mercatorY, key);
+      }
+   }
+
+   public double sampleLatLonElevationMetersLocalOnly(double lat, double lon, double worldScale) {
+      if (!(lat >= MIN_LAT) || !(lat <= MAX_LAT) || !(lon >= MIN_LON) || !(lon <= MAX_LON)) {
+         return Double.NaN;
+      } else {
+         Usgs3depElevationSource.ResolutionLevel level = Usgs3depElevationSource.ResolutionLevel.forWorldScale(worldScale);
+         double clampedLat = Mth.clamp(lat, MIN_LAT, MAX_LAT);
+         double clampedLon = Mth.clamp(lon, MIN_LON, MAX_LON);
+         double mercatorX = lonToMercatorX(clampedLon);
+         double mercatorY = latToMercatorY(clampedLat);
+         Usgs3depElevationSource.TileKey key = Usgs3depElevationSource.TileKey.forMercator(level, mercatorX, mercatorY);
+         Usgs3depElevationSource.TileRaster tile = this.getTileLocalOnly(key);
+         return tile == null ? Double.NaN : sampleBilinear(tile, mercatorX, mercatorY, key);
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      if (!(worldScale <= 0.0) && radius > 0) {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         if (lat >= MIN_LAT && lat <= MAX_LAT && lon >= MIN_LON && lon <= MAX_LON) {
+            Usgs3depElevationSource.ResolutionLevel level = Usgs3depElevationSource.ResolutionLevel.forWorldScale(worldScale);
+            Usgs3depElevationSource.TileKey center = Usgs3depElevationSource.TileKey.forLatLon(level, lat, lon);
+            this.prefetchNeighborhood(center, Math.max(1, radius));
+         }
+      }
+   }
+
+   private void prefetchNeighborhood(Usgs3depElevationSource.TileKey center, int tileRadius) {
+      for (int dy = -tileRadius; dy <= tileRadius; dy++) {
+         for (int dx = -tileRadius; dx <= tileRadius; dx++) {
+            this.prefetchTile(new Usgs3depElevationSource.TileKey(center.level(), center.tileX() + dx, center.tileY() + dy));
+         }
+      }
+   }
+
+   private void prefetchTile(Usgs3depElevationSource.TileKey key) {
+      if (this.fileCache.getIfPresent(key) == null) {
+         try {
+            this.fileCache.get(key);
+         } catch (ExecutionException error) {
+            Tellus.LOGGER.debug("Failed to prefetch USGS 3DEP tile {}", key, error);
+         }
+      }
+   }
+
+   private Usgs3depElevationSource.TileRaster getTile(Usgs3depElevationSource.TileKey key) {
+      try {
+         return this.fileCache.get(key);
+      } catch (ExecutionException error) {
+         Tellus.LOGGER.debug("Failed to load USGS 3DEP tile {}", key, error);
+         return null;
+      }
+   }
+
+   private Usgs3depElevationSource.TileRaster getTileLocalOnly(Usgs3depElevationSource.TileKey key) {
+      Usgs3depElevationSource.TileRaster cached = this.fileCache.getIfPresent(key);
+      if (cached != null) {
+         return cached;
+      } else {
+         Path cachePath = key.cachePath(this.cacheRoot);
+         if (!Files.exists(cachePath)) {
+            return null;
+         } else {
+            try {
+               Usgs3depElevationSource.TileRaster tile = readTiffRaster(Files.readAllBytes(cachePath));
+               Usgs3depElevationSource.TileRaster raced = this.fileCache.asMap().putIfAbsent(key, tile);
+               return raced != null ? raced : tile;
+            } catch (IOException error) {
+               Tellus.LOGGER.debug("Failed to load cached USGS 3DEP tile {}", key, error);
+               return null;
+            }
+         }
+      }
+   }
+
+   private Usgs3depElevationSource.TileRaster loadTile(Usgs3depElevationSource.TileKey key) throws Exception {
+      Path cachePath = key.cachePath(this.cacheRoot);
+      byte[] data;
+      if (Files.exists(cachePath)) {
+         try {
+            data = Files.readAllBytes(cachePath);
+            return readTiffRaster(data);
+         } catch (IOException error) {
+            Files.deleteIfExists(cachePath);
+         }
+      }
+
+      data = this.downloadTile(key);
+      this.writeCacheFile(cachePath, data);
+      return readTiffRaster(data);
+   }
+
+   private byte[] downloadTile(Usgs3depElevationSource.TileKey key) throws IOException {
+      URI uri = URI.create(key.url());
+      HttpURLConnection connection = (HttpURLConnection)uri.toURL().openConnection();
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT);
+      connection.setRequestProperty("User-Agent", HTTP_USER_AGENT);
+
+      try {
+         int status = connection.getResponseCode();
+         if (status != 200) {
+            throw new IOException("Unexpected USGS 3DEP status " + status + " for " + key.url());
+         } else {
+            String contentType = connection.getContentType();
+            String normalizedContentType = contentType == null ? "" : contentType.toLowerCase(Locale.ROOT);
+            if (!normalizedContentType.contains("tif")) {
+               byte[] errorBody;
+               try (InputStream input = connection.getInputStream()) {
+                  errorBody = input.readNBytes(512);
+               }
+
+               throw new IOException("Unexpected USGS 3DEP content type " + contentType + ": " + new String(errorBody, StandardCharsets.UTF_8));
+            } else {
+               DownloadProgressReporter.requestStarted(Math.max(0L, connection.getContentLengthLong()));
+               try (InputStream input = connection.getInputStream()) {
+                  return DownloadProgressReporter.readAllBytesWithProgress(input);
+               } finally {
+                  DownloadProgressReporter.requestFinished();
+               }
+            }
+         }
+      } finally {
+         connection.disconnect();
+      }
+   }
+
+   private void writeCacheFile(Path cachePath, byte[] data) throws IOException {
+      Files.createDirectories(cachePath.getParent());
+      Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+      Files.write(tempPath, data);
+
+      try {
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+      } catch (IOException error) {
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      }
+   }
+
+   private static Usgs3depElevationSource.TileRaster readTiffRaster(byte[] data) throws IOException {
+      if (data.length < 8) {
+         throw new IOException("Invalid TIFF header");
+      } else {
+         ByteOrder order = switch (data[0]) {
+            case 73 -> ByteOrder.LITTLE_ENDIAN;
+            case 77 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid TIFF byte order");
+         };
+         ByteBuffer header = ByteBuffer.wrap(data).order(order);
+         header.position(2);
+         short magic = header.getShort();
+         if (magic != 42) {
+            throw new IOException("Expected standard TIFF magic");
+         } else {
+            int ifdOffset = header.getInt();
+            if (ifdOffset < 0 || ifdOffset + 2 > data.length) {
+               throw new IOException("Invalid TIFF IFD offset");
+            } else {
+               ByteBuffer ifdHeader = ByteBuffer.wrap(data, ifdOffset, data.length - ifdOffset).order(order);
+               int entryCount = Short.toUnsignedInt(ifdHeader.getShort());
+               int entriesOffset = ifdOffset + 2;
+               if (entriesOffset + entryCount * 12 > data.length) {
+                  throw new IOException("Invalid TIFF entry table");
+               } else {
+                  ByteBuffer entries = ByteBuffer.wrap(data, entriesOffset, entryCount * 12).order(order);
+                  int width = -1;
+                  int height = -1;
+                  int tileWidth = -1;
+                  int tileHeight = -1;
+                  int compression = COMPRESSION_NONE;
+                  int bitsPerSample = -1;
+                  int sampleFormat = SAMPLE_FORMAT_IEEE_FLOAT;
+                  int samplesPerPixel = 1;
+                  int rowsPerStrip = -1;
+                  long[] tileOffsets = null;
+                  int[] tileByteCounts = null;
+                  long[] stripOffsets = null;
+                  int[] stripByteCounts = null;
+                  float noData = Float.NaN;
+                  boolean hasNoData = false;
+
+                  for (int i = 0; i < entryCount; i++) {
+                     int tag = Short.toUnsignedInt(entries.getShort());
+                     int type = Short.toUnsignedInt(entries.getShort());
+                     long count = Integer.toUnsignedLong(entries.getInt());
+                     int valueOffset = entries.getInt();
+                     switch (tag) {
+                        case TAG_IMAGE_WIDTH -> width = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_IMAGE_HEIGHT -> height = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_BITS_PER_SAMPLE -> bitsPerSample = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_COMPRESSION -> compression = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_STRIP_OFFSETS -> stripOffsets = readLongArray(data, order, type, count, valueOffset);
+                        case TAG_SAMPLES_PER_PIXEL -> samplesPerPixel = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_ROWS_PER_STRIP -> rowsPerStrip = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_STRIP_BYTE_COUNTS -> stripByteCounts = readIntArray(data, order, type, count, valueOffset);
+                        case TAG_TILE_WIDTH -> tileWidth = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_TILE_HEIGHT -> tileHeight = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_TILE_OFFSETS -> tileOffsets = readLongArray(data, order, type, count, valueOffset);
+                        case TAG_TILE_BYTE_COUNTS -> tileByteCounts = readIntArray(data, order, type, count, valueOffset);
+                        case TAG_SAMPLE_FORMAT -> sampleFormat = readIntValue(data, order, type, count, valueOffset);
+                        case TAG_GDAL_NODATA -> {
+                           noData = readNoDataValue(data, order, count, valueOffset);
+                           hasNoData = Float.isFinite(noData);
+                        }
+                     }
+                  }
+
+                  if (width <= 0 || height <= 0) {
+                     throw new IOException("Missing TIFF dimensions");
+                  } else if (compression != COMPRESSION_NONE) {
+                     throw new IOException("Unsupported TIFF compression " + compression);
+                  } else if (bitsPerSample != 32 || sampleFormat != SAMPLE_FORMAT_IEEE_FLOAT || samplesPerPixel != 1) {
+                     throw new IOException(
+                        "Unsupported TIFF raster format bits=" + bitsPerSample + " sampleFormat=" + sampleFormat + " samples=" + samplesPerPixel
+                     );
+                  } else {
+                     if ((tileOffsets == null || tileByteCounts == null) && stripOffsets != null && stripByteCounts != null && rowsPerStrip > 0) {
+                        tileWidth = width;
+                        tileHeight = rowsPerStrip;
+                        tileOffsets = stripOffsets;
+                        tileByteCounts = stripByteCounts;
+                     }
+
+                     if (tileOffsets == null || tileByteCounts == null || tileWidth <= 0 || tileHeight <= 0) {
+                        throw new IOException("Missing TIFF tile offsets");
+                     } else {
+                        FloatRaster raster = FloatRaster.create(width, height);
+                        int tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+
+                        for (int tileIndex = 0; tileIndex < tileOffsets.length && tileIndex < tileByteCounts.length; tileIndex++) {
+                           int byteCount = tileByteCounts[tileIndex];
+                           long offset = tileOffsets[tileIndex];
+                           if (byteCount <= 0) {
+                              continue;
+                           }
+
+                           if (offset < 0L || offset + byteCount > data.length) {
+                              throw new IOException("Invalid TIFF tile range");
+                           }
+
+                           int tileX = tileIndex % tilesPerRow;
+                           int tileY = tileIndex / tilesPerRow;
+                           int destX = tileX * tileWidth;
+                           int destY = tileY * tileHeight;
+                           int copyWidth = Math.max(0, Math.min(tileWidth, width - destX));
+                           int copyHeight = Math.max(0, Math.min(tileHeight, height - destY));
+                           if (copyWidth > 0 && copyHeight > 0) {
+                              ByteBuffer tileData = ByteBuffer.wrap(data, (int)offset, byteCount).order(order);
+
+                              for (int row = 0; row < tileHeight; row++) {
+                                 for (int col = 0; col < tileWidth; col++) {
+                                    float value = tileData.getFloat();
+                                    if (row < copyHeight && col < copyWidth) {
+                                       raster.set(destX + col, destY + row, normalizeSample(value, hasNoData, noData));
+                                    }
+                                 }
+                              }
+                           }
+                        }
+
+                        return new Usgs3depElevationSource.TileRaster(raster);
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private static float normalizeSample(float value, boolean hasNoData, float noData) {
+      if (!Float.isFinite(value) || value <= FLOAT_NODATA_SENTINEL || hasNoData && Float.compare(value, noData) == 0) {
+         return Float.NaN;
+      } else {
+         return value;
+      }
+   }
+
+   private static int readIntValue(byte[] data, ByteOrder order, int type, long count, int valueOffset) throws IOException {
+      if (count != 1L) {
+         throw new IOException("Unsupported TIFF scalar count " + count);
+      } else {
+         return switch (type) {
+            case TYPE_SHORT -> Short.toUnsignedInt(valueBuffer(data, order, TYPE_SHORT, 1L, valueOffset).getShort());
+            case TYPE_LONG -> valueOffset;
+            default -> throw new IOException("Unsupported TIFF scalar type " + type);
+         };
+      }
+   }
+
+   private static long[] readLongArray(byte[] data, ByteOrder order, int type, long count, int valueOffset) throws IOException {
+      if (count > Integer.MAX_VALUE) {
+         throw new IOException("Unsupported TIFF array count " + count);
+      } else {
+         ByteBuffer values = valueBuffer(data, order, type, count, valueOffset);
+         int intCount = (int)count;
+         long[] result = new long[intCount];
+
+         for (int i = 0; i < intCount; i++) {
+            result[i] = switch (type) {
+               case TYPE_SHORT -> Short.toUnsignedLong(values.getShort());
+               case TYPE_LONG -> Integer.toUnsignedLong(values.getInt());
+               default -> throw new IOException("Unsupported TIFF integer type " + type);
+            };
+         }
+
+         return result;
+      }
+   }
+
+   private static int[] readIntArray(byte[] data, ByteOrder order, int type, long count, int valueOffset) throws IOException {
+      long[] longs = readLongArray(data, order, type, count, valueOffset);
+      int[] result = new int[longs.length];
+
+      for (int i = 0; i < longs.length; i++) {
+         result[i] = Math.toIntExact(longs[i]);
+      }
+
+      return result;
+   }
+
+   private static float readNoDataValue(byte[] data, ByteOrder order, long count, int valueOffset) throws IOException {
+      ByteBuffer values = valueBuffer(data, order, TYPE_ASCII, count, valueOffset);
+      byte[] bytes = new byte[(int)count];
+      values.get(bytes);
+      String text = new String(bytes, StandardCharsets.US_ASCII).trim();
+      int nullIndex = text.indexOf(0);
+      if (nullIndex >= 0) {
+         text = text.substring(0, nullIndex);
+      }
+
+      try {
+         return (float)Double.parseDouble(text);
+      } catch (NumberFormatException error) {
+         return Float.NaN;
+      }
+   }
+
+   private static ByteBuffer valueBuffer(byte[] data, ByteOrder order, int type, long count, int valueOffset) throws IOException {
+      int byteCount = Math.toIntExact(count * typeSize(type));
+      if (byteCount <= 4) {
+         byte[] inline = ByteBuffer.allocate(4).order(order).putInt(valueOffset).array();
+         return ByteBuffer.wrap(inline, 0, byteCount).order(order);
+      } else if (valueOffset < 0 || valueOffset + byteCount > data.length) {
+         throw new IOException("Invalid TIFF value offset");
+      } else {
+         return ByteBuffer.wrap(data, valueOffset, byteCount).order(order);
+      }
+   }
+
+   private static int typeSize(int type) throws IOException {
+      return switch (type) {
+         case TYPE_ASCII -> 1;
+         case TYPE_SHORT -> 2;
+         case TYPE_LONG, TYPE_FLOAT -> 4;
+         case TYPE_RATIONAL -> 8;
+         default -> throw new IOException("Unsupported TIFF field type " + type);
+      };
+   }
+
+   private static double sampleBilinear(Usgs3depElevationSource.TileRaster tile, double mercatorX, double mercatorY, Usgs3depElevationSource.TileKey key) {
+      double localX = (mercatorX - key.minX()) / key.level().metersPerPixel();
+      double localY = (key.maxY() - mercatorY) / key.level().metersPerPixel();
+      int maxX = tile.raster().width() - 1;
+      int maxY = tile.raster().height() - 1;
+      int x0 = Mth.clamp(Mth.floor(localX), 0, maxX);
+      int y0 = Mth.clamp(Mth.floor(localY), 0, maxY);
+      int x1 = Math.min(x0 + 1, maxX);
+      int y1 = Math.min(y0 + 1, maxY);
+      double dx = localX - x0;
+      double dy = localY - y0;
+      float v00 = tile.raster().get(x0, y0);
+      float v10 = tile.raster().get(x1, y0);
+      float v01 = tile.raster().get(x0, y1);
+      float v11 = tile.raster().get(x1, y1);
+      return blendFiniteSamples(v00, v10, v01, v11, dx, dy);
+   }
+
+   private static double blendFiniteSamples(float v00, float v10, float v01, float v11, double dx, double dy) {
+      double w00 = (1.0 - dx) * (1.0 - dy);
+      double w10 = dx * (1.0 - dy);
+      double w01 = (1.0 - dx) * dy;
+      double w11 = dx * dy;
+      double sum = 0.0;
+      double weight = 0.0;
+      if (Float.isFinite(v00)) {
+         sum += v00 * w00;
+         weight += w00;
+      }
+
+      if (Float.isFinite(v10)) {
+         sum += v10 * w10;
+         weight += w10;
+      }
+
+      if (Float.isFinite(v01)) {
+         sum += v01 * w01;
+         weight += w01;
+      }
+
+      if (Float.isFinite(v11)) {
+         sum += v11 * w11;
+         weight += w11;
+      }
+
+      return weight <= 0.0 ? Double.NaN : sum / weight;
+   }
+
+   private static double lonToMercatorX(double lon) {
+      return Math.toRadians(lon) * 6378137.0;
+   }
+
+   private static double latToMercatorY(double lat) {
+      double clampedLat = Mth.clamp(lat, MIN_LAT, MAX_LAT);
+      double radians = Math.toRadians(clampedLat);
+      return 6378137.0 * Math.log(Math.tan(Math.PI * 0.25 + radians * 0.5));
+   }
+
+   private static int intProperty(String key, int defaultValue) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Math.max(1, Integer.parseInt(value));
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.USGS;
+   }
+
+   @Override
+   public void clearCache() {
+      this.fileCache.invalidateAll();
+      this.fileCache.cleanUp();
+   }
+
+   private record TileRaster(FloatRaster raster) {
+      private TileRaster {
+         Objects.requireNonNull(raster, "raster");
+      }
+   }
+
+   private record TileKey(Usgs3depElevationSource.ResolutionLevel level, int tileX, int tileY) {
+      private static Usgs3depElevationSource.TileKey forLatLon(Usgs3depElevationSource.ResolutionLevel level, double lat, double lon) {
+         return forMercator(level, lonToMercatorX(lon), latToMercatorY(lat));
+      }
+
+      private static Usgs3depElevationSource.TileKey forMercator(Usgs3depElevationSource.ResolutionLevel level, double mercatorX, double mercatorY) {
+         double span = level.tileSpanMeters();
+         int tileX = Mth.floor((mercatorX + MERCATOR_LIMIT) / span);
+         int tileY = Mth.floor((MERCATOR_LIMIT - mercatorY) / span);
+         return new Usgs3depElevationSource.TileKey(level, tileX, tileY);
+      }
+
+      private double minX() {
+         return -MERCATOR_LIMIT + this.tileX * this.level.tileSpanMeters();
+      }
+
+      private double maxX() {
+         return this.minX() + this.level.tileSpanMeters();
+      }
+
+      private double maxY() {
+         return MERCATOR_LIMIT - this.tileY * this.level.tileSpanMeters();
+      }
+
+      private double minY() {
+         return this.maxY() - this.level.tileSpanMeters();
+      }
+
+      private Path cachePath(Path root) {
+         return root.resolve(this.level.id()).resolve(String.format(Locale.ROOT, "%05d/%05d.tif", this.tileY, this.tileX));
+      }
+
+      private String url() {
+         return String.format(
+            Locale.ROOT,
+            "%s?bbox=%.3f,%.3f,%.3f,%.3f&bboxSR=3857&imageSR=3857&size=%d,%d&format=tiff&pixelType=F32&interpolation=RSP_BilinearInterpolation&f=image",
+            ENDPOINT,
+            this.minX(),
+            this.minY(),
+            this.maxX(),
+            this.maxY(),
+            TILE_PIXELS,
+            TILE_PIXELS
+         );
+      }
+   }
+
+   private static enum ResolutionLevel {
+      M1("r1", 1.0),
+      M3("r3", 3.4359738368),
+      M10("r10", 10.3079215104),
+      M30("r30", 30.9220809814);
+
+      private final String id;
+      private final double metersPerPixel;
+
+      private ResolutionLevel(String id, double metersPerPixel) {
+         this.id = id;
+         this.metersPerPixel = metersPerPixel;
+      }
+
+      private String id() {
+         return this.id;
+      }
+
+      private double metersPerPixel() {
+         return this.metersPerPixel;
+      }
+
+      private double tileSpanMeters() {
+         return this.metersPerPixel * TILE_PIXELS;
+      }
+
+      private static Usgs3depElevationSource.ResolutionLevel forWorldScale(double worldScale) {
+         if (worldScale <= 1.5) {
+            return M1;
+         } else if (worldScale <= 5.0) {
+            return M3;
+         } else if (worldScale <= 15.0) {
+            return M10;
+         } else {
+            return M30;
+         }
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/koppen/TellusKoppenSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/koppen/TellusKoppenSource.java
@@ -1,0 +1,990 @@
+package com.yucareux.tellus.world.data.koppen;
+
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.zip.InflaterInputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+
+public final class TellusKoppenSource implements TellusCacheHandle {
+   private static final double EQUATOR_CIRCUMFERENCE = 4.0075017E7;
+   private static final double MIN_LAT = -90.0;
+   private static final double MAX_LAT = 90.0;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final String RESOURCE_PATH = "tellus/koppen/koppen_geiger_0p00833333.tif";
+   private static final double SEARCH_RADIUS_METERS = 5000.0;
+   private static final int SMOOTH_RADIUS_PIXELS = 2;
+   private static final double WARP_AMPLITUDE_METERS = 800.0;
+   private static final double WARP_WAVELENGTH_METERS = 12000.0;
+   private static final int DITHER_NOISE_CELL_BLOCKS = 4;
+   private static final long DITHER_SEED = 5883890050026909207L;
+   private static final long WARP_SEED_X = 2611923443488327891L;
+   private static final long WARP_SEED_Z = 1376283091369227076L;
+   private static final String[] KOPPEN_CODES = new String[31];
+   private static final ThreadLocal<TellusKoppenSource.KoppenBlendScratch> DITHER_SCRATCH = ThreadLocal.withInitial(
+      TellusKoppenSource.KoppenBlendScratch::new
+   );
+   private final Path cachePath = FMLPaths.GAMEDIR.get().resolve("tellus/cache/koppen/koppen_geiger_0p00833333.tif");
+   private volatile TellusKoppenSource.GeoTiffRaster raster;
+
+   public TellusKoppenSource() {
+      this.raster = this.loadRaster();
+      TellusCacheRegistry.register(this);
+   }
+
+   public String sampleDitheredCode(double blockX, double blockZ, double worldScale) {
+      TellusKoppenSource.GeoTiffRaster raster = this.raster();
+      TellusKoppenSource.PixelSample center = this.toPixelSample(blockX, blockZ, worldScale);
+      if (center == null) {
+         return null;
+      } else {
+         return raster == TellusKoppenSource.GeoTiffRaster.MISSING ? null : raster.sampleDithered(center, blockX, blockZ);
+      }
+   }
+
+   public String sampleRawCode(double blockX, double blockZ, double worldScale) {
+      TellusKoppenSource.GeoTiffRaster raster = this.raster();
+      TellusKoppenSource.Pixel center = this.toPixel(blockX, blockZ, worldScale);
+      if (center == null) {
+         return null;
+      } else {
+         return raster == TellusKoppenSource.GeoTiffRaster.MISSING ? null : raster.sample(center);
+      }
+   }
+
+   public String sampleSmoothedCode(double blockX, double blockZ, double worldScale) {
+      TellusKoppenSource.GeoTiffRaster raster = this.raster();
+      TellusKoppenSource.Pixel center = this.toPixel(blockX, blockZ, worldScale);
+      if (center == null) {
+         return null;
+      } else {
+         return raster == TellusKoppenSource.GeoTiffRaster.MISSING ? null : raster.sampleSmoothed(center, SMOOTH_RADIUS_PIXELS);
+      }
+   }
+
+   public String findNearestCode(double blockX, double blockZ, double worldScale) {
+      TellusKoppenSource.GeoTiffRaster raster = this.raster();
+      TellusKoppenSource.Pixel center = this.toPixel(blockX, blockZ, worldScale);
+      if (center == null) {
+         return null;
+      } else if (raster == TellusKoppenSource.GeoTiffRaster.MISSING) {
+         return null;
+      } else {
+         int radius = raster.radiusForMeters(SEARCH_RADIUS_METERS);
+         return raster.findNearest(center, radius);
+      }
+   }
+
+   private TellusKoppenSource.Pixel toPixel(double blockX, double blockZ, double worldScale) {
+      TellusKoppenSource.PixelSample sample = this.toPixelSample(blockX, blockZ, worldScale);
+      return sample == null ? null : new TellusKoppenSource.Pixel(sample.x(), sample.y());
+   }
+
+   private TellusKoppenSource.PixelSample toPixelSample(double blockX, double blockZ, double worldScale) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         TellusKoppenSource.GeoTiffRaster raster = this.raster();
+         TellusKoppenSource.WarpedCoords warped = warpBlock(blockX, blockZ, worldScale);
+         blockX = warped.x();
+         blockZ = warped.z();
+         int step = downsampleStep(worldScale, raster.pixelSizeMeters());
+         if (step > 1) {
+            blockX = downsampleBlock(blockX, step);
+            blockZ = downsampleBlock(blockZ, step);
+         }
+
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+         double lon = blockX / blocksPerDegree;
+         double lat = EarthProjection.blockZToLat(blockZ, worldScale);
+         return !(lat < MIN_LAT) && !(lat > MAX_LAT) && !(lon < MIN_LON) && !(lon > MAX_LON) ? raster.toPixelSample(lon, lat) : null;
+      }
+   }
+
+   private static int downsampleStep(double worldScale, double resolutionMeters) {
+      return 1;
+   }
+
+   private static double downsampleBlock(double blockCoord, int step) {
+      if (step <= 1) {
+         return blockCoord;
+      } else {
+         int block = Mth.floor(blockCoord);
+         int snapped = Math.floorDiv(block, step) * step;
+         return snapped + step * 0.5;
+      }
+   }
+
+   private static TellusKoppenSource.WarpedCoords warpBlock(double blockX, double blockZ, double worldScale) {
+      if (worldScale <= 0.0) {
+         return new TellusKoppenSource.WarpedCoords(blockX, blockZ);
+      } else {
+         double amplitudeBlocks = WARP_AMPLITUDE_METERS / worldScale;
+         if (amplitudeBlocks < 0.5) {
+            return new TellusKoppenSource.WarpedCoords(blockX, blockZ);
+         } else {
+            double wavelengthBlocks = WARP_WAVELENGTH_METERS / worldScale;
+            if (wavelengthBlocks <= 1.0) {
+               return new TellusKoppenSource.WarpedCoords(blockX, blockZ);
+            } else {
+               double nx = blockX / wavelengthBlocks;
+               double nz = blockZ / wavelengthBlocks;
+               double offsetX = valueNoise(nx, nz, WARP_SEED_X) * amplitudeBlocks;
+               double offsetZ = valueNoise(nx + 37.0, nz - 59.0, WARP_SEED_Z) * amplitudeBlocks;
+               return new TellusKoppenSource.WarpedCoords(blockX + offsetX, blockZ + offsetZ);
+            }
+         }
+      }
+   }
+
+   private static double valueNoise(double x, double z, long seed) {
+      int x0 = Mth.floor(x);
+      int z0 = Mth.floor(z);
+      double fx = x - x0;
+      double fz = z - z0;
+      double v00 = hashToUnit(x0, z0, seed);
+      double v10 = hashToUnit(x0 + 1, z0, seed);
+      double v01 = hashToUnit(x0, z0 + 1, seed);
+      double v11 = hashToUnit(x0 + 1, z0 + 1, seed);
+      double u = fade(fx);
+      double v = fade(fz);
+      double lerpX0 = Mth.lerp(u, v00, v10);
+      double lerpX1 = Mth.lerp(u, v01, v11);
+      return Mth.lerp(v, lerpX0, lerpX1) * 2.0 - 1.0;
+   }
+
+   private static double fade(double t) {
+      return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+   }
+
+   private static double hashToUnit(int x, int z, long seed) {
+      long h = seed ^ x * -7046029254386353131L;
+      h ^= z * -4417276706812531889L;
+      h = mix64(h);
+      return (h >>> 11) * 1.110223E-16F;
+   }
+
+   private static long mix64(long value) {
+      long z = (value ^ value >>> 33) * -49064778989728563L;
+      z = (z ^ z >>> 33) * -4265267296055464877L;
+      return z ^ z >>> 33;
+   }
+
+   private TellusKoppenSource.GeoTiffRaster loadRaster() {
+      try {
+         if (!Files.exists(this.cachePath)) {
+            this.cacheRaster();
+         }
+
+         return !Files.exists(this.cachePath) ? TellusKoppenSource.GeoTiffRaster.MISSING : TellusKoppenSource.GeoTiffRaster.open(this.cachePath);
+      } catch (IOException var2) {
+         Tellus.LOGGER.warn("Failed to load Koppen raster", var2);
+         return TellusKoppenSource.GeoTiffRaster.MISSING;
+      }
+   }
+
+   private void cacheRaster() {
+      try {
+         try (InputStream input = TellusKoppenSource.class.getClassLoader().getResourceAsStream(RESOURCE_PATH)) {
+            if (input != null) {
+               Files.createDirectories(this.cachePath.getParent());
+               Path temp = this.cachePath.resolveSibling(this.cachePath.getFileName() + ".tmp");
+               Files.copy(input, temp, StandardCopyOption.REPLACE_EXISTING);
+               Files.move(temp, this.cachePath, StandardCopyOption.REPLACE_EXISTING);
+               return;
+            }
+
+            Tellus.LOGGER.warn("Missing Koppen raster resource {}", RESOURCE_PATH);
+         }
+      } catch (IOException var6) {
+         Tellus.LOGGER.warn("Failed to cache Koppen raster", var6);
+      }
+   }
+
+   private TellusKoppenSource.GeoTiffRaster raster() {
+      TellusKoppenSource.GeoTiffRaster current = this.raster;
+      if (current != TellusKoppenSource.GeoTiffRaster.MISSING) {
+         return current;
+      } else {
+         synchronized (this) {
+            current = this.raster;
+            if (current == TellusKoppenSource.GeoTiffRaster.MISSING) {
+               current = this.loadRaster();
+               this.raster = current;
+            }
+
+            return current;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.KOPPEN;
+   }
+
+   @Override
+   public void clearCache() {
+      synchronized (this) {
+         TellusKoppenSource.GeoTiffRaster current = this.raster;
+         if (current != null) {
+            current.close();
+         }
+
+         this.raster = TellusKoppenSource.GeoTiffRaster.MISSING;
+      }
+   }
+
+   static {
+      KOPPEN_CODES[1] = "Af";
+      KOPPEN_CODES[2] = "Am";
+      KOPPEN_CODES[3] = "Aw";
+      KOPPEN_CODES[4] = "BWh";
+      KOPPEN_CODES[5] = "BWk";
+      KOPPEN_CODES[6] = "BSh";
+      KOPPEN_CODES[7] = "BSk";
+      KOPPEN_CODES[8] = "Csa";
+      KOPPEN_CODES[9] = "Csb";
+      KOPPEN_CODES[10] = "Csc";
+      KOPPEN_CODES[11] = "Cwa";
+      KOPPEN_CODES[12] = "Cwb";
+      KOPPEN_CODES[13] = "Cwc";
+      KOPPEN_CODES[14] = "Cfa";
+      KOPPEN_CODES[15] = "Cfb";
+      KOPPEN_CODES[16] = "Cfc";
+      KOPPEN_CODES[17] = "Dsa";
+      KOPPEN_CODES[18] = "Dsb";
+      KOPPEN_CODES[19] = "Dsc";
+      KOPPEN_CODES[20] = "Dsd";
+      KOPPEN_CODES[21] = "Dwa";
+      KOPPEN_CODES[22] = "Dwb";
+      KOPPEN_CODES[23] = "Dwc";
+      KOPPEN_CODES[24] = "Dwd";
+      KOPPEN_CODES[25] = "Dfa";
+      KOPPEN_CODES[26] = "Dfb";
+      KOPPEN_CODES[27] = "Dfc";
+      KOPPEN_CODES[28] = "Dfd";
+      KOPPEN_CODES[29] = "ET";
+      KOPPEN_CODES[30] = "EF";
+   }
+
+   private static final class GeoTiffRaster {
+      private static final int TAG_IMAGE_WIDTH = 256;
+      private static final int TAG_IMAGE_HEIGHT = 257;
+      private static final int TAG_TILE_WIDTH = 322;
+      private static final int TAG_TILE_HEIGHT = 323;
+      private static final int TAG_TILE_OFFSETS = 324;
+      private static final int TAG_TILE_BYTE_COUNTS = 325;
+      private static final int TAG_COMPRESSION = 259;
+      private static final int TAG_MODEL_PIXEL_SCALE = 33550;
+      private static final int TAG_MODEL_TIEPOINT = 33922;
+      private static final int TYPE_SHORT = 3;
+      private static final int TYPE_LONG = 4;
+      private static final int COMPRESSION_LZW = 5;
+      private static final int COMPRESSION_DEFLATE = 8;
+      private static final int MAX_TILE_CACHE = 64;
+      private static final TellusKoppenSource.GeoTiffRaster MISSING = new TellusKoppenSource.GeoTiffRaster();
+      private final Path path;
+      private final FileChannel channel;
+      private final int width;
+      private final int height;
+      private final int tileWidth;
+      private final int tileHeight;
+      private final int tilesPerRow;
+      private final int compression;
+      private final long[] tileOffsets;
+      private final int[] tileByteCounts;
+      private final double pixelScaleX;
+      private final double pixelScaleY;
+      private final double tieLon;
+      private final double tieLat;
+      private final double pixelSizeMeters;
+      private final Map<Integer, byte[]> tileCache;
+
+      private GeoTiffRaster() {
+         this.path = null;
+         this.channel = null;
+         this.width = 0;
+         this.height = 0;
+         this.tileWidth = 0;
+         this.tileHeight = 0;
+         this.tilesPerRow = 0;
+         this.compression = 0;
+         this.tileOffsets = null;
+         this.tileByteCounts = null;
+         this.pixelScaleX = 0.0;
+         this.pixelScaleY = 0.0;
+         this.tieLon = 0.0;
+         this.tieLat = 0.0;
+         this.pixelSizeMeters = 0.0;
+         this.tileCache = Map.of();
+      }
+
+      private GeoTiffRaster(
+         Path path,
+         FileChannel channel,
+         int width,
+         int height,
+         int tileWidth,
+         int tileHeight,
+         int compression,
+         long[] tileOffsets,
+         int[] tileByteCounts,
+         double pixelScaleX,
+         double pixelScaleY,
+         double tieLon,
+         double tieLat
+      ) {
+         this.path = path;
+         this.channel = channel;
+         this.width = width;
+         this.height = height;
+         this.tileWidth = tileWidth;
+         this.tileHeight = tileHeight;
+         this.tilesPerRow = (int)Math.ceil((double)width / tileWidth);
+         this.compression = compression;
+         this.tileOffsets = tileOffsets;
+         this.tileByteCounts = tileByteCounts;
+         this.pixelScaleX = pixelScaleX;
+         this.pixelScaleY = pixelScaleY;
+         this.tieLon = tieLon;
+         this.tieLat = tieLat;
+         this.pixelSizeMeters = Math.abs(pixelScaleX) * (EQUATOR_CIRCUMFERENCE / 360.0);
+         this.tileCache = new LinkedHashMap<Integer, byte[]>(MAX_TILE_CACHE, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Entry<Integer, byte[]> eldest) {
+               return this.size() > MAX_TILE_CACHE;
+            }
+         };
+      }
+
+      static TellusKoppenSource.GeoTiffRaster open(Path path) throws IOException {
+         FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
+
+         try {
+            return readFromChannel(path, channel);
+         } catch (IOException var3) {
+            channel.close();
+            throw var3;
+         }
+      }
+
+      void close() {
+         if (this.channel != null) {
+            synchronized (this.tileCache) {
+               this.tileCache.clear();
+            }
+
+            try {
+               this.channel.close();
+            } catch (IOException var2) {
+               Tellus.LOGGER.warn("Failed to close Koppen raster {}", this.path, var2);
+            }
+         }
+      }
+
+      TellusKoppenSource.PixelSample toPixelSample(double lon, double lat) {
+         if (this == MISSING) {
+            return null;
+         } else {
+            double pixelXCoord = (lon - this.tieLon) / this.pixelScaleX;
+            double pixelYCoord = (this.tieLat - lat) / this.pixelScaleY;
+            int pixelX = (int)Math.floor(pixelXCoord);
+            int pixelY = (int)Math.floor(pixelYCoord);
+            if (pixelX >= 0 && pixelY >= 0 && pixelX < this.width && pixelY < this.height) {
+               double fracX = Mth.clamp(pixelXCoord - pixelX, 0.0, 0.999999);
+               double fracY = Mth.clamp(pixelYCoord - pixelY, 0.0, 0.999999);
+               return new TellusKoppenSource.PixelSample(pixelX, pixelY, fracX, fracY);
+            } else {
+               return null;
+            }
+         }
+      }
+
+      String sampleSmoothed(TellusKoppenSource.Pixel center, int radius) {
+         if (center != null && radius > 0) {
+            int[] counts = new int[TellusKoppenSource.KOPPEN_CODES.length];
+            int centerValue = this.sampleValue(center.x, center.y);
+
+            for (int dy = -radius; dy <= radius; dy++) {
+               for (int dx = -radius; dx <= radius; dx++) {
+                  if (dx * dx + dy * dy <= radius * radius) {
+                     int value = this.sampleValue(center.x + dx, center.y + dy);
+                     if (value > 0 && value < counts.length) {
+                        counts[value]++;
+                     }
+                  }
+               }
+            }
+
+            int bestIndex = -1;
+            int bestCount = -1;
+
+            for (int i = 1; i < counts.length; i++) {
+               int count = counts[i];
+               if (count > bestCount) {
+                  bestCount = count;
+                  bestIndex = i;
+               } else if (count == bestCount && count > 0 && i == centerValue) {
+                  bestIndex = i;
+               }
+            }
+
+            return bestIndex <= 0 ? null : TellusKoppenSource.KOPPEN_CODES[bestIndex];
+         } else {
+            return this.sample(center);
+         }
+      }
+
+      String sampleDithered(TellusKoppenSource.PixelSample center, double blockX, double blockZ) {
+         if (center == null) {
+            return null;
+         } else {
+            int centerValue = this.sampleValue(center.x, center.y);
+            if (centerValue > 0 && centerValue < TellusKoppenSource.KOPPEN_CODES.length) {
+               double blendX = center.x + center.fracX - 0.5;
+               double blendY = center.y + center.fracY - 0.5;
+               int x0 = Mth.floor(blendX);
+               int y0 = Mth.floor(blendY);
+               int x1 = x0 + 1;
+               int y1 = y0 + 1;
+               double fx = blendX - x0;
+               double fy = blendY - y0;
+               double inverseFx = 1.0 - fx;
+               double inverseFy = 1.0 - fy;
+               TellusKoppenSource.KoppenBlendScratch scratch = DITHER_SCRATCH.get();
+               scratch.reset();
+               scratch.add(this.sampleValue(x0, y0), inverseFx * inverseFy);
+               scratch.add(this.sampleValue(x1, y0), fx * inverseFy);
+               scratch.add(this.sampleValue(x0, y1), inverseFx * fy);
+               scratch.add(this.sampleValue(x1, y1), fx * fy);
+               int noiseX = Math.floorDiv(Mth.floor(blockX), DITHER_NOISE_CELL_BLOCKS);
+               int noiseZ = Math.floorDiv(Mth.floor(blockZ), DITHER_NOISE_CELL_BLOCKS);
+               int selectedValue = scratch.pickWeighted(centerValue, TellusKoppenSource.hashToUnit(noiseX, noiseZ, DITHER_SEED));
+               return selectedValue > 0 && selectedValue < TellusKoppenSource.KOPPEN_CODES.length ? TellusKoppenSource.KOPPEN_CODES[selectedValue] : null;
+            } else {
+               return null;
+            }
+         }
+      }
+
+      String findNearest(TellusKoppenSource.Pixel center, int radius) {
+         if (center != null && radius > 0) {
+            int bestValue = 0;
+            int bestDist = Integer.MAX_VALUE;
+            int maxDist = radius * radius;
+
+            for (int dy = -radius; dy <= radius; dy++) {
+               for (int dx = -radius; dx <= radius; dx++) {
+                  int dist = dx * dx + dy * dy;
+                  if (dist <= maxDist) {
+                     int value = this.sampleValue(center.x + dx, center.y + dy);
+                     if (value > 0 && value < TellusKoppenSource.KOPPEN_CODES.length && dist < bestDist) {
+                        bestDist = dist;
+                        bestValue = value;
+                     }
+                  }
+               }
+            }
+
+            return bestValue > 0 ? TellusKoppenSource.KOPPEN_CODES[bestValue] : null;
+         } else {
+            return null;
+         }
+      }
+
+      int radiusForMeters(double meters) {
+         return this.pixelSizeMeters <= 0.0 ? 0 : Math.max(1, (int)Math.ceil(meters / this.pixelSizeMeters));
+      }
+
+      double pixelSizeMeters() {
+         return this.pixelSizeMeters;
+      }
+
+      private String sample(TellusKoppenSource.Pixel pixel) {
+         if (pixel == null) {
+            return null;
+         } else {
+            int value = this.sampleValue(pixel.x, pixel.y);
+            return value > 0 && value < TellusKoppenSource.KOPPEN_CODES.length ? TellusKoppenSource.KOPPEN_CODES[value] : null;
+         }
+      }
+
+      private int sampleValue(int pixelX, int pixelY) {
+         if (this == MISSING) {
+            return 0;
+         } else if (pixelX >= 0 && pixelY >= 0 && pixelX < this.width && pixelY < this.height) {
+            int tileX = pixelX / this.tileWidth;
+            int tileY = pixelY / this.tileHeight;
+            int tileIndex = tileY * this.tilesPerRow + tileX;
+
+            byte[] tile;
+            try {
+               tile = this.getTile(tileIndex);
+            } catch (IOException var9) {
+               if (!(var9 instanceof ClosedByInterruptException) && !Thread.currentThread().isInterrupted()) {
+                  Tellus.LOGGER.warn("Failed to read Koppen tile {} in {}", new Object[]{tileIndex, this.path, var9});
+                  return 0;
+               }
+
+               Thread.currentThread().interrupt();
+               return 0;
+            }
+
+            int localX = pixelX - tileX * this.tileWidth;
+            int localY = pixelY - tileY * this.tileHeight;
+            return Byte.toUnsignedInt(tile[localX + localY * this.tileWidth]);
+         } else {
+            return 0;
+         }
+      }
+
+      private byte[] getTile(int tileIndex) throws IOException {
+         synchronized (this.tileCache) {
+            byte[] cached = this.tileCache.get(tileIndex);
+            if (cached != null) {
+               return cached;
+            }
+         }
+
+         byte[] tile = this.readTile(tileIndex);
+         synchronized (this.tileCache) {
+            this.tileCache.put(tileIndex, tile);
+            return tile;
+         }
+      }
+
+      private byte[] readTile(int tileIndex) throws IOException {
+         long offset = this.tileOffsets[tileIndex];
+         int length = this.tileByteCounts[tileIndex];
+         byte[] compressed = new byte[length];
+
+         try {
+            readFully(this.channel, compressed, offset);
+         } catch (ClosedChannelException var12) {
+            if (this.path == null) {
+               throw var12;
+            }
+
+            try (FileChannel reopened = FileChannel.open(this.path, StandardOpenOption.READ)) {
+               readFully(reopened, compressed, offset);
+            }
+         }
+
+         int expectedSize = this.tileWidth * this.tileHeight;
+         if (this.compression == COMPRESSION_DEFLATE) {
+            return inflate(compressed, expectedSize);
+         } else if (this.compression == COMPRESSION_LZW) {
+            return decompressLzw(compressed, expectedSize);
+         } else {
+            throw new IOException("Unsupported TIFF compression " + this.compression);
+         }
+      }
+
+      private static TellusKoppenSource.GeoTiffRaster readFromChannel(Path path, FileChannel channel) throws IOException {
+         ByteBuffer header = ByteBuffer.allocate(8);
+         readFully(channel, header, 0L);
+         header.flip();
+         short order = header.getShort();
+
+         ByteOrder byteOrder = switch (order) {
+            case 18761 -> ByteOrder.LITTLE_ENDIAN;
+            case 19789 -> ByteOrder.BIG_ENDIAN;
+            default -> throw new IOException("Invalid TIFF byte order");
+         };
+         header.order(byteOrder);
+         short magic = header.getShort();
+         if (magic != 42) {
+            throw new IOException("Invalid TIFF magic");
+         } else {
+            int ifdOffset = header.getInt();
+            ByteBuffer countBuffer = ByteBuffer.allocate(2).order(byteOrder);
+            readFully(channel, countBuffer, ifdOffset);
+            countBuffer.flip();
+            int entryCount = Short.toUnsignedInt(countBuffer.getShort());
+            ByteBuffer entries = ByteBuffer.allocate(entryCount * 12).order(byteOrder);
+            readFully(channel, entries, ifdOffset + 2L);
+            entries.flip();
+            int width = -1;
+            int height = -1;
+            int tileWidth = -1;
+            int tileHeight = -1;
+            int compression = -1;
+            long[] tileOffsets = null;
+            int[] tileByteCounts = null;
+            double[] pixelScale = null;
+            double[] tiepoint = null;
+
+            for (int i = 0; i < entryCount; i++) {
+               int tag = Short.toUnsignedInt(entries.getShort());
+               int type = Short.toUnsignedInt(entries.getShort());
+               int count = entries.getInt();
+               int value = entries.getInt();
+               switch (tag) {
+                  case TAG_IMAGE_WIDTH:
+                     width = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_IMAGE_HEIGHT:
+                     height = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_COMPRESSION:
+                     compression = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_TILE_WIDTH:
+                     tileWidth = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_TILE_HEIGHT:
+                     tileHeight = readIntValue(type, count, value, byteOrder);
+                     break;
+                  case TAG_TILE_OFFSETS:
+                     tileOffsets = readLongArray(channel, value, count, byteOrder);
+                     break;
+                  case TAG_TILE_BYTE_COUNTS:
+                     tileByteCounts = readIntArray(channel, value, count, byteOrder);
+                     break;
+                  case TAG_MODEL_PIXEL_SCALE:
+                     pixelScale = readDoubleArray(channel, value, count, byteOrder);
+                     break;
+                  case TAG_MODEL_TIEPOINT:
+                     tiepoint = readDoubleArray(channel, value, count, byteOrder);
+               }
+            }
+
+            if (compression != COMPRESSION_DEFLATE && compression != COMPRESSION_LZW) {
+               throw new IOException("Unsupported TIFF compression " + compression);
+            } else if (width <= 0 || height <= 0 || tileWidth <= 0 || tileHeight <= 0) {
+               throw new IOException("Missing TIFF size tags");
+            } else if (tileOffsets == null || tileByteCounts == null) {
+               throw new IOException("Missing TIFF tile offsets");
+            } else if (pixelScale != null && pixelScale.length >= 2 && tiepoint != null && tiepoint.length >= 5) {
+               return new TellusKoppenSource.GeoTiffRaster(
+                  path,
+                  channel,
+                  width,
+                  height,
+                  tileWidth,
+                  tileHeight,
+                  compression,
+                  tileOffsets,
+                  tileByteCounts,
+                  pixelScale[0],
+                  pixelScale[1],
+                  tiepoint[3],
+                  tiepoint[4]
+               );
+            } else {
+               throw new IOException("Missing TIFF georeference tags");
+            }
+         }
+      }
+
+      private static int readIntValue(int type, int count, int value, ByteOrder order) throws IOException {
+         if (count != 1) {
+            throw new IOException("Expected single TIFF value");
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(4).order(order);
+            buffer.putInt(value);
+            buffer.flip();
+            if (type == TYPE_SHORT) {
+               return Short.toUnsignedInt(buffer.getShort());
+            } else if (type == TYPE_LONG) {
+               return buffer.getInt();
+            } else {
+               throw new IOException("Unsupported TIFF value type " + type);
+            }
+         }
+      }
+
+      private static long[] readLongArray(FileChannel channel, long offset, int count, ByteOrder order) throws IOException {
+         if (count <= 0) {
+            return new long[0];
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(count * 4).order(order);
+            readFully(channel, buffer, offset);
+            buffer.flip();
+            long[] values = new long[count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = Integer.toUnsignedLong(buffer.getInt());
+            }
+
+            return values;
+         }
+      }
+
+      private static int[] readIntArray(FileChannel channel, long offset, int count, ByteOrder order) throws IOException {
+         if (count <= 0) {
+            return new int[0];
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(count * 4).order(order);
+            readFully(channel, buffer, offset);
+            buffer.flip();
+            int[] values = new int[count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getInt();
+            }
+
+            return values;
+         }
+      }
+
+      private static double[] readDoubleArray(FileChannel channel, long offset, int count, ByteOrder order) throws IOException {
+         if (count <= 0) {
+            return new double[0];
+         } else {
+            ByteBuffer buffer = ByteBuffer.allocate(count * 8).order(order);
+            readFully(channel, buffer, offset);
+            buffer.flip();
+            double[] values = new double[count];
+
+            for (int i = 0; i < count; i++) {
+               values[i] = buffer.getDouble();
+            }
+
+            return values;
+         }
+      }
+
+      private static void readFully(FileChannel channel, ByteBuffer buffer, long offset) throws IOException {
+         long position = offset;
+
+         while (buffer.hasRemaining()) {
+            int read = channel.read(buffer, position);
+            if (read < 0) {
+               throw new EOFException("Unexpected end of file");
+            }
+
+            position += read;
+         }
+      }
+
+      private static void readFully(FileChannel channel, byte[] dest, long offset) throws IOException {
+         readFully(channel, ByteBuffer.wrap(dest), offset);
+      }
+
+      private static byte[] inflate(byte[] compressed, int expectedSize) throws IOException {
+         byte[] output = new byte[expectedSize];
+
+         byte[] var8;
+         try (InflaterInputStream inflater = new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+            int offset = 0;
+
+            while (offset < expectedSize) {
+               int read = inflater.read(output, offset, expectedSize - offset);
+               if (read < 0) {
+                  break;
+               }
+
+               offset += read;
+            }
+
+            if (offset != expectedSize) {
+               throw new IOException("Unexpected inflated data length");
+            }
+
+            var8 = output;
+         }
+
+         return var8;
+      }
+
+      private static byte[] decompressLzw(byte[] compressed, int expectedSize) throws IOException {
+         byte[][] table = new byte[4096][];
+
+         for (int i = 0; i < 256; i++) {
+            table[i] = new byte[]{(byte)i};
+         }
+
+         int clearCode = 256;
+         int endCode = 257;
+         int codeSize = 9;
+         int nextCode = 258;
+         byte[] output = new byte[expectedSize];
+         int outPos = 0;
+         TellusKoppenSource.GeoTiffRaster.LzwBitReader reader = new TellusKoppenSource.GeoTiffRaster.LzwBitReader(compressed);
+         byte[] previous = null;
+
+         while (true) {
+            int code = reader.read(codeSize);
+            if (code < 0) {
+               break;
+            }
+
+            if (code == clearCode) {
+               for (int i = 0; i < 256; i++) {
+                  table[i] = new byte[]{(byte)i};
+               }
+
+               for (int i = 256; i < table.length; i++) {
+                  table[i] = null;
+               }
+
+               codeSize = 9;
+               nextCode = 258;
+               previous = null;
+            } else {
+               if (code == endCode) {
+                  break;
+               }
+
+               byte[] entry;
+               if (code < nextCode && table[code] != null) {
+                  entry = table[code];
+               } else {
+                  if (code != nextCode || previous == null) {
+                     throw new IOException("Invalid LZW code " + code);
+                  }
+
+                  entry = concat(previous, previous[0]);
+               }
+
+               if (outPos + entry.length > output.length) {
+                  throw new IOException("Unexpected LZW output size");
+               }
+
+               System.arraycopy(entry, 0, output, outPos, entry.length);
+               outPos += entry.length;
+               if (previous != null && nextCode < table.length) {
+                  table[nextCode++] = concat(previous, entry[0]);
+                  int threshold = (1 << codeSize) - 1;
+                  if (nextCode == threshold && codeSize < 12) {
+                     codeSize++;
+                  }
+               }
+
+               previous = entry;
+               if (outPos == output.length) {
+                  break;
+               }
+            }
+         }
+
+         if (outPos != output.length) {
+            throw new IOException("Unexpected LZW output length " + outPos);
+         } else {
+            return output;
+         }
+      }
+
+      private static byte[] concat(byte[] prefix, byte suffix) {
+         byte[] combined = new byte[prefix.length + 1];
+         System.arraycopy(prefix, 0, combined, 0, prefix.length);
+         combined[prefix.length] = suffix;
+         return combined;
+      }
+
+      private static final class LzwBitReader {
+         private final byte[] data;
+         private int bitPos;
+
+         private LzwBitReader(byte[] data) {
+            this.data = data;
+         }
+
+         private int read(int bits) {
+            int totalBits = this.data.length * 8;
+            if (this.bitPos + bits > totalBits) {
+               return -1;
+            } else {
+               int value = 0;
+
+               for (int i = 0; i < bits; i++) {
+                  int offset = this.bitPos + i;
+                  int byteIndex = offset >> 3;
+                  int bitIndex = 7 - (offset & 7);
+                  int current = this.data[byteIndex] & 255;
+                  value = value << 1 | current >> bitIndex & 1;
+               }
+
+               this.bitPos += bits;
+               return value;
+            }
+         }
+      }
+   }
+
+   private static final class KoppenBlendScratch {
+      private final double[] weights = new double[TellusKoppenSource.KOPPEN_CODES.length];
+      private final int[] used = new int[TellusKoppenSource.KOPPEN_CODES.length];
+      private int usedCount;
+
+      private void reset() {
+         for (int i = 0; i < this.usedCount; i++) {
+            this.weights[this.used[i]] = 0.0;
+         }
+
+         this.usedCount = 0;
+      }
+
+      private void add(int value, double weight) {
+         if (value > 0 && value < this.weights.length && weight > 0.0) {
+            if (!(this.weights[value] > 0.0)) {
+               this.used[this.usedCount++] = value;
+            }
+
+            this.weights[value] += weight;
+         }
+      }
+
+      private int pickWeighted(int fallbackValue, double threshold) {
+         if (this.usedCount == 0) {
+            return fallbackValue;
+         } else {
+            double total = 0.0;
+
+            for (int i = 0; i < this.usedCount; i++) {
+               total += this.weights[this.used[i]];
+            }
+
+            if (!(total > 0.0)) {
+               return fallbackValue;
+            } else {
+               double target = Mth.clamp(threshold, 0.0, 0.9999999999999999) * total;
+               double cumulative = 0.0;
+               int lastValue = fallbackValue;
+
+               for (int i = 0; i < this.usedCount; i++) {
+                  int value = this.used[i];
+                  lastValue = value;
+                  cumulative += this.weights[value];
+                  if (target < cumulative || i + 1 == this.usedCount) {
+                     return value;
+                  }
+               }
+
+               return lastValue;
+            }
+         }
+      }
+   }
+
+   private record Pixel(int x, int y) {
+   }
+
+   private record PixelSample(int x, int y, double fracX, double fracY) {
+   }
+
+   private record WarpedCoords(double x, double z) {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmBuildingSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmBuildingSource.java
@@ -1,0 +1,962 @@
+package com.yucareux.tellus.world.data.osm;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Feature;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.GeomType;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Layer;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Value;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+import net.minecraft.Util;
+
+public final class TellusOsmBuildingSource implements TellusCacheHandle {
+   private static final String DEFAULT_PM_TILES_URL = "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-02-18.0/buildings.pmtiles";
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final double METERS_PER_DEGREE = 111319.49166666667;
+   private static final double POINT_EPSILON = 1.0E-9;
+   private static final int DEFAULT_TILE_EXTENT = 4096;
+   private static final int CONNECT_TIMEOUT_MS = intProperty("tellus.overture.buildings.connectTimeoutMs", 7000, 1, 120000);
+   private static final int READ_TIMEOUT_MS = intProperty("tellus.overture.buildings.readTimeoutMs", 20000, 1, 180000);
+   private static final int DIRECTORY_CACHE_ENTRIES = intProperty("tellus.overture.buildings.dirCache", 256, 1, 8192);
+   private static final int MAX_CACHE_TILES = intProperty("tellus.osm.buildings.cacheTiles", 256, 1, 8192);
+   private static final int QUERY_ZOOM = intProperty("tellus.osm.buildings.queryZoom", 14, 0, 20);
+   private static final int MAX_ASYNC_PREFETCH_LOADS = intProperty("tellus.osm.buildings.prefetchAsyncMax", 96, 0, 8192);
+   private static final int FETCH_RETRY_ATTEMPTS = intProperty("tellus.overture.buildings.fetchRetries", 3, 1, 8);
+   private static final int PMTILES_TILETYPE_MVT = 1;
+   private static final String BUILDING_LAYER_NAME = "building";
+   private static final String BUILDING_PART_LAYER_NAME = "building_part";
+   private static final byte[] EMPTY_TILE_PAYLOAD = new byte[0];
+   private final Path cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/map/buildings");
+   private final PmTilesRangeReader pmTilesReader;
+   private final Object initLock = new Object();
+   private final LoadingCache<TileKey, OsmBuildingTile> cache;
+   private final Set<TileKey> pendingAsyncLoads;
+   private final Set<TileKey> tileLoadFailures;
+   private volatile int queryZoom = QUERY_ZOOM;
+   private volatile boolean available;
+   private volatile boolean initialized;
+
+   public TellusOsmBuildingSource() {
+      String pmTilesUrl = System.getProperty("tellus.overture.buildings.pmtiles", DEFAULT_PM_TILES_URL);
+      this.pmTilesReader = new PmTilesRangeReader(pmTilesUrl, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS, DIRECTORY_CACHE_ENTRIES);
+      this.cache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_TILES).build(new CacheLoader<TileKey, OsmBuildingTile>() {
+         public OsmBuildingTile load(TileKey key) {
+            return TellusOsmBuildingSource.this.loadTile(key);
+         }
+      });
+      this.pendingAsyncLoads = ConcurrentHashMap.newKeySet();
+      this.tileLoadFailures = ConcurrentHashMap.newKeySet();
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean available() {
+      this.ensureInitialized();
+      return this.available;
+   }
+
+   public BuildingQueryResult buildingsForAreaWithStatus(
+      int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks, OsmQueryMode mode
+   ) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0)) {
+         GeoBounds bounds = geoBoundsForBlockArea(minBlockX, minBlockZ, maxBlockX, maxBlockZ, marginBlocks, worldScale);
+         if (bounds == null) {
+            return new BuildingQueryResult(List.of(), false);
+         } else {
+            List<TileKey> keys = tileKeysForBounds(bounds, this.queryZoom);
+            if (keys.isEmpty()) {
+               return new BuildingQueryResult(List.of(), false);
+            } else {
+               List<OsmBuildingFeature> features = new ArrayList<>();
+               boolean hadCacheMiss = false;
+
+               for (TileKey key : keys) {
+                  TileLookup lookup = this.getTileLookup(key, mode);
+                  hadCacheMiss |= lookup.cacheMiss();
+                  OsmBuildingTile tile = lookup.tile();
+                  if (!tile.isEmpty()) {
+                     features.addAll(tile.featuresInBounds(bounds.south(), bounds.west(), bounds.north(), bounds.east()));
+                  }
+               }
+
+               return new BuildingQueryResult(features, hadCacheMiss);
+            }
+         }
+      } else {
+         return new BuildingQueryResult(List.of(), false);
+      }
+   }
+
+   public List<OsmBuildingFeature> buildingsForArea(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks) {
+      return this.buildingsForAreaWithStatus(minBlockX, minBlockZ, maxBlockX, maxBlockZ, worldScale, marginBlocks, OsmQueryMode.BLOCKING).features();
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0) && radius > 0) {
+         TileKey center = tileKeyForBlock(blockX, blockZ, worldScale, this.queryZoom);
+         if (center != null) {
+            int tilesPerAxis = 1 << this.queryZoom;
+            int minX = Math.max(0, center.x() - radius);
+            int maxX = Math.min(tilesPerAxis - 1, center.x() + radius);
+            int minY = Math.max(0, center.y() - radius);
+            int maxY = Math.min(tilesPerAxis - 1, center.y() + radius);
+
+            for (int tileY = minY; tileY <= maxY; tileY++) {
+               for (int tileX = minX; tileX <= maxX; tileX++) {
+                  this.getTile(new TileKey(this.queryZoom, tileX, tileY), OsmQueryMode.NON_BLOCKING);
+               }
+            }
+         }
+      }
+   }
+
+   private OsmBuildingTile getTile(TileKey key, OsmQueryMode mode) {
+      return this.getTileLookup(key, mode).tile();
+   }
+
+   private TileLookup getTileLookup(TileKey key, OsmQueryMode mode) {
+      OsmBuildingTile cached = this.cache.getIfPresent(key);
+      if (cached != null) {
+         if (!cached.isEmpty() || !this.tileLoadFailures.contains(key)) {
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.MEMORY);
+            return new TileLookup(cached, false);
+         }
+
+         this.cache.invalidate(key);
+      }
+
+      OsmQueryMode queryMode = mode == null ? OsmQueryMode.BLOCKING : mode;
+      if (queryMode == OsmQueryMode.NON_BLOCKING) {
+         this.queueAsyncLoad(key);
+         return new TileLookup(OsmBuildingTile.empty(), true);
+      } else {
+         try {
+            return new TileLookup(this.cache.get(key), false);
+         } catch (Exception error) {
+            Tellus.LOGGER.debug("Failed to load Overture building tile {}", key, error);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.FAILURE);
+            return new TileLookup(OsmBuildingTile.empty(), false);
+         }
+      }
+   }
+
+   private void queueAsyncLoad(TileKey key) {
+      if (MAX_ASYNC_PREFETCH_LOADS <= 0 || this.pendingAsyncLoads.size() < MAX_ASYNC_PREFETCH_LOADS) {
+         if (this.pendingAsyncLoads.add(key)) {
+            Util.backgroundExecutor().execute(() -> {
+               try {
+                  this.cache.get(key);
+               } catch (Exception error) {
+                  Tellus.LOGGER.debug("Async load failed for Overture building tile {}", key, error);
+                  this.tileLoadFailures.add(key);
+                  OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.FAILURE);
+               } finally {
+                  this.pendingAsyncLoads.remove(key);
+               }
+            });
+         }
+      }
+   }
+
+   private OsmBuildingTile loadTile(TileKey key) {
+      this.ensureInitialized();
+      if (!this.available) {
+         return OsmBuildingTile.empty();
+      } else {
+         TileGeoBounds bounds = tileBounds(key);
+         Path cachePath = this.cachePathFor(key);
+         Path parsedCachePath = this.parsedCachePathFor(key);
+         if (Files.exists(parsedCachePath)) {
+            try {
+               OsmBuildingTile parsed = ParsedTileCodec.readBuildingTile(parsedCachePath);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.PARSED_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException error) {
+               Tellus.LOGGER.debug("Invalid parsed Overture building cache tile {}, refetching", key, error);
+
+               try {
+                  Files.deleteIfExists(parsedCachePath);
+               } catch (IOException deleteError) {
+                  Tellus.LOGGER.debug("Failed to delete invalid parsed Overture building cache tile {}", parsedCachePath, deleteError);
+               }
+            }
+         }
+
+         if (Files.exists(cachePath)) {
+            try {
+               byte[] payload = this.readCompressed(cachePath);
+               OsmBuildingTile parsed = this.parseVectorTile(payload, bounds, key);
+               this.cacheParsedTile(parsedCachePath, parsed);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.RAW_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException error) {
+               Tellus.LOGGER.debug("Invalid Overture building cache tile {}, refetching", key, error);
+
+               try {
+                  Files.deleteIfExists(cachePath);
+               } catch (IOException deleteError) {
+                  Tellus.LOGGER.debug("Failed to delete invalid Overture building cache tile {}", cachePath, deleteError);
+               }
+            }
+         }
+
+         byte[] payload = this.fetchTilePayloadWithRetry(key);
+         OsmBuildingTile parsed;
+
+         try {
+            parsed = this.parseVectorTile(payload, bounds, key);
+         } catch (RuntimeException error) {
+            Tellus.LOGGER.warn("Overture building parse failed for tile {}", key, error);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.FAILURE);
+            throw new RuntimeException("Overture building parse failed for tile " + key, error);
+         }
+
+         this.cacheTile(cachePath, payload);
+         this.cacheParsedTile(parsedCachePath, parsed);
+         this.tileLoadFailures.remove(key);
+         OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.NETWORK);
+         return parsed;
+      }
+   }
+
+   private void ensureInitialized() {
+      if (this.initialized) {
+         return;
+      }
+
+      synchronized (this.initLock) {
+         if (this.initialized) {
+            return;
+         }
+
+         int resolvedZoom = QUERY_ZOOM;
+         boolean sourceAvailable;
+
+         try {
+            PmTilesRangeReader.PmTilesHeader header = this.pmTilesReader.header();
+            if (header.tileType() != PMTILES_TILETYPE_MVT) {
+               Tellus.LOGGER.warn("Unexpected Overture building PMTiles tile type {}, expected MVT", header.tileType());
+            }
+
+            resolvedZoom = Mth.clamp(resolvedZoom, header.minZoom(), header.maxZoom());
+            sourceAvailable = true;
+         } catch (IOException error) {
+            sourceAvailable = false;
+            Tellus.LOGGER.warn("Overture building PMTiles unavailable, OSM buildings disabled", error);
+         }
+
+         this.queryZoom = resolvedZoom;
+         this.available = sourceAvailable;
+         this.initialized = true;
+      }
+   }
+
+   private byte[] fetchTilePayloadWithRetry(TileKey key) {
+      RuntimeException lastFailure = null;
+
+      for (int attempt = 1; attempt <= FETCH_RETRY_ATTEMPTS; attempt++) {
+         try {
+            byte[] fetched = this.pmTilesReader.getTileBytes(key.zoom(), key.x(), key.y());
+            return fetched == null ? EMPTY_TILE_PAYLOAD : fetched;
+         } catch (IOException error) {
+            lastFailure = new RuntimeException("Overture building fetch failed for tile " + key, error);
+            if (attempt < FETCH_RETRY_ATTEMPTS) {
+               continue;
+            }
+            break;
+         }
+      }
+
+      this.tileLoadFailures.add(key);
+      OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_BUILDINGS, OsmPerf.TileLoadPath.FAILURE);
+      if (lastFailure != null) {
+         throw lastFailure;
+      } else {
+         return EMPTY_TILE_PAYLOAD;
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] payload) {
+      try {
+         Files.createDirectories(cachePath.getParent());
+         Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+
+         try (OutputStream output = new GZIPOutputStream(Files.newOutputStream(tempPath))) {
+            output.write(payload);
+         }
+
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to cache Overture building tile {}", cachePath, error);
+      }
+   }
+
+   private void cacheParsedTile(Path cachePath, OsmBuildingTile tile) {
+      try {
+         ParsedTileCodec.writeBuildingTile(cachePath, tile);
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to cache parsed Overture building tile {}", cachePath, error);
+      }
+   }
+
+   private byte[] readCompressed(Path path) throws IOException {
+      try (InputStream input = new GZIPInputStream(Files.newInputStream(path))) {
+         return input.readAllBytes();
+      }
+   }
+
+   private OsmBuildingTile parseVectorTile(byte[] payload, TileGeoBounds bounds, TileKey key) {
+      if (payload.length == 0) {
+         return OsmBuildingTile.empty();
+      } else {
+         Tile tile;
+
+         try {
+            tile = Tile.parseFrom(payload);
+         } catch (Exception error) {
+            throw new RuntimeException("Failed to decode building MVT payload", error);
+         }
+
+         if (tile.getLayersCount() == 0) {
+            return OsmBuildingTile.empty();
+         } else {
+            List<OsmBuildingFeature> features = new ArrayList<>();
+
+            for (Layer layer : tile.getLayersList()) {
+               String name = layer.getName();
+               if (BUILDING_PART_LAYER_NAME.equals(name) || BUILDING_LAYER_NAME.equals(name)) {
+                  int extent = layer.hasExtent() && layer.getExtent() > 0 ? layer.getExtent() : DEFAULT_TILE_EXTENT;
+
+                  for (Feature feature : layer.getFeaturesList()) {
+                     if (feature.getType() == GeomType.POLYGON) {
+                        OsmBuildingFeature parsed = this.parseFeature(feature, layer, key, extent, BUILDING_PART_LAYER_NAME.equals(name));
+                        if (parsed != null) {
+                           features.add(parsed);
+                        }
+                     }
+                  }
+               }
+            }
+
+            return features.isEmpty() ? OsmBuildingTile.empty() : new OsmBuildingTile(features, bounds.south(), bounds.west(), bounds.north(), bounds.east());
+         }
+      }
+   }
+
+   private OsmBuildingFeature parseFeature(Feature feature, Layer layer, TileKey key, int extent, boolean buildingPart) {
+      Map<String, Object> tags = decodeTags(feature, layer);
+      if (isTruthy(asString(tags.get("is_underground")))) {
+         return null;
+      } else {
+         OsmBuildingKind kind = buildingPart ? OsmBuildingKind.PART : OsmBuildingKind.FOOTPRINT;
+         boolean hasParts = isTruthy(asString(tags.get("has_parts")));
+         if (!buildingPart && hasParts) {
+            return null;
+         } else {
+            double heightMeters = buildingPart ? resolvePartHeightMeters(tags) : resolveFootprintHeightMeters(tags);
+            double minHeightMeters = buildingPart ? resolveMinHeightMeters(tags) : 0.0;
+            if (!(heightMeters > 0.0) || heightMeters <= minHeightMeters) {
+               return null;
+            } else {
+               List<List<TilePoint>> rings = decodePolygonRings(feature.getGeometryList());
+               if (rings.isEmpty()) {
+                  return null;
+               } else {
+                  double[][] longitudes = new double[rings.size()][];
+                  double[][] latitudes = new double[rings.size()][];
+
+                  for (int part = 0; part < rings.size(); part++) {
+                     List<TilePoint> ring = rings.get(part);
+                     int points = ring.size();
+                     double[] lonPart = new double[points];
+                     double[] latPart = new double[points];
+                     int count = 0;
+                     double previousLon = Double.NaN;
+                     double previousLat = Double.NaN;
+
+                     for (TilePoint point : ring) {
+                        double lon = tilePointToLon(key.zoom(), key.x(), (double)point.x / extent);
+                        double lat = tilePointToLat(key.zoom(), key.y(), (double)point.y / extent);
+                        if (Double.isFinite(lat)
+                           && Double.isFinite(lon)
+                           && !(lat < MIN_LAT)
+                           && !(lat > MAX_LAT)
+                           && !(lon < MIN_LON)
+                           && !(lon > MAX_LON)
+                           && (count <= 0 || !(Math.abs(lon - previousLon) < POINT_EPSILON) || !(Math.abs(lat - previousLat) < POINT_EPSILON))) {
+                           lonPart[count] = lon;
+                           latPart[count] = lat;
+                           previousLon = lon;
+                           previousLat = lat;
+                           count++;
+                        }
+                     }
+
+                     if (count < 4) {
+                        return null;
+                     }
+
+                     if (lonPart[0] != lonPart[count - 1] || latPart[0] != latPart[count - 1]) {
+                        if (count + 1 > lonPart.length) {
+                           lonPart = Arrays.copyOf(lonPart, count + 1);
+                           latPart = Arrays.copyOf(latPart, count + 1);
+                        }
+
+                        lonPart[count] = lonPart[0];
+                        latPart[count] = latPart[0];
+                        count++;
+                     }
+
+                     longitudes[part] = count == lonPart.length ? lonPart : Arrays.copyOf(lonPart, count);
+                     latitudes[part] = count == latPart.length ? latPart : Arrays.copyOf(latPart, count);
+                  }
+
+                  long featureId = resolveFeatureId(feature, tags);
+                  String buildingId = nonBlank(asString(tags.get("building_id")));
+                  OsmBuildingMetadata metadata = resolveMetadata(tags, heightMeters);
+                  return new OsmBuildingFeature(kind, featureId, buildingId, hasParts, metadata, heightMeters, Math.max(0.0, minHeightMeters), longitudes, latitudes);
+               }
+            }
+         }
+      }
+   }
+
+   private static OsmBuildingMetadata resolveMetadata(Map<String, Object> tags, double heightMeters) {
+      int floorCount = resolveFloorCount(tags, heightMeters);
+      return new OsmBuildingMetadata(
+         firstNonBlank(tags, "class", "building_class", "category", "kind"),
+         firstNonBlank(tags, "subtype", "building_subtype", "building", "type"),
+         firstNonBlank(tags, "building_use", "building:use", "use", "function", "subtype"),
+         firstNonBlank(tags, "@name", "name"),
+         floorCount,
+         firstNonBlank(tags, "roof_shape", "roof:shape"),
+         firstNonBlank(tags, "roof_material", "roof:material", "roof:colour", "roof_color")
+      );
+   }
+
+   private static double resolveFootprintHeightMeters(Map<String, Object> tags) {
+      Double height = parseDouble(tags.get("height"));
+      if (height != null && height > 0.0) {
+         return height;
+      } else {
+         Double floors = parseDouble(tags.get("num_floors"));
+         if (floors != null && floors > 0.0) {
+            return floors * 3.2;
+         } else {
+            return 6.0;
+         }
+      }
+   }
+
+   private static double resolvePartHeightMeters(Map<String, Object> tags) {
+      Double height = parseDouble(tags.get("height"));
+      if (height != null && height > 0.0) {
+         return height;
+      } else {
+         Double floors = parseDouble(tags.get("num_floors"));
+         if (floors != null && floors > 0.0) {
+            return floors * 3.2;
+         } else {
+            return 4.0;
+         }
+      }
+   }
+
+   private static double resolveMinHeightMeters(Map<String, Object> tags) {
+      Double minHeight = parseDouble(tags.get("min_height"));
+      if (minHeight != null && minHeight > 0.0) {
+         return minHeight;
+      } else {
+         Double minFloor = parseDouble(tags.get("min_floor"));
+         return minFloor != null && minFloor > 0.0 ? minFloor * 3.2 : 0.0;
+      }
+   }
+
+   private static int resolveFloorCount(Map<String, Object> tags, double heightMeters) {
+      Object[] candidates = new Object[]{
+         tags.get("num_floors"), tags.get("floors"), tags.get("building_levels"), tags.get("building:levels"), tags.get("level")
+      };
+
+      for (Object candidate : candidates) {
+         Double parsed = parseDouble(candidate);
+         if (parsed != null && parsed > 0.0) {
+            return Math.max(1, (int)Math.round(parsed));
+         }
+      }
+
+      return Math.max(1, (int)Math.round(heightMeters / 3.2));
+   }
+
+   private static List<List<TilePoint>> decodePolygonRings(List<Integer> geometry) {
+      if (geometry != null && !geometry.isEmpty()) {
+         List<List<TilePoint>> rings = new ArrayList<>();
+         List<TilePoint> current = null;
+         int cursorX = 0;
+         int cursorY = 0;
+         int cursor = 0;
+
+         while (cursor < geometry.size()) {
+            int commandAndCount = geometry.get(cursor++);
+            int command = commandAndCount & 7;
+            int count = commandAndCount >>> 3;
+            if (count > 0) {
+               switch (command) {
+                  case 1:
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return rings;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        if (current != null && !current.isEmpty()) {
+                           addRing(rings, current);
+                        }
+
+                        current = new ArrayList<>();
+                        current.add(new TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 2:
+                     if (current == null) {
+                        current = new ArrayList<>();
+                     }
+
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return rings;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        current.add(new TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 7:
+                     if (current != null && !current.isEmpty()) {
+                        addRing(rings, current);
+                        current = null;
+                     }
+                     break;
+                  default:
+                     return rings;
+               }
+            }
+         }
+
+         if (current != null && !current.isEmpty()) {
+            addRing(rings, current);
+         }
+
+         return rings;
+      } else {
+         return List.of();
+      }
+   }
+
+   private static void addRing(List<List<TilePoint>> rings, List<TilePoint> points) {
+      List<TilePoint> cleaned = new ArrayList<>(points.size());
+
+      for (TilePoint point : points) {
+         if (cleaned.isEmpty() || !samePoint(cleaned.get(cleaned.size() - 1), point)) {
+            cleaned.add(point);
+         }
+      }
+
+      if (cleaned.size() >= 3) {
+         TilePoint first = cleaned.get(0);
+         TilePoint last = cleaned.get(cleaned.size() - 1);
+         if (!samePoint(first, last)) {
+            cleaned.add(first);
+         }
+
+         if (cleaned.size() >= 4) {
+            rings.add(List.copyOf(cleaned));
+         }
+      }
+   }
+
+   private static boolean samePoint(TilePoint a, TilePoint b) {
+      return a.x == b.x && a.y == b.y;
+   }
+
+   private static int zigZagDecode(int encoded) {
+      return encoded >>> 1 ^ -(encoded & 1);
+   }
+
+   private static double tilePointToLon(int zoom, int tileX, double localX) {
+      double n = tilesPerAxis(zoom);
+      double normalizedX = (tileX + localX) / n;
+      return normalizedX * 360.0 - 180.0;
+   }
+
+   private static double tilePointToLat(int zoom, int tileY, double localY) {
+      double n = tilesPerAxis(zoom);
+      double normalizedY = (tileY + localY) / n;
+      double mercator = Math.PI * (1.0 - 2.0 * normalizedY);
+      return Math.toDegrees(Math.atan(Math.sinh(mercator)));
+   }
+
+   private static Map<String, Object> decodeTags(Feature feature, Layer layer) {
+      List<Integer> tags = feature.getTagsList();
+      if (tags.isEmpty()) {
+         return Map.of();
+      } else {
+         Map<String, Object> values = new HashMap<>(tags.size() / 2);
+
+         for (int i = 0; i + 1 < tags.size(); i += 2) {
+            int keyIndex = tags.get(i);
+            int valueIndex = tags.get(i + 1);
+            if (keyIndex >= 0 && keyIndex < layer.getKeysCount() && valueIndex >= 0 && valueIndex < layer.getValuesCount()) {
+               String key = layer.getKeys(keyIndex);
+               Object value = decodeValue(layer.getValues(valueIndex));
+               if (value != null) {
+                  values.put(key, value);
+               }
+            }
+         }
+
+         return values;
+      }
+   }
+
+   private static Object decodeValue(Value value) {
+      if (value.hasStringValue()) {
+         return value.getStringValue();
+      } else if (value.hasIntValue()) {
+         return value.getIntValue();
+      } else if (value.hasSintValue()) {
+         return value.getSintValue();
+      } else if (value.hasUintValue()) {
+         return value.getUintValue();
+      } else if (value.hasFloatValue()) {
+         return value.getFloatValue();
+      } else if (value.hasDoubleValue()) {
+         return value.getDoubleValue();
+      } else if (value.hasBoolValue()) {
+         return value.getBoolValue();
+      } else {
+         return null;
+      }
+   }
+
+   private static long resolveFeatureId(Feature feature, Map<String, Object> tags) {
+      if (feature.hasId()) {
+         return feature.getId();
+      } else {
+         Object[] candidates = new Object[]{tags.get("id"), tags.get("@id"), tags.get("building_id")};
+
+         for (Object candidate : candidates) {
+            Long resolved = tryResolveId(candidate);
+            if (resolved != null) {
+               return resolved;
+            }
+         }
+
+         Object sources = tags.get("sources");
+         if (sources instanceof String stringSources && !stringSources.isBlank()) {
+            Long resolved = tryParseSourcesId(stringSources);
+            if (resolved != null) {
+               return resolved;
+            }
+         }
+
+         return hash64(String.valueOf(tags));
+      }
+   }
+
+   private static Long tryResolveId(Object value) {
+      if (value == null) {
+         return null;
+      } else if (value instanceof Number number) {
+         return number.longValue();
+      } else {
+         String text = String.valueOf(value).trim();
+         if (text.isEmpty()) {
+            return null;
+         } else {
+            try {
+               return text.contains("-") ? hashUuid(text) : Long.parseLong(text);
+            } catch (RuntimeException error) {
+               return hash64(text);
+            }
+         }
+      }
+   }
+
+   private static long hashUuid(String text) {
+      UUID uuid = UUID.fromString(text);
+      return uuid.getMostSignificantBits() ^ uuid.getLeastSignificantBits();
+   }
+
+   private static Long tryParseSourcesId(String sources) {
+      int idIndex = sources.indexOf("\"id\"");
+      if (idIndex < 0) {
+         return null;
+      } else {
+         int colon = sources.indexOf(58, idIndex);
+         if (colon < 0) {
+            return null;
+         } else {
+            int start = colon + 1;
+
+            while (start < sources.length() && Character.isWhitespace(sources.charAt(start))) {
+               start++;
+            }
+
+            int end = start;
+            while (end < sources.length() && Character.isDigit(sources.charAt(end))) {
+               end++;
+            }
+
+            if (end <= start) {
+               return null;
+            } else {
+               try {
+                  return Long.parseLong(sources.substring(start, end));
+               } catch (NumberFormatException error) {
+                  return null;
+               }
+            }
+         }
+      }
+   }
+
+   private static long hash64(String text) {
+      long hash = -3750763034362895579L;
+
+      for (int i = 0; i < text.length(); i++) {
+         hash ^= text.charAt(i);
+         hash *= 1099511628211L;
+      }
+
+      return hash;
+   }
+
+   private static Double parseDouble(Object value) {
+      if (value == null) {
+         return null;
+      } else if (value instanceof Number number) {
+         return number.doubleValue();
+      } else {
+         String text = String.valueOf(value);
+         if (text.isBlank()) {
+            return null;
+         } else {
+            try {
+               return Double.parseDouble(text.trim());
+            } catch (NumberFormatException error) {
+               return null;
+            }
+         }
+      }
+   }
+
+   private static boolean isTruthy(String value) {
+      if (value == null) {
+         return false;
+      } else {
+         String normalized = value.trim().toLowerCase(Locale.ROOT);
+         return !normalized.isEmpty() && !"no".equals(normalized) && !"false".equals(normalized) && !"0".equals(normalized);
+      }
+   }
+
+   private static String asString(Object value) {
+      return value == null ? null : String.valueOf(value);
+   }
+
+   private static String firstNonBlank(Map<String, Object> tags, String... keys) {
+      for (String key : keys) {
+         String value = nonBlank(asString(tags.get(key)));
+         if (value != null) {
+            return value;
+         }
+      }
+
+      return null;
+   }
+
+   private static String nonBlank(String value) {
+      return value != null && !value.isBlank() ? value : null;
+   }
+
+   private Path cachePathFor(TileKey key) {
+      return this.cacheRoot.resolve("raw").resolve(key.zoom() + "/" + key.x()).resolve(key.y() + ".mvt.gz");
+   }
+
+   private Path parsedCachePathFor(TileKey key) {
+      return this.cacheRoot.resolve("parsed").resolve(key.zoom() + "/" + key.x()).resolve(key.y() + ".tile");
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.OSM;
+   }
+
+   @Override
+   public void clearCache() {
+      this.cache.invalidateAll();
+      this.cache.cleanUp();
+      this.pendingAsyncLoads.clear();
+      this.tileLoadFailures.clear();
+   }
+
+   private static GeoBounds geoBoundsForBlockArea(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, int margin, double worldScale) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double west = clampLon((Math.min(minBlockX, maxBlockX) - margin) / blocksPerDegree);
+         double east = clampLon((Math.max(minBlockX, maxBlockX) + margin) / blocksPerDegree);
+         double north = clampLat(EarthProjection.blockZToLat(Math.min(minBlockZ, maxBlockZ) - margin, worldScale));
+         double south = clampLat(EarthProjection.blockZToLat(Math.max(minBlockZ, maxBlockZ) + margin, worldScale));
+         return south <= north && west <= east ? new GeoBounds(south, west, north, east) : null;
+      }
+   }
+
+   private static List<TileKey> tileKeysForBounds(GeoBounds bounds, int zoom) {
+      int minX = clampTile(lonToTileX(bounds.west(), zoom), zoom);
+      int maxX = clampTile(lonToTileX(bounds.east(), zoom), zoom);
+      int minY = clampTile(latToTileY(bounds.north(), zoom), zoom);
+      int maxY = clampTile(latToTileY(bounds.south(), zoom), zoom);
+      if (maxX < minX || maxY < minY) {
+         return List.of();
+      } else {
+         List<TileKey> keys = new ArrayList<>((maxX - minX + 1) * (maxY - minY + 1));
+
+         for (int tileY = minY; tileY <= maxY; tileY++) {
+            for (int tileX = minX; tileX <= maxX; tileX++) {
+               keys.add(new TileKey(zoom, tileX, tileY));
+            }
+         }
+
+         return keys;
+      }
+   }
+
+   private static TileKey tileKeyForBlock(double blockX, double blockZ, double worldScale, int zoom) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double lon = clampLon(blockX / blocksPerDegree);
+         double lat = clampLat(EarthProjection.blockZToLat(blockZ, worldScale));
+         return new TileKey(zoom, clampTile(lonToTileX(lon, zoom), zoom), clampTile(latToTileY(lat, zoom), zoom));
+      }
+   }
+
+   private static TileGeoBounds tileBounds(TileKey key) {
+      double west = tileXToLon(key.x(), key.zoom());
+      double east = tileXToLon(key.x() + 1, key.zoom());
+      double north = tileYToLat(key.y(), key.zoom());
+      double south = tileYToLat(key.y() + 1, key.zoom());
+      return new TileGeoBounds(south, west, north, east);
+   }
+
+   private static int lonToTileX(double lon, int zoom) {
+      double normalized = (lon + 180.0) / 360.0;
+      return (int)Math.floor(normalized * tilesPerAxis(zoom));
+   }
+
+   private static int latToTileY(double lat, int zoom) {
+      double clampedLat = clampLat(lat);
+      double latRad = Math.toRadians(clampedLat);
+      double normalized = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0;
+      return (int)Math.floor(normalized * tilesPerAxis(zoom));
+   }
+
+   private static double tileXToLon(int tileX, int zoom) {
+      return (double)tileX / tilesPerAxis(zoom) * 360.0 - 180.0;
+   }
+
+   private static double tileYToLat(int tileY, int zoom) {
+      double mercator = Math.PI * (1.0 - 2.0 * (double)tileY / tilesPerAxis(zoom));
+      return Math.toDegrees(Math.atan(Math.sinh(mercator)));
+   }
+
+   private static int clampTile(int value, int zoom) {
+      int max = (1 << zoom) - 1;
+      return Mth.clamp(value, 0, max);
+   }
+
+   private static double tilesPerAxis(int zoom) {
+      return (double)(1 << zoom);
+   }
+
+   private static double clampLon(double lon) {
+      return Mth.clamp(lon, MIN_LON, MAX_LON);
+   }
+
+   private static double clampLat(double lat) {
+      return Mth.clamp(lat, MIN_LAT, MAX_LAT);
+   }
+
+   private static int intProperty(String key, int defaultValue, int minInclusive, int maxInclusive) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            return Mth.clamp(Integer.parseInt(value.trim()), minInclusive, maxInclusive);
+         } catch (NumberFormatException error) {
+            return defaultValue;
+         }
+      }
+   }
+
+   public record BuildingQueryResult(List<OsmBuildingFeature> features, boolean hadCacheMiss) {
+      public BuildingQueryResult(List<OsmBuildingFeature> features, boolean hadCacheMiss) {
+         features = features == null ? List.of() : List.copyOf(features);
+         this.features = features;
+         this.hadCacheMiss = hadCacheMiss;
+      }
+   }
+
+   private record TileLookup(OsmBuildingTile tile, boolean cacheMiss) {
+   }
+
+   private record TileKey(int zoom, int x, int y) {
+   }
+
+   private record GeoBounds(double south, double west, double north, double east) {
+   }
+
+   private record TileGeoBounds(double south, double west, double north, double east) {
+   }
+
+   private record TilePoint(int x, int y) {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmRoadSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmRoadSource.java
@@ -1,0 +1,1356 @@
+package com.yucareux.tellus.world.data.osm;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Feature;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.GeomType;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Layer;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Value;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+import net.minecraft.Util;
+
+public final class TellusOsmRoadSource implements TellusCacheHandle {
+   private static final String DEFAULT_PM_TILES_URL = "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-02-18.0/transportation.pmtiles";
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final double METERS_PER_DEGREE = 111319.49166666667;
+   private static final double POINT_EPSILON = 1.0E-9;
+   private static final int DEFAULT_TILE_EXTENT = 4096;
+   private static final int CONNECT_TIMEOUT_MS = intProperty("tellus.overture.roads.connectTimeoutMs", 7000, 1, 120000);
+   private static final int READ_TIMEOUT_MS = intProperty("tellus.overture.roads.readTimeoutMs", 20000, 1, 180000);
+   private static final int DIRECTORY_CACHE_ENTRIES = intProperty("tellus.overture.roads.dirCache", 256, 1, 8192);
+   private static final int MAX_CACHE_TILES = intProperty("tellus.osm.roads.cacheTiles", 256, 1, 8192);
+   private static final int QUERY_ZOOM = intProperty("tellus.osm.roads.queryZoom", 14, 0, 20);
+   private static final int MAX_ASYNC_PREFETCH_LOADS = intProperty("tellus.osm.roads.prefetchAsyncMax", 96, 0, 8192);
+   private static final int MAX_BRIDGE_LEVEL = intProperty("tellus.overture.roads.maxBridgeLevel", 3, 1, 16);
+   private static final int FETCH_RETRY_ATTEMPTS = intProperty("tellus.overture.roads.fetchRetries", 3, 1, 8);
+   private static final int PMTILES_TILETYPE_MVT = 1;
+   private static final String SEGMENT_LAYER_NAME = "segment";
+   private static final byte[] EMPTY_TILE_PAYLOAD = new byte[0];
+   private final Path cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/map/roads");
+   private final PmTilesRangeReader pmTilesReader;
+   private final Object initLock = new Object();
+   private final LoadingCache<TellusOsmRoadSource.TileKey, OverpassRoadTile> cache;
+   private final Set<TellusOsmRoadSource.TileKey> pendingAsyncLoads;
+   private final Set<TellusOsmRoadSource.TileKey> tileLoadFailures;
+   private volatile int queryZoom = QUERY_ZOOM;
+   private volatile boolean available;
+   private volatile boolean initialized;
+
+   public TellusOsmRoadSource() {
+      String pmTilesUrl = System.getProperty(
+         "tellus.overture.roads.pmtiles", DEFAULT_PM_TILES_URL
+      );
+      this.pmTilesReader = new PmTilesRangeReader(pmTilesUrl, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS, DIRECTORY_CACHE_ENTRIES);
+      this.cache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_TILES).build(new CacheLoader<TellusOsmRoadSource.TileKey, OverpassRoadTile>() {
+         public OverpassRoadTile load(TellusOsmRoadSource.TileKey key) {
+            return TellusOsmRoadSource.this.loadTile(key);
+         }
+      });
+      this.pendingAsyncLoads = ConcurrentHashMap.newKeySet();
+      this.tileLoadFailures = ConcurrentHashMap.newKeySet();
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean available() {
+      this.ensureInitialized();
+      return this.available;
+   }
+
+   public List<RoadFeature> roadsForArea(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks) {
+      return this.roadsForArea(minBlockX, minBlockZ, maxBlockX, maxBlockZ, worldScale, marginBlocks, OsmQueryMode.BLOCKING);
+   }
+
+   public List<RoadFeature> roadsForArea(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks, OsmQueryMode mode) {
+      return this.roadsForAreaWithStatus(minBlockX, minBlockZ, maxBlockX, maxBlockZ, worldScale, marginBlocks, mode).features();
+   }
+
+   public TellusOsmRoadSource.RoadQueryResult roadsForAreaWithStatus(
+      int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks, OsmQueryMode mode
+   ) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0)) {
+         TellusOsmRoadSource.GeoBounds bounds = geoBoundsForBlockArea(minBlockX, minBlockZ, maxBlockX, maxBlockZ, marginBlocks, worldScale);
+         if (bounds == null) {
+            return new TellusOsmRoadSource.RoadQueryResult(List.of(), false);
+         } else {
+            List<TellusOsmRoadSource.TileKey> keys = tileKeysForBounds(bounds, this.queryZoom);
+            if (keys.isEmpty()) {
+               return new TellusOsmRoadSource.RoadQueryResult(List.of(), false);
+            } else {
+               List<RoadFeature> roads = new ArrayList<>();
+               boolean hadCacheMiss = false;
+
+               for (TellusOsmRoadSource.TileKey key : keys) {
+                  TellusOsmRoadSource.TileLookup lookup = this.getTileLookup(key, mode);
+                  hadCacheMiss |= lookup.cacheMiss();
+                  OverpassRoadTile tile = lookup.tile();
+                  if (!tile.isEmpty()) {
+                     List<RoadFeature> tileFeatures = tile.featuresInBounds(bounds.south(), bounds.west(), bounds.north(), bounds.east());
+                     roads.addAll(tileFeatures);
+                  }
+               }
+
+               return new TellusOsmRoadSource.RoadQueryResult(roads, hadCacheMiss);
+            }
+         }
+      } else {
+         return new TellusOsmRoadSource.RoadQueryResult(List.of(), false);
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0) && radius > 0) {
+         TellusOsmRoadSource.TileKey center = tileKeyForBlock(blockX, blockZ, worldScale, this.queryZoom);
+         if (center != null) {
+            int tilesPerAxis = 1 << this.queryZoom;
+            int minX = Math.max(0, center.x() - radius);
+            int maxX = Math.min(tilesPerAxis - 1, center.x() + radius);
+            int minY = Math.max(0, center.y() - radius);
+            int maxY = Math.min(tilesPerAxis - 1, center.y() + radius);
+
+            for (int tileY = minY; tileY <= maxY; tileY++) {
+               for (int tileX = minX; tileX <= maxX; tileX++) {
+                  this.getTile(new TellusOsmRoadSource.TileKey(this.queryZoom, tileX, tileY), OsmQueryMode.NON_BLOCKING);
+               }
+            }
+         }
+      }
+   }
+
+   private OverpassRoadTile getTile(TellusOsmRoadSource.TileKey key, OsmQueryMode mode) {
+      return this.getTileLookup(key, mode).tile();
+   }
+
+   private TellusOsmRoadSource.TileLookup getTileLookup(TellusOsmRoadSource.TileKey key, OsmQueryMode mode) {
+      OverpassRoadTile cached = (OverpassRoadTile)this.cache.getIfPresent(key);
+      if (cached != null) {
+         if (!cached.isEmpty() || !this.tileLoadFailures.contains(key)) {
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.MEMORY);
+            return new TellusOsmRoadSource.TileLookup(cached, false);
+         }
+
+         this.cache.invalidate(key);
+      }
+
+      OsmQueryMode queryMode = mode == null ? OsmQueryMode.BLOCKING : mode;
+      if (queryMode == OsmQueryMode.NON_BLOCKING) {
+         this.queueAsyncLoad(key);
+         return new TellusOsmRoadSource.TileLookup(OverpassRoadTile.empty(), true);
+      } else {
+         try {
+            return new TellusOsmRoadSource.TileLookup((OverpassRoadTile)this.cache.get(key), false);
+         } catch (Exception var6) {
+            Tellus.LOGGER.debug("Failed to load Overture road tile {}", key, var6);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.FAILURE);
+            return new TellusOsmRoadSource.TileLookup(OverpassRoadTile.empty(), false);
+         }
+      }
+   }
+
+   private void queueAsyncLoad(TellusOsmRoadSource.TileKey key) {
+      if (MAX_ASYNC_PREFETCH_LOADS <= 0 || this.pendingAsyncLoads.size() < MAX_ASYNC_PREFETCH_LOADS) {
+         if (this.pendingAsyncLoads.add(key)) {
+            Util.backgroundExecutor().execute(() -> {
+               try {
+                  this.cache.get(key);
+               } catch (Exception var6) {
+                  Tellus.LOGGER.debug("Async load failed for Overture road tile {}", key, var6);
+                  this.tileLoadFailures.add(key);
+                  OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.FAILURE);
+               } finally {
+                  this.pendingAsyncLoads.remove(key);
+               }
+            });
+         }
+      }
+   }
+
+   private OverpassRoadTile loadTile(TellusOsmRoadSource.TileKey key) {
+      this.ensureInitialized();
+      if (!this.available) {
+         return OverpassRoadTile.empty();
+      } else {
+         TellusOsmRoadSource.TileGeoBounds bounds = tileBounds(key);
+         Path cachePath = this.cachePathFor(key);
+         Path parsedCachePath = this.parsedCachePathFor(key);
+         if (Files.exists(parsedCachePath)) {
+            try {
+               OverpassRoadTile parsed = ParsedTileCodec.readRoadTile(parsedCachePath);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.PARSED_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException var12) {
+               Tellus.LOGGER.debug("Invalid parsed Overture road cache tile {}, refetching", key, var12);
+
+               try {
+                  Files.deleteIfExists(parsedCachePath);
+               } catch (IOException var10) {
+                  Tellus.LOGGER.debug("Failed to delete invalid parsed Overture road cache tile {}", parsedCachePath, var10);
+               }
+            }
+         }
+
+         if (Files.exists(cachePath)) {
+            try {
+               byte[] payload = this.readCompressed(cachePath);
+               OverpassRoadTile parsed = this.parseVectorTile(payload, bounds, key);
+               this.cacheParsedTile(parsedCachePath, parsed);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.RAW_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException var11) {
+               Tellus.LOGGER.debug("Invalid Overture road cache tile {}, refetching", key, var11);
+
+               try {
+                  Files.deleteIfExists(cachePath);
+               } catch (IOException var9) {
+                  Tellus.LOGGER.debug("Failed to delete invalid Overture road cache tile {}", cachePath, var9);
+               }
+            }
+         }
+
+         byte[] payload = this.fetchTilePayloadWithRetry(key);
+
+         OverpassRoadTile parsed;
+         try {
+            parsed = this.parseVectorTile(payload, bounds, key);
+         } catch (RuntimeException var8) {
+            Tellus.LOGGER.warn("Overture road parse failed for tile {}", key, var8);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.FAILURE);
+            throw new RuntimeException("Overture road parse failed for tile " + key, var8);
+         }
+
+         this.cacheTile(cachePath, payload);
+         this.cacheParsedTile(parsedCachePath, parsed);
+         this.tileLoadFailures.remove(key);
+         OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.NETWORK);
+         return parsed;
+      }
+   }
+
+   private void ensureInitialized() {
+      if (this.initialized) {
+         return;
+      }
+
+      synchronized (this.initLock) {
+         if (this.initialized) {
+            return;
+         }
+
+         int resolvedZoom = QUERY_ZOOM;
+         boolean sourceAvailable;
+
+         try {
+            PmTilesRangeReader.PmTilesHeader header = this.pmTilesReader.header();
+            if (header.tileType() != PMTILES_TILETYPE_MVT) {
+               Tellus.LOGGER.warn("Unexpected Overture road PMTiles tile type {}, expected MVT", header.tileType());
+            }
+
+            resolvedZoom = Mth.clamp(resolvedZoom, header.minZoom(), header.maxZoom());
+            sourceAvailable = true;
+         } catch (IOException error) {
+            sourceAvailable = false;
+            Tellus.LOGGER.warn("Overture road PMTiles unavailable, roads disabled", error);
+         }
+
+         this.queryZoom = resolvedZoom;
+         this.available = sourceAvailable;
+         this.initialized = true;
+      }
+   }
+
+   private byte[] fetchTilePayloadWithRetry(TellusOsmRoadSource.TileKey key) {
+      RuntimeException lastFailure = null;
+
+      for (int attempt = 1; attempt <= FETCH_RETRY_ATTEMPTS; attempt++) {
+         try {
+            byte[] fetched = this.pmTilesReader.getTileBytes(key.zoom(), key.x(), key.y());
+            return fetched == null ? EMPTY_TILE_PAYLOAD : fetched;
+         } catch (IOException var5) {
+            lastFailure = new RuntimeException("Overture road fetch failed for tile " + key, var5);
+            if (attempt < FETCH_RETRY_ATTEMPTS) {
+               continue;
+            }
+            break;
+         }
+      }
+
+      this.tileLoadFailures.add(key);
+      OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_ROADS, OsmPerf.TileLoadPath.FAILURE);
+      if (lastFailure != null) {
+         throw lastFailure;
+      } else {
+         return EMPTY_TILE_PAYLOAD;
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] payload) {
+      try {
+         Files.createDirectories(cachePath.getParent());
+         Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+
+         try (OutputStream output = new GZIPOutputStream(Files.newOutputStream(tempPath))) {
+            output.write(payload);
+         }
+
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException var9) {
+         Tellus.LOGGER.debug("Failed to cache Overture road tile {}", cachePath, var9);
+      }
+   }
+
+   private void cacheParsedTile(Path cachePath, OverpassRoadTile tile) {
+      try {
+         ParsedTileCodec.writeRoadTile(cachePath, tile);
+      } catch (IOException var4) {
+         Tellus.LOGGER.debug("Failed to cache parsed Overture road tile {}", cachePath, var4);
+      }
+   }
+
+   private byte[] readCompressed(Path path) throws IOException {
+      byte[] var3;
+      try (InputStream input = new GZIPInputStream(Files.newInputStream(path))) {
+         var3 = input.readAllBytes();
+      }
+
+      return var3;
+   }
+
+   private OverpassRoadTile parseVectorTile(byte[] payload, TellusOsmRoadSource.TileGeoBounds bounds, TellusOsmRoadSource.TileKey key) {
+      if (payload.length == 0) {
+         return OverpassRoadTile.empty();
+      } else {
+         Tile tile;
+         try {
+            tile = Tile.parseFrom(payload);
+         } catch (Exception var12) {
+            throw new RuntimeException("Failed to decode transportation MVT payload", var12);
+         }
+
+         if (tile.getLayersCount() == 0) {
+            return OverpassRoadTile.empty();
+         } else {
+            List<RoadFeature> features = new ArrayList<>();
+
+            for (Layer layer : tile.getLayersList()) {
+               if (SEGMENT_LAYER_NAME.equals(layer.getName())) {
+                  int extent = layer.hasExtent() && layer.getExtent() > 0 ? layer.getExtent() : DEFAULT_TILE_EXTENT;
+
+                  for (Feature feature : layer.getFeaturesList()) {
+                     if (feature.getType() == GeomType.LINESTRING) {
+                        features.addAll(this.parseFeature(feature, layer, key, extent));
+                     }
+                  }
+               }
+            }
+
+            return features.isEmpty() ? OverpassRoadTile.empty() : new OverpassRoadTile(features, bounds.south(), bounds.west(), bounds.north(), bounds.east());
+         }
+      }
+   }
+
+   private List<RoadFeature> parseFeature(Feature feature, Layer layer, TellusOsmRoadSource.TileKey key, int extent) {
+      Map<String, Object> tags = decodeTags(feature, layer);
+      String subtype = asString(tags.get("subtype"));
+      if (subtype != null && "road".equalsIgnoreCase(subtype)) {
+         String classTag = resolveClassTag(tags);
+         if (classTag == null) {
+            return List.of();
+         } else {
+            RoadClass maybeRoadClass = RoadClass.fromHighwayTag(classTag);
+            if (maybeRoadClass == null) {
+               return List.of();
+            } else {
+               TellusOsmRoadSource.LineString line = selectPrimaryLineString(feature.getGeometryList());
+               if (line == null) {
+                  return List.of();
+               } else {
+                  long wayId = resolveFeatureId(feature, tags);
+                  return buildFeaturesFromLine(wayId, maybeRoadClass, classTag, tags, line, key.zoom(), key.x(), key.y(), extent);
+               }
+            }
+         }
+      } else {
+         return List.of();
+      }
+   }
+
+   private static List<RoadFeature> buildFeaturesFromLine(
+      long wayId,
+      RoadClass roadClass,
+      String highwayTag,
+      Map<String, Object> tags,
+      TellusOsmRoadSource.LineString line,
+      int zoom,
+      int tileX,
+      int tileY,
+      int extent
+   ) {
+      List<TellusOsmRoadSource.TilePoint> points = line.points();
+      int maxPoints = points.size();
+      double[] longitudes = new double[maxPoints];
+      double[] latitudes = new double[maxPoints];
+      int count = 0;
+      double previousLon = Double.NaN;
+      double previousLat = Double.NaN;
+
+      for (TellusOsmRoadSource.TilePoint point : points) {
+         double localX = (double)point.x / extent;
+         double localY = (double)point.y / extent;
+         double lon = tilePointToLon(zoom, tileX, localX);
+         double lat = tilePointToLat(zoom, tileY, localY);
+         if (Double.isFinite(lat)
+            && Double.isFinite(lon)
+            && !(lat < MIN_LAT)
+            && !(lat > MAX_LAT)
+            && !(lon < MIN_LON)
+            && !(lon > MAX_LON)
+            && (count <= 0 || !(Math.abs(lon - previousLon) < POINT_EPSILON) || !(Math.abs(lat - previousLat) < POINT_EPSILON))) {
+            longitudes[count] = lon;
+            latitudes[count] = lat;
+            previousLon = lon;
+            previousLat = lat;
+            count++;
+         }
+      }
+
+      if (count < 2) {
+         return List.of();
+      } else {
+         double[] trimmedLon = count == longitudes.length ? longitudes : Arrays.copyOf(longitudes, count);
+         double[] trimmedLat = count == latitudes.length ? latitudes : Arrays.copyOf(latitudes, count);
+         return buildFeatures(wayId, roadClass, highwayTag, tags, trimmedLon, trimmedLat);
+      }
+   }
+
+   static List<RoadFeature> buildFeatures(
+      long wayId, RoadClass roadClass, String highwayTag, Map<String, Object> tags, double[] longitudes, double[] latitudes
+   ) {
+      Map<String, Object> safeTags = tags == null ? Map.of() : tags;
+      TellusOsmRoadSource.LineGeometry geometry = TellusOsmRoadSource.LineGeometry.create(longitudes, latitudes);
+      if (geometry == null) {
+         return List.of();
+      } else {
+         List<Double> breakpoints = collectScopedBreakpoints(safeTags);
+         List<RoadFeature> features = new ArrayList<>();
+         TellusOsmRoadSource.RoadDescriptor activeDescriptor = null;
+         double activeStart = 0.0;
+         double activeEnd = 0.0;
+
+         for (int i = 1; i < breakpoints.size(); i++) {
+            double start = breakpoints.get(i - 1);
+            double end = breakpoints.get(i);
+            if (!(end - start <= 1.0E-6)) {
+               TellusOsmRoadSource.RoadDescriptor descriptor = resolveRoadDescriptorAt(safeTags, roadClass, start + (end - start) * 0.5);
+               if (activeDescriptor != null && activeDescriptor.equals(descriptor) && Math.abs(start - activeEnd) <= 1.0E-6) {
+                  activeEnd = end;
+               } else {
+                  appendRoadSlice(features, wayId, roadClass, highwayTag, geometry, activeDescriptor, activeStart, activeEnd);
+                  activeDescriptor = descriptor;
+                  activeStart = start;
+                  activeEnd = end;
+               }
+            }
+         }
+
+         appendRoadSlice(features, wayId, roadClass, highwayTag, geometry, activeDescriptor, activeStart, activeEnd);
+         return features;
+      }
+   }
+
+   private static void appendRoadSlice(
+      List<RoadFeature> features,
+      long wayId,
+      RoadClass roadClass,
+      String highwayTag,
+      TellusOsmRoadSource.LineGeometry geometry,
+      TellusOsmRoadSource.RoadDescriptor descriptor,
+      double start,
+      double end
+   ) {
+      if (descriptor != null) {
+         RoadFeature feature = buildFeatureFromRange(wayId, roadClass, descriptor.mode(), descriptor.bridgeLevel(), highwayTag, geometry, start, end);
+         if (feature != null) {
+            features.add(feature);
+         }
+      }
+   }
+
+   private static RoadFeature buildFeatureFromRange(
+      long wayId,
+      RoadClass roadClass,
+      RoadMode mode,
+      int bridgeLevel,
+      String highwayTag,
+      TellusOsmRoadSource.LineGeometry geometry,
+      double start,
+      double end
+   ) {
+      double clampedStart = Mth.clamp(start, 0.0, 1.0);
+      double clampedEnd = Mth.clamp(end, 0.0, 1.0);
+      if (!(clampedEnd - clampedStart <= 1.0E-6) && geometry.totalLength() > 1.0E-9) {
+         double startDistance = geometry.totalLength() * clampedStart;
+         double endDistance = geometry.totalLength() * clampedEnd;
+         List<Double> sliceLon = new ArrayList<>();
+         List<Double> sliceLat = new ArrayList<>();
+         TellusOsmRoadSource.GeoPoint startPoint = pointAtDistance(geometry, startDistance);
+         appendPoint(sliceLon, sliceLat, startPoint.lon(), startPoint.lat());
+
+         for (int i = 1; i < geometry.longitudes().length - 1; i++) {
+            double distance = geometry.distances()[i];
+            if (distance > startDistance + 1.0E-9 && distance < endDistance - 1.0E-9) {
+               appendPoint(sliceLon, sliceLat, geometry.longitudes()[i], geometry.latitudes()[i]);
+            }
+         }
+
+         TellusOsmRoadSource.GeoPoint endPoint = pointAtDistance(geometry, endDistance);
+         appendPoint(sliceLon, sliceLat, endPoint.lon(), endPoint.lat());
+         if (sliceLon.size() < 2) {
+            return null;
+         } else {
+            double[] featureLon = new double[sliceLon.size()];
+            double[] featureLat = new double[sliceLat.size()];
+
+            for (int i = 0; i < sliceLon.size(); i++) {
+               featureLon[i] = sliceLon.get(i);
+               featureLat[i] = sliceLat.get(i);
+            }
+
+            return new RoadFeature(wayId, roadClass, mode, bridgeLevel, highwayTag, featureLon, featureLat);
+         }
+      } else {
+         return null;
+      }
+   }
+
+   private static void appendPoint(List<Double> longitudes, List<Double> latitudes, double lon, double lat) {
+      int size = longitudes.size();
+      if (size <= 0
+         || Math.abs(longitudes.get(size - 1) - lon) >= POINT_EPSILON
+         || Math.abs(latitudes.get(size - 1) - lat) >= POINT_EPSILON) {
+         longitudes.add(lon);
+         latitudes.add(lat);
+      }
+   }
+
+   private static TellusOsmRoadSource.GeoPoint pointAtDistance(TellusOsmRoadSource.LineGeometry geometry, double distance) {
+      double clampedDistance = Mth.clamp(distance, 0.0, geometry.totalLength());
+      if (clampedDistance <= 1.0E-9) {
+         return new TellusOsmRoadSource.GeoPoint(geometry.longitudes()[0], geometry.latitudes()[0]);
+      } else if (geometry.totalLength() - clampedDistance <= 1.0E-9) {
+         int last = geometry.longitudes().length - 1;
+         return new TellusOsmRoadSource.GeoPoint(geometry.longitudes()[last], geometry.latitudes()[last]);
+      } else {
+         for (int i = 1; i < geometry.longitudes().length; i++) {
+            double endDistance = geometry.distances()[i];
+            if (clampedDistance <= endDistance + 1.0E-9) {
+               double startDistance = geometry.distances()[i - 1];
+               double segmentLength = endDistance - startDistance;
+               if (segmentLength <= 1.0E-9) {
+                  return new TellusOsmRoadSource.GeoPoint(geometry.longitudes()[i], geometry.latitudes()[i]);
+               }
+
+               double t = (clampedDistance - startDistance) / segmentLength;
+               double lon = geometry.longitudes()[i - 1] + (geometry.longitudes()[i] - geometry.longitudes()[i - 1]) * t;
+               double lat = geometry.latitudes()[i - 1] + (geometry.latitudes()[i] - geometry.latitudes()[i - 1]) * t;
+               return new TellusOsmRoadSource.GeoPoint(lon, lat);
+            }
+         }
+
+         int last = geometry.longitudes().length - 1;
+         return new TellusOsmRoadSource.GeoPoint(geometry.longitudes()[last], geometry.latitudes()[last]);
+      }
+   }
+
+   private static String resolveClassTag(Map<String, Object> tags) {
+      String classTag = asString(tags.get("class"));
+      return classTag != null && !classTag.isBlank() ? classTag : null;
+   }
+
+   private static List<Double> collectScopedBreakpoints(Map<String, Object> tags) {
+      List<Double> breakpoints = new ArrayList<>();
+      breakpoints.add(0.0);
+      breakpoints.add(1.0);
+      collectScopedBreakpoints(tags.get("road_flags"), breakpoints);
+      collectScopedBreakpoints(tags.get("level_rules"), breakpoints);
+      breakpoints.sort(Double::compare);
+      List<Double> normalized = new ArrayList<>(breakpoints.size());
+
+      for (double breakpoint : breakpoints) {
+         double clamped = Mth.clamp(breakpoint, 0.0, 1.0);
+         if (normalized.isEmpty() || Math.abs(normalized.get(normalized.size() - 1) - clamped) > 1.0E-6) {
+            normalized.add(clamped);
+         }
+      }
+
+      return normalized;
+   }
+
+   private static void collectScopedBreakpoints(Object rulesValue, List<Double> breakpoints) {
+      JsonArray rules = parseRuleArray(rulesValue);
+      if (rules != null) {
+         for (JsonElement ruleElement : rules) {
+            if (ruleElement.isJsonObject()) {
+               TellusOsmRoadSource.ScopeRange range = parseScopeRange(ruleElement.getAsJsonObject());
+               if (range != null) {
+                  breakpoints.add(range.start());
+                  breakpoints.add(range.end());
+               }
+            }
+         }
+      }
+   }
+
+   private static TellusOsmRoadSource.RoadDescriptor resolveRoadDescriptorAt(Map<String, Object> tags, RoadClass roadClass, double position) {
+      int signedLevel = resolveSignedLevelAt(tags, position);
+      boolean explicitBridge = isTruthy(asString(tags.get("bridge"))) || containsFlagAt(tags.get("road_flags"), "is_bridge", position);
+      if (explicitBridge) {
+         int bridgeLevel = signedLevel > 0 && roadClass != RoadClass.DIRT ? Mth.clamp(signedLevel, 1, MAX_BRIDGE_LEVEL) : 1;
+         return new TellusOsmRoadSource.RoadDescriptor(RoadMode.BRIDGE, bridgeLevel);
+      } else {
+         boolean tunnel = containsFlagAt(tags.get("road_flags"), "is_tunnel", position)
+            || isTruthy(asString(tags.get("tunnel")))
+            || signedLevel < 0;
+         return tunnel ? new TellusOsmRoadSource.RoadDescriptor(RoadMode.TUNNEL, 0) : new TellusOsmRoadSource.RoadDescriptor(RoadMode.NORMAL, 0);
+      }
+   }
+
+   private static int resolveSignedLevelAt(Map<String, Object> tags, double position) {
+      int[] levels = new int[]{0, 0};
+      collectLevelValue(tags.get("layer"), levels);
+      collectLevelValue(tags.get("level"), levels);
+      collectLevelRulesAt(tags.get("level_rules"), levels, position);
+      if (levels[0] > 0) {
+         return levels[0];
+      } else {
+         return levels[1] < 0 ? levels[1] : 0;
+      }
+   }
+
+   private static void collectLevelRulesAt(Object rulesValue, int[] levels, double position) {
+      JsonArray rules = parseRuleArray(rulesValue);
+      if (rules != null) {
+         for (JsonElement ruleElement : rules) {
+            if (ruleElement.isJsonObject()) {
+               JsonObject rule = ruleElement.getAsJsonObject();
+               if (ruleAppliesAt(rule, position)) {
+                  collectLevelElement(rule.get("value"), levels);
+               }
+            }
+         }
+      }
+   }
+
+   private static void collectLevelValue(Object value, int[] levels) {
+      if (value != null) {
+         collectLevelNumber(parseInteger(value), levels);
+      }
+   }
+
+   private static void collectLevelElement(JsonElement value, int[] levels) {
+      if (value != null && !value.isJsonNull()) {
+         collectLevelNumber(parseInteger(value), levels);
+      }
+   }
+
+   private static void collectLevelNumber( Integer value, int[] levels) {
+      if (value != null && value != 0) {
+         if (value > 0) {
+            levels[0] = Math.max(levels[0], value);
+         } else {
+            levels[1] = Math.min(levels[1], value);
+         }
+      }
+   }
+
+   private static boolean containsFlagAt(Object rulesValue, String flag, double position) {
+      JsonArray rules = parseRuleArray(rulesValue);
+      if (rules == null) {
+         return false;
+      } else {
+         for (JsonElement ruleElement : rules) {
+            String directValue = asString(ruleElement);
+            if (directValue != null && flag.equalsIgnoreCase(directValue)) {
+               return true;
+            }
+
+            if (ruleElement.isJsonObject()) {
+               JsonObject rule = ruleElement.getAsJsonObject();
+               if (!ruleAppliesAt(rule, position)) {
+                  continue;
+               }
+
+               JsonArray values = getArray(rule, "values");
+               if (values != null) {
+                  for (JsonElement valueElement : values) {
+                     String value = asString(valueElement);
+                     if (value != null && flag.equalsIgnoreCase(value)) {
+                        return true;
+                     }
+                  }
+               }
+
+               String value = asString(rule.get("value"));
+               if (value != null && flag.equalsIgnoreCase(value)) {
+                  return true;
+               }
+            }
+         }
+
+         return false;
+      }
+   }
+
+   private static boolean ruleAppliesAt(JsonObject rule, double position) {
+      TellusOsmRoadSource.ScopeRange range = parseScopeRange(rule);
+      if (range == null) {
+         return true;
+      } else {
+         double clampedPosition = Mth.clamp(position, 0.0, 1.0);
+         return clampedPosition + 1.0E-6 >= range.start() && clampedPosition - 1.0E-6 <= range.end();
+      }
+   }
+
+   private static TellusOsmRoadSource.ScopeRange parseScopeRange(JsonObject rule) {
+      JsonArray between = getArray(rule, "between");
+      if (between != null && between.size() == 2) {
+         Double start = parseDouble(between.get(0));
+         Double end = parseDouble(between.get(1));
+         if (start != null && end != null) {
+            double clampedStart = Mth.clamp(start, 0.0, 1.0);
+            double clampedEnd = Mth.clamp(end, 0.0, 1.0);
+            if (clampedEnd > clampedStart + 1.0E-6) {
+               return new TellusOsmRoadSource.ScopeRange(clampedStart, clampedEnd);
+            }
+         }
+      }
+
+      return null;
+   }
+
+   
+   private static JsonArray parseRuleArray(Object rulesValue) {
+      if (rulesValue == null) {
+         return null;
+      } else {
+         try {
+            if (rulesValue instanceof JsonArray array) {
+               return array;
+            } else if (rulesValue instanceof JsonElement element) {
+               return element.isJsonArray() ? element.getAsJsonArray() : null;
+            } else {
+               String text = String.valueOf(rulesValue);
+               if (text.isBlank()) {
+                  return null;
+               } else {
+                  JsonElement parsed = JsonParser.parseString(text);
+                  return parsed.isJsonArray() ? parsed.getAsJsonArray() : null;
+               }
+            }
+         } catch (RuntimeException var3) {
+            return null;
+         }
+      }
+   }
+
+   
+   private static Integer parseInteger(Object value) {
+      if (value == null) {
+         return null;
+      } else if (value instanceof Number number) {
+         return (int)Math.round(number.doubleValue());
+      } else {
+         String text = String.valueOf(value);
+         if (text.isBlank()) {
+            return null;
+         } else {
+            String normalized = text.trim();
+            if (normalized.startsWith("+")) {
+               normalized = normalized.substring(1);
+            }
+
+            int separator = normalized.indexOf(32);
+            if (separator > 0) {
+               normalized = normalized.substring(0, separator);
+            }
+
+            try {
+               return normalized.contains(".") ? (int)Math.round(Double.parseDouble(normalized)) : Integer.parseInt(normalized);
+            } catch (NumberFormatException var5) {
+               return null;
+            }
+         }
+      }
+   }
+
+   
+   private static Integer parseInteger(JsonElement value) {
+      if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) {
+         try {
+            return value.getAsJsonPrimitive().isNumber() ? (int)Math.round(value.getAsDouble()) : parseInteger(value.getAsString());
+         } catch (RuntimeException var2) {
+            return null;
+         }
+      } else {
+         return null;
+      }
+   }
+
+   private static Double parseDouble(JsonElement value) {
+      if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) {
+         try {
+            return value.getAsJsonPrimitive().isNumber() ? value.getAsDouble() : Double.parseDouble(value.getAsString());
+         } catch (RuntimeException var2) {
+            return null;
+         }
+      } else {
+         return null;
+      }
+   }
+
+   private static boolean isTruthy(String value) {
+      if (value == null) {
+         return false;
+      } else {
+         String normalized = value.trim().toLowerCase(Locale.ROOT);
+         return !normalized.isEmpty() && !"no".equals(normalized) && !"false".equals(normalized) && !"0".equals(normalized);
+      }
+   }
+
+   
+   private static TellusOsmRoadSource.LineString selectPrimaryLineString(List<Integer> geometry) {
+      List<TellusOsmRoadSource.LineString> lines = decodeLineStrings(geometry);
+      if (lines.isEmpty()) {
+         return null;
+      } else {
+         TellusOsmRoadSource.LineString selected = null;
+
+         for (TellusOsmRoadSource.LineString line : lines) {
+            if (selected == null || line.lengthScore > selected.lengthScore) {
+               selected = line;
+            }
+         }
+
+         return selected;
+      }
+   }
+
+   private static List<TellusOsmRoadSource.LineString> decodeLineStrings(List<Integer> geometry) {
+      if (geometry != null && !geometry.isEmpty()) {
+         List<TellusOsmRoadSource.LineString> lines = new ArrayList<>();
+         List<TellusOsmRoadSource.TilePoint> current = null;
+         int cursorX = 0;
+         int cursorY = 0;
+         int cursor = 0;
+
+         while (cursor < geometry.size()) {
+            int commandAndCount = geometry.get(cursor++);
+            int command = commandAndCount & 7;
+            int count = commandAndCount >>> 3;
+            if (count > 0) {
+               switch (command) {
+                  case 1:
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return lines;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        if (current != null && !current.isEmpty()) {
+                           addLine(lines, current);
+                        }
+
+                        current = new ArrayList<>();
+                        current.add(new TellusOsmRoadSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 2:
+                     if (current == null) {
+                        current = new ArrayList<>();
+                     }
+
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return lines;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        current.add(new TellusOsmRoadSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 7:
+                     if (current != null && !current.isEmpty()) {
+                        addLine(lines, current);
+                        current = null;
+                     }
+                     break;
+                  default:
+                     return lines;
+               }
+            }
+         }
+
+         if (current != null && !current.isEmpty()) {
+            addLine(lines, current);
+         }
+
+         return lines;
+      } else {
+         return List.of();
+      }
+   }
+
+   private static void addLine(List<TellusOsmRoadSource.LineString> lines, List<TellusOsmRoadSource.TilePoint> points) {
+      if (points.size() >= 2) {
+         List<TellusOsmRoadSource.TilePoint> cleaned = new ArrayList<>(points.size());
+
+         for (TellusOsmRoadSource.TilePoint point : points) {
+            if (cleaned.isEmpty() || !samePoint(cleaned.get(cleaned.size() - 1), point)) {
+               cleaned.add(point);
+            }
+         }
+
+         if (cleaned.size() >= 2) {
+            double lengthScore = 0.0;
+
+            for (int i = 1; i < cleaned.size(); i++) {
+               TellusOsmRoadSource.TilePoint a = cleaned.get(i - 1);
+               TellusOsmRoadSource.TilePoint b = cleaned.get(i);
+               double dx = b.x - a.x;
+               double dy = b.y - a.y;
+               lengthScore += dx * dx + dy * dy;
+            }
+
+            if (!(lengthScore <= 0.0)) {
+               lines.add(new TellusOsmRoadSource.LineString(List.copyOf(cleaned), lengthScore));
+            }
+         }
+      }
+   }
+
+   private static boolean samePoint(TellusOsmRoadSource.TilePoint a, TellusOsmRoadSource.TilePoint b) {
+      return a.x == b.x && a.y == b.y;
+   }
+
+   private static int zigZagDecode(int encoded) {
+      return encoded >>> 1 ^ -(encoded & 1);
+   }
+
+   private static double tilePointToLon(int zoom, int tileX, double localX) {
+      double n = tilesPerAxis(zoom);
+      double normalizedX = (tileX + localX) / n;
+      return normalizedX * 360.0 - 180.0;
+   }
+
+   private static double tilePointToLat(int zoom, int tileY, double localY) {
+      double n = tilesPerAxis(zoom);
+      double normalizedY = (tileY + localY) / n;
+      double mercator = Math.PI * (1.0 - 2.0 * normalizedY);
+      return Math.toDegrees(Math.atan(Math.sinh(mercator)));
+   }
+
+   private static Map<String, Object> decodeTags(Feature feature, Layer layer) {
+      List<Integer> tags = feature.getTagsList();
+      if (tags.isEmpty()) {
+         return Map.of();
+      } else {
+         Map<String, Object> values = new HashMap<>(tags.size() / 2);
+
+         for (int i = 0; i + 1 < tags.size(); i += 2) {
+            int keyIndex = tags.get(i);
+            int valueIndex = tags.get(i + 1);
+            if (keyIndex >= 0 && keyIndex < layer.getKeysCount() && valueIndex >= 0 && valueIndex < layer.getValuesCount()) {
+               String key = layer.getKeys(keyIndex);
+               Object value = decodeValue(layer.getValues(valueIndex));
+               if (key != null && !key.isBlank() && value != null) {
+                  values.put(key, value);
+               }
+            }
+         }
+
+         return values;
+      }
+   }
+
+   
+   private static Object decodeValue(Value value) {
+      if (value.hasStringValue()) {
+         return value.getStringValue();
+      } else if (value.hasDoubleValue()) {
+         return value.getDoubleValue();
+      } else if (value.hasFloatValue()) {
+         return (double)value.getFloatValue();
+      } else if (value.hasSintValue()) {
+         return value.getSintValue();
+      } else if (value.hasIntValue()) {
+         return value.getIntValue();
+      } else if (value.hasUintValue()) {
+         return value.getUintValue();
+      } else {
+         return value.hasBoolValue() ? value.getBoolValue() : null;
+      }
+   }
+
+   private static long resolveFeatureId(Feature feature, Map<String, Object> tags) {
+      if (feature.hasId() && feature.getId() != 0L) {
+         return feature.getId();
+      } else {
+         long idFromTag = parseLongId(tags.get("id"));
+         if (idFromTag != 0L) {
+            return idFromTag;
+         } else {
+            long idFromSources = parseSourceWayId(tags.get("sources"));
+            return idFromSources != 0L ? idFromSources : 0L;
+         }
+      }
+   }
+
+   private static long parseLongId(Object value) {
+      if (value == null) {
+         return 0L;
+      } else if (value instanceof Number number) {
+         return number.longValue();
+      } else {
+         String text = String.valueOf(value).trim();
+         if (text.isEmpty()) {
+            return 0L;
+         } else {
+            try {
+               return Long.parseLong(text);
+            } catch (NumberFormatException var6) {
+               try {
+                  UUID uuid = UUID.fromString(text);
+                  long mixed = uuid.getMostSignificantBits() ^ uuid.getLeastSignificantBits();
+                  return mixed == 0L ? 1L : mixed;
+               } catch (IllegalArgumentException var5) {
+                  return hash64(text);
+               }
+            }
+         }
+      }
+   }
+
+   private static long parseSourceWayId(Object value) {
+      if (value instanceof String sources && !sources.isBlank()) {
+         int cursor = 0;
+
+         while (true) {
+            int recordIndex = sources.indexOf("\"record_id\":\"w", cursor);
+            if (recordIndex < 0) {
+               return 0L;
+            }
+
+            int start = recordIndex + "\"record_id\":\"w".length();
+
+            int end;
+            for (end = start; end < sources.length(); end++) {
+               char ch = sources.charAt(end);
+               if (ch < '0' || ch > '9') {
+                  break;
+               }
+            }
+
+            if (end > start) {
+               try {
+                  return Long.parseLong(sources.substring(start, end));
+               } catch (NumberFormatException var7) {
+               }
+            }
+
+            cursor = end > start ? end : recordIndex + 1;
+         }
+      } else {
+         return 0L;
+      }
+   }
+
+   private static long hash64(String text) {
+      long hash = -3750763034362895579L;
+      byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+
+      for (byte value : bytes) {
+         hash ^= value & 255;
+         hash *= 1099511628211L;
+      }
+
+      return hash == 0L ? 1L : hash;
+   }
+
+   
+   private static String asString(Object value) {
+      return value == null ? null : String.valueOf(value);
+   }
+
+   
+   private static String asString(JsonElement value) {
+      if (value != null && !value.isJsonNull() && value.isJsonPrimitive()) {
+         try {
+            return value.getAsString();
+         } catch (RuntimeException var2) {
+            return null;
+         }
+      } else {
+         return null;
+      }
+   }
+
+   private Path cachePathFor(TellusOsmRoadSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".mvt.gz");
+   }
+
+   private Path parsedCachePathFor(TellusOsmRoadSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".pm.parsed.bin");
+   }
+
+   
+   private static TellusOsmRoadSource.GeoBounds geoBoundsForBlockArea(
+      int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, int marginBlocks, double worldScale
+   ) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         int margin = Math.max(0, marginBlocks);
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double west = clampLon((Math.min(minBlockX, maxBlockX) - margin) / blocksPerDegree);
+         double east = clampLon((Math.max(minBlockX, maxBlockX) + margin) / blocksPerDegree);
+         double north = clampLat(EarthProjection.blockZToLat(Math.min(minBlockZ, maxBlockZ) - margin, worldScale));
+         double south = clampLat(EarthProjection.blockZToLat(Math.max(minBlockZ, maxBlockZ) + margin, worldScale));
+         if (south > north) {
+            double swap = south;
+            south = north;
+            north = swap;
+         }
+
+         return new TellusOsmRoadSource.GeoBounds(south, west, north, east);
+      }
+   }
+
+   private static List<TellusOsmRoadSource.TileKey> tileKeysForBounds(TellusOsmRoadSource.GeoBounds bounds, int zoom) {
+      int tilesPerAxis = 1 << zoom;
+      int minX = Mth.clamp(lonToTileX(bounds.west(), zoom), 0, tilesPerAxis - 1);
+      int maxX = Mth.clamp(lonToTileX(bounds.east(), zoom), 0, tilesPerAxis - 1);
+      int minY = Mth.clamp(latToTileY(bounds.north(), zoom), 0, tilesPerAxis - 1);
+      int maxY = Mth.clamp(latToTileY(bounds.south(), zoom), 0, tilesPerAxis - 1);
+      if (maxX >= minX && maxY >= minY) {
+         List<TellusOsmRoadSource.TileKey> keys = new ArrayList<>((maxX - minX + 1) * (maxY - minY + 1));
+
+         for (int y = minY; y <= maxY; y++) {
+            for (int x = minX; x <= maxX; x++) {
+               keys.add(new TellusOsmRoadSource.TileKey(zoom, x, y));
+            }
+         }
+
+         return keys;
+      } else {
+         return List.of();
+      }
+   }
+
+   
+   private static TellusOsmRoadSource.TileKey tileKeyForBlock(double blockX, double blockZ, double worldScale, int zoom) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double lon = clampLon(blockX / blocksPerDegree);
+         double lat = clampLat(EarthProjection.blockZToLat(blockZ, worldScale));
+         double n = tilesPerAxis(zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(Math.toRadians(lat)) + 1.0 / Math.cos(Math.toRadians(lat))) / Math.PI) / 2.0 * n;
+         return !(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n) ? new TellusOsmRoadSource.TileKey(zoom, Mth.floor(x), Mth.floor(y)) : null;
+      }
+   }
+
+   private static TellusOsmRoadSource.TileGeoBounds tileBounds(TellusOsmRoadSource.TileKey key) {
+      double n = tilesPerAxis(key.zoom());
+      double west = key.x() / n * 360.0 - 180.0;
+      double east = (key.x() + 1.0) / n * 360.0 - 180.0;
+      double north = Math.toDegrees(Math.atan(Math.sinh(Math.PI * (1.0 - 2.0 * key.y() / n))));
+      double south = Math.toDegrees(Math.atan(Math.sinh(Math.PI * (1.0 - 2.0 * (key.y() + 1.0) / n))));
+      return new TellusOsmRoadSource.TileGeoBounds(south, west, north, east);
+   }
+
+   private static int lonToTileX(double lon, int zoom) {
+      double n = tilesPerAxis(zoom);
+      double x = (clampLon(lon) + 180.0) / 360.0 * n;
+      if (x >= n) {
+         x = n - 1.0;
+      }
+
+      return Mth.floor(x);
+   }
+
+   private static int latToTileY(double lat, int zoom) {
+      double clampedLat = clampLat(lat);
+      double n = tilesPerAxis(zoom);
+      double latRad = Math.toRadians(clampedLat);
+      double y = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+      if (y >= n) {
+         y = n - 1.0;
+      }
+
+      return Mth.floor(y);
+   }
+
+   private static double clampLat(double latitude) {
+      return Mth.clamp(latitude, MIN_LAT, MAX_LAT);
+   }
+
+   private static double clampLon(double longitude) {
+      return Mth.clamp(longitude, MIN_LON, MAX_LON);
+   }
+
+   private static double tilesPerAxis(int zoom) {
+      return (double)(1 << zoom);
+   }
+
+   
+   private static JsonArray getArray(JsonObject object, String key) {
+      JsonElement value = object.get(key);
+      return value != null && value.isJsonArray() ? value.getAsJsonArray() : null;
+   }
+
+   private static int intProperty(String key, int defaultValue, int minInclusive, int maxInclusive) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            int parsed = Integer.parseInt(value);
+            return Mth.clamp(parsed, minInclusive, maxInclusive);
+         } catch (NumberFormatException var6) {
+            Tellus.LOGGER.debug("Invalid integer system property {}='{}', using {}", new Object[]{key, value, defaultValue});
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.OSM;
+   }
+
+   @Override
+   public void clearCache() {
+      this.cache.invalidateAll();
+      this.cache.cleanUp();
+      this.pendingAsyncLoads.clear();
+      this.tileLoadFailures.clear();
+   }
+
+   private record GeoPoint(double lon, double lat) {
+   }
+
+   private record ScopeRange(double start, double end) {
+   }
+
+   private record RoadDescriptor(RoadMode mode, int bridgeLevel) {
+   }
+
+   private record LineGeometry(double[] longitudes, double[] latitudes, double[] distances, double totalLength) {
+      private static TellusOsmRoadSource.LineGeometry create(double[] longitudes, double[] latitudes) {
+         if (longitudes == null || latitudes == null || longitudes.length != latitudes.length || longitudes.length < 2) {
+            return null;
+         } else {
+            double[] cleanedLon = new double[longitudes.length];
+            double[] cleanedLat = new double[latitudes.length];
+            int count = 0;
+
+            for (int i = 0; i < longitudes.length; i++) {
+               double lon = longitudes[i];
+               double lat = latitudes[i];
+               if (Double.isFinite(lon)
+                  && Double.isFinite(lat)
+                  && (count <= 0 || !(Math.abs(cleanedLon[count - 1] - lon) < POINT_EPSILON) || !(Math.abs(cleanedLat[count - 1] - lat) < POINT_EPSILON))) {
+                  cleanedLon[count] = lon;
+                  cleanedLat[count] = lat;
+                  count++;
+               }
+            }
+
+            if (count < 2) {
+               return null;
+            } else {
+               double[] trimmedLon = count == cleanedLon.length ? cleanedLon : Arrays.copyOf(cleanedLon, count);
+               double[] trimmedLat = count == cleanedLat.length ? cleanedLat : Arrays.copyOf(cleanedLat, count);
+               double[] distances = new double[count];
+               double totalLength = 0.0;
+
+               for (int i = 1; i < count; i++) {
+                  double dx = trimmedLon[i] - trimmedLon[i - 1];
+                  double dy = trimmedLat[i] - trimmedLat[i - 1];
+                  totalLength += Math.sqrt(dx * dx + dy * dy);
+                  distances[i] = totalLength;
+               }
+
+               return totalLength <= 1.0E-9 ? null : new TellusOsmRoadSource.LineGeometry(trimmedLon, trimmedLat, distances, totalLength);
+            }
+         }
+      }
+   }
+
+   private record GeoBounds(double south, double west, double north, double east) {
+   }
+
+   private record LineString(List<TellusOsmRoadSource.TilePoint> points, double lengthScore) {
+   }
+
+   public record RoadQueryResult(List<RoadFeature> features, boolean hadCacheMiss) {
+      public RoadQueryResult(List<RoadFeature> features, boolean hadCacheMiss) {
+         features = features == null ? List.of() : List.copyOf(features);
+         this.features = features;
+         this.hadCacheMiss = hadCacheMiss;
+      }
+   }
+
+   private record TileGeoBounds(double south, double west, double north, double east) {
+   }
+
+   private record TileKey(int zoom, int x, int y) {
+   }
+
+   private record TileLookup(OverpassRoadTile tile, boolean cacheMiss) {
+   }
+
+   private record TilePoint(int x, int y) {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmSandSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmSandSource.java
@@ -1,0 +1,775 @@
+package com.yucareux.tellus.world.data.osm;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Feature;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.GeomType;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Layer;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Value;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+import net.minecraft.Util;
+
+public final class TellusOsmSandSource implements TellusCacheHandle {
+   private static final String DEFAULT_PM_TILES_URL = "https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2026-01-21/base.pmtiles";
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final double METERS_PER_DEGREE = 111319.49166666667;
+   private static final double POINT_EPSILON = 1.0E-9;
+   private static final int DEFAULT_TILE_EXTENT = 4096;
+   private static final int CONNECT_TIMEOUT_MS = intProperty("tellus.overture.sand.connectTimeoutMs", 7000, 1, 120000);
+   private static final int READ_TIMEOUT_MS = intProperty("tellus.overture.sand.readTimeoutMs", 20000, 1, 180000);
+   private static final int DIRECTORY_CACHE_ENTRIES = intProperty("tellus.overture.sand.dirCache", 256, 1, 8192);
+   private static final int MAX_CACHE_TILES = intProperty("tellus.osm.sand.cacheTiles", 256, 1, 8192);
+   private static final int MAX_ASYNC_PREFETCH_LOADS = intProperty("tellus.osm.sand.prefetchAsyncMax", 96, 0, 8192);
+   private static final int FETCH_RETRY_ATTEMPTS = intProperty("tellus.overture.sand.fetchRetries", 3, 1, 8);
+   private static final int MIN_TILE_WIDTH_BLOCKS = intProperty("tellus.osm.sand.minTileWidthBlocks", 96, 1, 16384);
+   private static final int PMTILES_TILETYPE_MVT = 1;
+   private static final String LAND_LAYER_NAME = "land";
+   private static final String SAND_SUBTYPE = "sand";
+   private static final byte[] EMPTY_TILE_PAYLOAD = new byte[0];
+   private final Path cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/map/sand");
+   private final PmTilesRangeReader pmTilesReader;
+   private final Object initLock = new Object();
+   private final LoadingCache<TellusOsmSandSource.TileKey, OsmSandTile> cache;
+   private final Set<TellusOsmSandSource.TileKey> pendingAsyncLoads;
+   private final Set<TellusOsmSandSource.TileKey> tileLoadFailures;
+   private volatile boolean available;
+   private volatile int minZoom;
+   private volatile int maxZoom;
+   private volatile boolean initialized;
+
+   public TellusOsmSandSource() {
+      String pmTilesUrl = System.getProperty("tellus.overture.sand.pmtiles", DEFAULT_PM_TILES_URL);
+      this.pmTilesReader = new PmTilesRangeReader(pmTilesUrl, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS, DIRECTORY_CACHE_ENTRIES);
+      this.cache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_TILES).build(new CacheLoader<TellusOsmSandSource.TileKey, OsmSandTile>() {
+         public OsmSandTile load(TellusOsmSandSource.TileKey key) {
+            return TellusOsmSandSource.this.loadTile(key);
+         }
+      });
+      this.pendingAsyncLoads = ConcurrentHashMap.newKeySet();
+      this.tileLoadFailures = ConcurrentHashMap.newKeySet();
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean available() {
+      this.ensureInitialized();
+      return this.available;
+   }
+
+   public boolean containsSand(int blockX, int blockZ, double worldScale, OsmQueryMode mode) {
+      this.ensureInitialized();
+      if (!this.available || worldScale <= 0.0) {
+         return false;
+      } else {
+         int zoom = this.queryZoomForScale(worldScale);
+         TellusOsmSandSource.TileKey key = tileKeyForBlock(blockX, blockZ, worldScale, zoom);
+         if (key == null) {
+            return false;
+         } else {
+            OsmSandTile tile = this.getTileLookup(key, mode).tile();
+            if (tile.isEmpty()) {
+               return false;
+            } else {
+               for (OsmSandFeature feature : tile.features()) {
+                  if (feature.containsBlock(blockX, blockZ, worldScale)) {
+                     return true;
+                  }
+               }
+
+               return false;
+            }
+         }
+      }
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0) && radius > 0) {
+         int zoom = this.queryZoomForScale(worldScale);
+         TellusOsmSandSource.TileKey center = tileKeyForBlock(blockX, blockZ, worldScale, zoom);
+         if (center != null) {
+            int tilesPerAxis = 1 << zoom;
+            int minX = Math.max(0, center.x() - radius);
+            int maxX = Math.min(tilesPerAxis - 1, center.x() + radius);
+            int minY = Math.max(0, center.y() - radius);
+            int maxY = Math.min(tilesPerAxis - 1, center.y() + radius);
+
+            for (int tileY = minY; tileY <= maxY; tileY++) {
+               for (int tileX = minX; tileX <= maxX; tileX++) {
+                  this.getTile(new TellusOsmSandSource.TileKey(zoom, tileX, tileY), OsmQueryMode.NON_BLOCKING);
+               }
+            }
+         }
+      }
+   }
+
+   private int queryZoomForScale(double worldScale) {
+      this.ensureInitialized();
+      if (worldScale <= 0.0) {
+         return this.minZoom;
+      } else {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+
+         for (int zoom = this.maxZoom; zoom >= this.minZoom; zoom--) {
+            double tileWidthBlocks = 360.0 * blocksPerDegree / (1 << zoom);
+            if (tileWidthBlocks >= MIN_TILE_WIDTH_BLOCKS) {
+               return zoom;
+            }
+         }
+
+         return this.minZoom;
+      }
+   }
+
+   private OsmSandTile getTile(TellusOsmSandSource.TileKey key, OsmQueryMode mode) {
+      return this.getTileLookup(key, mode).tile();
+   }
+
+   private TellusOsmSandSource.TileLookup getTileLookup(TellusOsmSandSource.TileKey key, OsmQueryMode mode) {
+      OsmSandTile cached = this.cache.getIfPresent(key);
+      if (cached != null) {
+         if (!cached.isEmpty() || !this.tileLoadFailures.contains(key)) {
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.MEMORY);
+            return new TellusOsmSandSource.TileLookup(cached, false);
+         }
+
+         this.cache.invalidate(key);
+      }
+
+      OsmQueryMode queryMode = mode == null ? OsmQueryMode.BLOCKING : mode;
+      if (queryMode == OsmQueryMode.NON_BLOCKING) {
+         this.queueAsyncLoad(key);
+         return new TellusOsmSandSource.TileLookup(OsmSandTile.empty(), true);
+      } else {
+         try {
+            return new TellusOsmSandSource.TileLookup(this.cache.get(key), false);
+         } catch (Exception error) {
+            Tellus.LOGGER.debug("Failed to load Overture sand tile {}", key, error);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.FAILURE);
+            return new TellusOsmSandSource.TileLookup(OsmSandTile.empty(), false);
+         }
+      }
+   }
+
+   private void queueAsyncLoad(TellusOsmSandSource.TileKey key) {
+      if (MAX_ASYNC_PREFETCH_LOADS <= 0 || this.pendingAsyncLoads.size() < MAX_ASYNC_PREFETCH_LOADS) {
+         if (this.pendingAsyncLoads.add(key)) {
+            Util.backgroundExecutor().execute(() -> {
+               try {
+                  this.cache.get(key);
+               } catch (Exception error) {
+                  Tellus.LOGGER.debug("Async load failed for Overture sand tile {}", key, error);
+                  this.tileLoadFailures.add(key);
+                  OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.FAILURE);
+               } finally {
+                  this.pendingAsyncLoads.remove(key);
+               }
+            });
+         }
+      }
+   }
+
+   private OsmSandTile loadTile(TellusOsmSandSource.TileKey key) {
+      this.ensureInitialized();
+      if (!this.available) {
+         return OsmSandTile.empty();
+      } else {
+         Path cachePath = this.cachePathFor(key);
+         Path parsedCachePath = this.parsedCachePathFor(key);
+         if (Files.exists(parsedCachePath)) {
+            try {
+               OsmSandTile parsed = ParsedTileCodec.readSandTile(parsedCachePath);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.PARSED_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException error) {
+               Tellus.LOGGER.debug("Invalid parsed Overture sand cache tile {}, refetching", key, error);
+
+               try {
+                  Files.deleteIfExists(parsedCachePath);
+               } catch (IOException deleteError) {
+                  Tellus.LOGGER.debug("Failed to delete invalid parsed Overture sand cache tile {}", parsedCachePath, deleteError);
+               }
+            }
+         }
+
+         if (Files.exists(cachePath)) {
+            try {
+               byte[] payload = this.readCompressed(cachePath);
+               OsmSandTile parsed = this.parseVectorTile(payload, key);
+               this.cacheParsedTile(parsedCachePath, parsed);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.RAW_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException error) {
+               Tellus.LOGGER.debug("Invalid Overture sand cache tile {}, refetching", key, error);
+
+               try {
+                  Files.deleteIfExists(cachePath);
+               } catch (IOException deleteError) {
+                  Tellus.LOGGER.debug("Failed to delete invalid Overture sand cache tile {}", cachePath, deleteError);
+               }
+            }
+         }
+
+         byte[] payload = this.fetchTilePayloadWithRetry(key);
+
+         OsmSandTile parsed;
+         try {
+            parsed = this.parseVectorTile(payload, key);
+         } catch (RuntimeException error) {
+            Tellus.LOGGER.warn("Overture sand parse failed for tile {}", key, error);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.FAILURE);
+            throw new RuntimeException("Overture sand parse failed for tile " + key, error);
+         }
+
+         this.cacheTile(cachePath, payload);
+         this.cacheParsedTile(parsedCachePath, parsed);
+         this.tileLoadFailures.remove(key);
+         OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.NETWORK);
+         return parsed;
+      }
+   }
+
+   private void ensureInitialized() {
+      if (this.initialized) {
+         return;
+      }
+
+      synchronized (this.initLock) {
+         if (this.initialized) {
+            return;
+         }
+
+         int resolvedMinZoom = 0;
+         int resolvedMaxZoom = 0;
+         boolean sourceAvailable;
+
+         try {
+            PmTilesRangeReader.PmTilesHeader header = this.pmTilesReader.header();
+            if (header.tileType() != PMTILES_TILETYPE_MVT) {
+               Tellus.LOGGER.warn("Unexpected Overture sand PMTiles tile type {}, expected MVT", header.tileType());
+            }
+
+            resolvedMinZoom = header.minZoom();
+            resolvedMaxZoom = header.maxZoom();
+            sourceAvailable = true;
+         } catch (IOException error) {
+            sourceAvailable = false;
+            Tellus.LOGGER.warn("Overture sand PMTiles unavailable, OSM sand disabled", error);
+         }
+
+         this.available = sourceAvailable;
+         this.minZoom = resolvedMinZoom;
+         this.maxZoom = resolvedMaxZoom;
+         this.initialized = true;
+      }
+   }
+
+   private byte[] fetchTilePayloadWithRetry(TellusOsmSandSource.TileKey key) {
+      RuntimeException lastFailure = null;
+
+      for (int attempt = 1; attempt <= FETCH_RETRY_ATTEMPTS; attempt++) {
+         try {
+            byte[] fetched = this.pmTilesReader.getTileBytes(key.zoom(), key.x(), key.y());
+            return fetched == null ? EMPTY_TILE_PAYLOAD : fetched;
+         } catch (IOException error) {
+            lastFailure = new RuntimeException("Overture sand fetch failed for tile " + key, error);
+            if (attempt < FETCH_RETRY_ATTEMPTS) {
+               continue;
+            }
+            break;
+         }
+      }
+
+      this.tileLoadFailures.add(key);
+      OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_SAND, OsmPerf.TileLoadPath.FAILURE);
+      if (lastFailure != null) {
+         throw lastFailure;
+      } else {
+         return EMPTY_TILE_PAYLOAD;
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] payload) {
+      try {
+         Files.createDirectories(cachePath.getParent());
+         Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+
+         try (OutputStream output = new GZIPOutputStream(Files.newOutputStream(tempPath))) {
+            output.write(payload);
+         }
+
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to cache Overture sand tile {}", cachePath, error);
+      }
+   }
+
+   private void cacheParsedTile(Path cachePath, OsmSandTile tile) {
+      try {
+         ParsedTileCodec.writeSandTile(cachePath, tile);
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to cache parsed Overture sand tile {}", cachePath, error);
+      }
+   }
+
+   private byte[] readCompressed(Path path) throws IOException {
+      try (InputStream input = new GZIPInputStream(Files.newInputStream(path))) {
+         return input.readAllBytes();
+      }
+   }
+
+   private OsmSandTile parseVectorTile(byte[] payload, TellusOsmSandSource.TileKey key) {
+      if (payload.length == 0) {
+         return OsmSandTile.empty();
+      } else {
+         Tile tile;
+         try {
+            tile = Tile.parseFrom(payload);
+         } catch (Exception error) {
+            throw new RuntimeException("Failed to decode sand MVT payload", error);
+         }
+
+         if (tile.getLayersCount() == 0) {
+            return OsmSandTile.empty();
+         } else {
+            List<OsmSandFeature> features = new ArrayList<>();
+
+            for (Layer layer : tile.getLayersList()) {
+               if (LAND_LAYER_NAME.equals(layer.getName())) {
+                  int extent = layer.hasExtent() && layer.getExtent() > 0 ? layer.getExtent() : DEFAULT_TILE_EXTENT;
+
+                  for (Feature feature : layer.getFeaturesList()) {
+                     if (feature.getType() == GeomType.POLYGON) {
+                        OsmSandFeature parsed = this.parseFeature(feature, layer, key, extent);
+                        if (parsed != null) {
+                           features.add(parsed);
+                        }
+                     }
+                  }
+               }
+            }
+
+            return features.isEmpty() ? OsmSandTile.empty() : new OsmSandTile(features);
+         }
+      }
+   }
+
+   private OsmSandFeature parseFeature(Feature feature, Layer layer, TellusOsmSandSource.TileKey key, int extent) {
+      Map<String, Object> tags = decodeTags(feature, layer);
+      if (!isSandLikeFeature(tags)) {
+         return null;
+      } else {
+         List<List<TellusOsmSandSource.TilePoint>> rings = decodePolygonRings(feature.getGeometryList());
+         if (rings.isEmpty()) {
+            return null;
+         } else {
+            double[][] longitudes = new double[rings.size()][];
+            double[][] latitudes = new double[rings.size()][];
+
+            for (int part = 0; part < rings.size(); part++) {
+               List<TellusOsmSandSource.TilePoint> ring = rings.get(part);
+               int points = ring.size();
+               double[] lonPart = new double[points];
+               double[] latPart = new double[points];
+               int count = 0;
+               double previousLon = Double.NaN;
+               double previousLat = Double.NaN;
+
+               for (TellusOsmSandSource.TilePoint point : ring) {
+                  double lon = tilePointToLon(key.zoom(), key.x(), (double)point.x / extent);
+                  double lat = tilePointToLat(key.zoom(), key.y(), (double)point.y / extent);
+                  if (Double.isFinite(lat)
+                     && Double.isFinite(lon)
+                     && !(lat < MIN_LAT)
+                     && !(lat > MAX_LAT)
+                     && !(lon < MIN_LON)
+                     && !(lon > MAX_LON)
+                     && (count <= 0 || !(Math.abs(lon - previousLon) < POINT_EPSILON) || !(Math.abs(lat - previousLat) < POINT_EPSILON))) {
+                     lonPart[count] = lon;
+                     latPart[count] = lat;
+                     previousLon = lon;
+                     previousLat = lat;
+                     count++;
+                  }
+               }
+
+               if (count < 4) {
+                  return null;
+               }
+
+               if (lonPart[0] != lonPart[count - 1] || latPart[0] != latPart[count - 1]) {
+                  if (count + 1 > lonPart.length) {
+                     lonPart = Arrays.copyOf(lonPart, count + 1);
+                     latPart = Arrays.copyOf(latPart, count + 1);
+                  }
+
+                  lonPart[count] = lonPart[0];
+                  latPart[count] = latPart[0];
+                  count++;
+               }
+
+               longitudes[part] = count == lonPart.length ? lonPart : Arrays.copyOf(lonPart, count);
+               latitudes[part] = count == latPart.length ? latPart : Arrays.copyOf(latPart, count);
+            }
+
+            return new OsmSandFeature(resolveFeatureId(feature, tags), longitudes, latitudes);
+         }
+      }
+   }
+
+   private static boolean isSandLikeFeature(Map<String, Object> tags) {
+      String subtype = nonBlank(asString(tags.get("subtype")));
+      if (SAND_SUBTYPE.equalsIgnoreCase(subtype)) {
+         return true;
+      } else {
+         String classTag = nonBlank(asString(tags.get("class")));
+         return "sand".equalsIgnoreCase(classTag) || "beach".equalsIgnoreCase(classTag) || "dune".equalsIgnoreCase(classTag);
+      }
+   }
+
+   private static List<List<TellusOsmSandSource.TilePoint>> decodePolygonRings(List<Integer> geometry) {
+      if (geometry != null && !geometry.isEmpty()) {
+         List<List<TellusOsmSandSource.TilePoint>> rings = new ArrayList<>();
+         List<TellusOsmSandSource.TilePoint> current = null;
+         int cursorX = 0;
+         int cursorY = 0;
+         int cursor = 0;
+
+         while (cursor < geometry.size()) {
+            int commandAndCount = geometry.get(cursor++);
+            int command = commandAndCount & 7;
+            int count = commandAndCount >>> 3;
+            if (count > 0) {
+               switch (command) {
+                  case 1:
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return rings;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        if (current != null && !current.isEmpty()) {
+                           addRing(rings, current);
+                        }
+
+                        current = new ArrayList<>();
+                        current.add(new TellusOsmSandSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 2:
+                     if (current == null) {
+                        current = new ArrayList<>();
+                     }
+
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return rings;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        current.add(new TellusOsmSandSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 7:
+                     if (current != null && !current.isEmpty()) {
+                        addRing(rings, current);
+                        current = null;
+                     }
+                     break;
+                  default:
+                     return rings;
+               }
+            }
+         }
+
+         if (current != null && !current.isEmpty()) {
+            addRing(rings, current);
+         }
+
+         return rings;
+      } else {
+         return List.of();
+      }
+   }
+
+   private static void addRing(List<List<TellusOsmSandSource.TilePoint>> rings, List<TellusOsmSandSource.TilePoint> points) {
+      List<TellusOsmSandSource.TilePoint> cleaned = new ArrayList<>(points.size());
+
+      for (TellusOsmSandSource.TilePoint point : points) {
+         if (cleaned.isEmpty() || !samePoint(cleaned.get(cleaned.size() - 1), point)) {
+            cleaned.add(point);
+         }
+      }
+
+      if (cleaned.size() >= 3) {
+         TellusOsmSandSource.TilePoint first = cleaned.get(0);
+         TellusOsmSandSource.TilePoint last = cleaned.get(cleaned.size() - 1);
+         if (!samePoint(first, last)) {
+            cleaned.add(first);
+         }
+
+         if (cleaned.size() >= 4) {
+            rings.add(List.copyOf(cleaned));
+         }
+      }
+   }
+
+   private static boolean samePoint(TellusOsmSandSource.TilePoint a, TellusOsmSandSource.TilePoint b) {
+      return a.x == b.x && a.y == b.y;
+   }
+
+   private static int zigZagDecode(int encoded) {
+      return encoded >>> 1 ^ -(encoded & 1);
+   }
+
+   private static double tilePointToLon(int zoom, int tileX, double localX) {
+      double n = tilesPerAxis(zoom);
+      double normalizedX = (tileX + localX) / n;
+      return normalizedX * 360.0 - 180.0;
+   }
+
+   private static double tilePointToLat(int zoom, int tileY, double localY) {
+      double n = tilesPerAxis(zoom);
+      double normalizedY = (tileY + localY) / n;
+      double mercator = Math.PI * (1.0 - 2.0 * normalizedY);
+      return Math.toDegrees(Math.atan(Math.sinh(mercator)));
+   }
+
+   private static Map<String, Object> decodeTags(Feature feature, Layer layer) {
+      List<Integer> tags = feature.getTagsList();
+      if (tags.isEmpty()) {
+         return Map.of();
+      } else {
+         Map<String, Object> values = new HashMap<>(tags.size() / 2);
+
+         for (int i = 0; i + 1 < tags.size(); i += 2) {
+            int keyIndex = tags.get(i);
+            int valueIndex = tags.get(i + 1);
+            if (keyIndex >= 0 && keyIndex < layer.getKeysCount() && valueIndex >= 0 && valueIndex < layer.getValuesCount()) {
+               String key = layer.getKeys(keyIndex);
+               Object value = decodeValue(layer.getValues(valueIndex));
+               if (key != null && !key.isBlank() && value != null) {
+                  values.put(key, value);
+               }
+            }
+         }
+
+         return values;
+      }
+   }
+
+   private static Object decodeValue(Value value) {
+      if (value.hasStringValue()) {
+         return value.getStringValue();
+      } else if (value.hasDoubleValue()) {
+         return value.getDoubleValue();
+      } else if (value.hasFloatValue()) {
+         return (double)value.getFloatValue();
+      } else if (value.hasSintValue()) {
+         return value.getSintValue();
+      } else if (value.hasIntValue()) {
+         return value.getIntValue();
+      } else if (value.hasUintValue()) {
+         return value.getUintValue();
+      } else {
+         return value.hasBoolValue() ? value.getBoolValue() : null;
+      }
+   }
+
+   private static long resolveFeatureId(Feature feature, Map<String, Object> tags) {
+      if (feature.hasId() && feature.getId() != 0L) {
+         return feature.getId();
+      } else {
+         long idFromTag = parseLongId(tags.get("id"));
+         if (idFromTag != 0L) {
+            return idFromTag;
+         } else {
+            long idFromSources = parseSourceWayId(tags.get("sources"));
+            return idFromSources != 0L ? idFromSources : 0L;
+         }
+      }
+   }
+
+   private static long parseLongId(Object value) {
+      if (value == null) {
+         return 0L;
+      } else if (value instanceof Number number) {
+         return number.longValue();
+      } else {
+         String text = String.valueOf(value).trim();
+         if (text.isEmpty()) {
+            return 0L;
+         } else {
+            try {
+               return Long.parseLong(text);
+            } catch (NumberFormatException error) {
+               try {
+                  UUID uuid = UUID.fromString(text);
+                  long mixed = uuid.getMostSignificantBits() ^ uuid.getLeastSignificantBits();
+                  return mixed == 0L ? 1L : mixed;
+               } catch (IllegalArgumentException ignored) {
+                  return hash64(text);
+               }
+            }
+         }
+      }
+   }
+
+   private static long parseSourceWayId(Object value) {
+      if (value instanceof String sources && !sources.isBlank()) {
+         int cursor = 0;
+
+         while (true) {
+            int recordIndex = sources.indexOf("\"record_id\":\"w", cursor);
+            if (recordIndex < 0) {
+               return 0L;
+            }
+
+            int start = recordIndex + "\"record_id\":\"w".length();
+
+            int end;
+            for (end = start; end < sources.length(); end++) {
+               char ch = sources.charAt(end);
+               if (ch < '0' || ch > '9') {
+                  break;
+               }
+            }
+
+            if (end > start) {
+               try {
+                  return Long.parseLong(sources.substring(start, end));
+               } catch (NumberFormatException ignored) {
+               }
+            }
+
+            cursor = end > start ? end : recordIndex + 1;
+         }
+      } else {
+         return 0L;
+      }
+   }
+
+   private static long hash64(String text) {
+      long hash = -3750763034362895579L;
+      byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+
+      for (byte value : bytes) {
+         hash ^= value & 255;
+         hash *= 1099511628211L;
+      }
+
+      return hash == 0L ? 1L : hash;
+   }
+
+   private Path cachePathFor(TellusOsmSandSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".mvt.gz");
+   }
+
+   private Path parsedCachePathFor(TellusOsmSandSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".pm.parsed.bin");
+   }
+
+   private static TellusOsmSandSource.TileKey tileKeyForBlock(double blockX, double blockZ, double worldScale, int zoom) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double lon = clampLon(blockX / blocksPerDegree);
+         double lat = clampLat(EarthProjection.blockZToLat(blockZ, worldScale));
+         double n = tilesPerAxis(zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(Math.toRadians(lat)) + 1.0 / Math.cos(Math.toRadians(lat))) / Math.PI) / 2.0 * n;
+         return !(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n) ? new TellusOsmSandSource.TileKey(zoom, Mth.floor(x), Mth.floor(y)) : null;
+      }
+   }
+
+   private static double clampLat(double latitude) {
+      return Mth.clamp(latitude, MIN_LAT, MAX_LAT);
+   }
+
+   private static double clampLon(double longitude) {
+      return Mth.clamp(longitude, MIN_LON, MAX_LON);
+   }
+
+   private static double tilesPerAxis(int zoom) {
+      return (double)(1 << zoom);
+   }
+
+   private static String asString(Object value) {
+      return value == null ? null : String.valueOf(value);
+   }
+
+   private static String nonBlank(String value) {
+      return value != null && !value.isBlank() ? value : null;
+   }
+
+   private static int intProperty(String key, int defaultValue, int minInclusive, int maxInclusive) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            int parsed = Integer.parseInt(value);
+            return Mth.clamp(parsed, minInclusive, maxInclusive);
+         } catch (NumberFormatException error) {
+            Tellus.LOGGER.debug("Invalid integer system property {}='{}', using {}", new Object[]{key, value, defaultValue});
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.OSM;
+   }
+
+   @Override
+   public void clearCache() {
+      this.cache.invalidateAll();
+      this.cache.cleanUp();
+      this.pendingAsyncLoads.clear();
+      this.tileLoadFailures.clear();
+   }
+
+   private record TileKey(int zoom, int x, int y) {
+   }
+
+   private record TileLookup(OsmSandTile tile, boolean cacheMiss) {
+   }
+
+   private record TilePoint(int x, int y) {
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmWaterSource.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/data/osm/TellusOsmWaterSource.java
@@ -1,0 +1,1061 @@
+package com.yucareux.tellus.world.data.osm;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.cache.TellusCacheDomain;
+import com.yucareux.tellus.cache.TellusCacheHandle;
+import com.yucareux.tellus.cache.TellusCacheRegistry;
+import com.yucareux.tellus.worldgen.EarthProjection;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Feature;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Layer;
+import io.github.sebasbaumh.mapbox.vectortile.VectorTile.Tile.Value;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import net.neoforged.fml.loading.FMLPaths;
+import net.minecraft.util.Mth;
+import net.minecraft.Util;
+
+public final class TellusOsmWaterSource implements TellusCacheHandle {
+   private static final String DEFAULT_PM_TILES_URL = "https://overturemaps-tiles-us-west-2-beta.s3.amazonaws.com/2026-01-21/base.pmtiles";
+   private static final double MIN_LAT = -85.05112878;
+   private static final double MAX_LAT = 85.05112878;
+   private static final double MIN_LON = -180.0;
+   private static final double MAX_LON = 180.0;
+   private static final double METERS_PER_DEGREE = 111319.49166666667;
+   private static final double POINT_EPSILON = 1.0E-9;
+   private static final int DEFAULT_TILE_EXTENT = 4096;
+   private static final int CONNECT_TIMEOUT_MS = intProperty("tellus.overture.water.connectTimeoutMs", 7000, 1, 120000);
+   private static final int READ_TIMEOUT_MS = intProperty("tellus.overture.water.readTimeoutMs", 20000, 1, 180000);
+   private static final int DIRECTORY_CACHE_ENTRIES = intProperty("tellus.overture.water.dirCache", 256, 1, 8192);
+   private static final int MAX_CACHE_TILES = intProperty("tellus.osm.water.cacheTiles", 256, 1, 8192);
+   private static final int MAX_ASYNC_PREFETCH_LOADS = intProperty("tellus.osm.water.prefetchAsyncMax", 96, 0, 8192);
+   private static final int FETCH_RETRY_ATTEMPTS = intProperty("tellus.overture.water.fetchRetries", 3, 1, 8);
+   private static final int MAX_QUERY_TILES = intProperty("tellus.osm.water.maxQueryTiles", 64, 1, 4096);
+   private static final int MIN_TILE_WIDTH_BLOCKS = intProperty("tellus.osm.water.minTileWidthBlocks", 96, 1, 16384);
+   private static final int PMTILES_TILETYPE_MVT = 1;
+   private static final String WATER_LAYER_NAME = "water";
+   private static final byte[] EMPTY_TILE_PAYLOAD = new byte[0];
+   private final Path cacheRoot = FMLPaths.GAMEDIR.get().resolve("tellus/cache/map/water");
+   private final PmTilesRangeReader pmTilesReader;
+   private final Object initLock = new Object();
+   private final LoadingCache<TellusOsmWaterSource.TileKey, OsmWaterTile> cache;
+   private final Set<TellusOsmWaterSource.TileKey> pendingAsyncLoads;
+   private final Set<TellusOsmWaterSource.TileKey> tileLoadFailures;
+   private volatile boolean available;
+   private volatile int minZoom;
+   private volatile int maxZoom;
+   private volatile boolean initialized;
+
+   public TellusOsmWaterSource() {
+      String pmTilesUrl = System.getProperty("tellus.overture.water.pmtiles", DEFAULT_PM_TILES_URL);
+      this.pmTilesReader = new PmTilesRangeReader(pmTilesUrl, CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS, DIRECTORY_CACHE_ENTRIES);
+      this.cache = CacheBuilder.newBuilder().maximumSize(MAX_CACHE_TILES).build(new CacheLoader<TellusOsmWaterSource.TileKey, OsmWaterTile>() {
+         public OsmWaterTile load(TellusOsmWaterSource.TileKey key) {
+            return TellusOsmWaterSource.this.loadTile(key);
+         }
+      });
+      this.pendingAsyncLoads = ConcurrentHashMap.newKeySet();
+      this.tileLoadFailures = ConcurrentHashMap.newKeySet();
+      TellusCacheRegistry.register(this);
+   }
+
+   public boolean available() {
+      this.ensureInitialized();
+      return this.available;
+   }
+
+   public WaterQueryResult waterForAreaWithStatus(
+      int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks, OsmQueryMode mode
+   ) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0)) {
+         TellusOsmWaterSource.GeoBounds bounds = geoBoundsForBlockArea(minBlockX, minBlockZ, maxBlockX, maxBlockZ, marginBlocks, worldScale);
+         if (bounds == null) {
+            return new WaterQueryResult(List.of(), false, 0);
+         } else {
+            int zoom = this.queryZoomForBounds(bounds, worldScale);
+            List<TellusOsmWaterSource.TileKey> keys = tileKeysForBounds(bounds, zoom);
+            if (keys.isEmpty()) {
+               return new WaterQueryResult(List.of(), false, zoom);
+            } else {
+               List<OsmWaterFeature> features = new ArrayList<>();
+               boolean hadCacheMiss = false;
+
+               for (TellusOsmWaterSource.TileKey key : keys) {
+                  TellusOsmWaterSource.TileLookup lookup = this.getTileLookup(key, mode);
+                  hadCacheMiss |= lookup.cacheMiss();
+                  OsmWaterTile tile = lookup.tile();
+                  if (!tile.isEmpty()) {
+                     features.addAll(tile.featuresInBounds(bounds.south(), bounds.west(), bounds.north(), bounds.east()));
+                  }
+               }
+
+               return new WaterQueryResult(features, hadCacheMiss, zoom);
+            }
+         }
+      } else {
+         return new WaterQueryResult(List.of(), false, 0);
+      }
+   }
+
+   public List<OsmWaterFeature> waterForArea(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks) {
+      return this.waterForAreaWithStatus(minBlockX, minBlockZ, maxBlockX, maxBlockZ, worldScale, marginBlocks, OsmQueryMode.BLOCKING).features();
+   }
+
+   public FastWaterSample sampleWater(int blockX, int blockZ, double worldScale, OsmQueryMode mode) {
+      WaterQueryResult result = this.waterForAreaWithStatus(blockX - 1, blockZ - 1, blockX + 1, blockZ + 1, worldScale, 0, mode);
+      if (result.features().isEmpty()) {
+         return new FastWaterSample(false, false, result.hadCacheMiss());
+      } else {
+         boolean hasWater = false;
+         boolean ocean = false;
+
+         for (OsmWaterFeature feature : result.features()) {
+            if (feature.containsBlock(blockX, blockZ, worldScale)) {
+               hasWater = true;
+               if (feature.oceanHint()) {
+                  ocean = true;
+                  break;
+               }
+            }
+         }
+
+         return new FastWaterSample(hasWater, ocean, result.hadCacheMiss());
+      }
+   }
+
+   public boolean hasWaterInArea(int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, double worldScale, int marginBlocks, OsmQueryMode mode) {
+      return !this.waterForAreaWithStatus(minBlockX, minBlockZ, maxBlockX, maxBlockZ, worldScale, marginBlocks, mode).features().isEmpty();
+   }
+
+   public void prefetchTiles(double blockX, double blockZ, double worldScale, int radius) {
+      this.ensureInitialized();
+      if (this.available && !(worldScale <= 0.0) && radius > 0) {
+         int zoom = this.queryZoomForScale(worldScale);
+         TellusOsmWaterSource.TileKey center = tileKeyForBlock(blockX, blockZ, worldScale, zoom);
+         if (center != null) {
+            int tilesPerAxis = 1 << zoom;
+            int minX = Math.max(0, center.x() - radius);
+            int maxX = Math.min(tilesPerAxis - 1, center.x() + radius);
+            int minY = Math.max(0, center.y() - radius);
+            int maxY = Math.min(tilesPerAxis - 1, center.y() + radius);
+
+            for (int tileY = minY; tileY <= maxY; tileY++) {
+               for (int tileX = minX; tileX <= maxX; tileX++) {
+                  this.getTile(new TellusOsmWaterSource.TileKey(zoom, tileX, tileY), OsmQueryMode.NON_BLOCKING);
+               }
+            }
+         }
+      }
+   }
+
+   private int queryZoomForBounds(TellusOsmWaterSource.GeoBounds bounds, double worldScale) {
+      this.ensureInitialized();
+      int zoom = this.queryZoomForScale(worldScale);
+
+      while (zoom > this.minZoom) {
+         if (tileKeysForBounds(bounds, zoom).size() <= MAX_QUERY_TILES) {
+            break;
+         }
+
+         zoom--;
+      }
+
+      return zoom;
+   }
+
+   private int queryZoomForScale(double worldScale) {
+      this.ensureInitialized();
+      if (worldScale <= 0.0) {
+         return this.minZoom;
+      } else {
+         double blocksPerDegree = EarthProjection.blocksPerDegree(worldScale);
+
+         for (int zoom = this.maxZoom; zoom >= this.minZoom; zoom--) {
+            double tileWidthBlocks = 360.0 * blocksPerDegree / (1 << zoom);
+            if (tileWidthBlocks >= MIN_TILE_WIDTH_BLOCKS) {
+               return zoom;
+            }
+         }
+
+         return this.minZoom;
+      }
+   }
+
+   private OsmWaterTile getTile(TellusOsmWaterSource.TileKey key, OsmQueryMode mode) {
+      return this.getTileLookup(key, mode).tile();
+   }
+
+   private TellusOsmWaterSource.TileLookup getTileLookup(TellusOsmWaterSource.TileKey key, OsmQueryMode mode) {
+      OsmWaterTile cached = this.cache.getIfPresent(key);
+      if (cached != null) {
+         if (!cached.isEmpty() || !this.tileLoadFailures.contains(key)) {
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.MEMORY);
+            return new TellusOsmWaterSource.TileLookup(cached, false);
+         }
+
+         this.cache.invalidate(key);
+      }
+
+      OsmQueryMode queryMode = mode == null ? OsmQueryMode.BLOCKING : mode;
+      if (queryMode == OsmQueryMode.NON_BLOCKING) {
+         this.queueAsyncLoad(key);
+         return new TellusOsmWaterSource.TileLookup(OsmWaterTile.empty(), true);
+      } else {
+         try {
+            return new TellusOsmWaterSource.TileLookup(this.cache.get(key), false);
+         } catch (Exception error) {
+            Tellus.LOGGER.debug("Failed to load Overture water tile {}", key, error);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.FAILURE);
+            return new TellusOsmWaterSource.TileLookup(OsmWaterTile.empty(), false);
+         }
+      }
+   }
+
+   private void queueAsyncLoad(TellusOsmWaterSource.TileKey key) {
+      if (MAX_ASYNC_PREFETCH_LOADS <= 0 || this.pendingAsyncLoads.size() < MAX_ASYNC_PREFETCH_LOADS) {
+         if (this.pendingAsyncLoads.add(key)) {
+            Util.backgroundExecutor().execute(() -> {
+               try {
+                  this.cache.get(key);
+               } catch (Exception error) {
+                  Tellus.LOGGER.debug("Async load failed for Overture water tile {}", key, error);
+                  this.tileLoadFailures.add(key);
+                  OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.FAILURE);
+               } finally {
+                  this.pendingAsyncLoads.remove(key);
+               }
+            });
+         }
+      }
+   }
+
+   private OsmWaterTile loadTile(TellusOsmWaterSource.TileKey key) {
+      this.ensureInitialized();
+      if (!this.available) {
+         return OsmWaterTile.empty();
+      } else {
+         TellusOsmWaterSource.TileGeoBounds bounds = tileBounds(key);
+         Path cachePath = this.cachePathFor(key);
+         Path parsedCachePath = this.parsedCachePathFor(key);
+         if (Files.exists(parsedCachePath)) {
+            try {
+               OsmWaterTile parsed = ParsedTileCodec.readWaterTile(parsedCachePath);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.PARSED_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException error) {
+               Tellus.LOGGER.debug("Invalid parsed Overture water cache tile {}, refetching", key, error);
+
+               try {
+                  Files.deleteIfExists(parsedCachePath);
+               } catch (IOException deleteError) {
+                  Tellus.LOGGER.debug("Failed to delete invalid parsed Overture water cache tile {}", parsedCachePath, deleteError);
+               }
+            }
+         }
+
+         if (Files.exists(cachePath)) {
+            try {
+               byte[] payload = this.readCompressed(cachePath);
+               OsmWaterTile parsed = this.parseVectorTile(payload, bounds, key);
+               this.cacheParsedTile(parsedCachePath, parsed);
+               this.tileLoadFailures.remove(key);
+               OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.RAW_DISK);
+               return parsed;
+            } catch (RuntimeException | IOException error) {
+               Tellus.LOGGER.debug("Invalid Overture water cache tile {}, refetching", key, error);
+
+               try {
+                  Files.deleteIfExists(cachePath);
+               } catch (IOException deleteError) {
+                  Tellus.LOGGER.debug("Failed to delete invalid Overture water cache tile {}", cachePath, deleteError);
+               }
+            }
+         }
+
+         byte[] payload = this.fetchTilePayloadWithRetry(key);
+
+         OsmWaterTile parsed;
+         try {
+            parsed = this.parseVectorTile(payload, bounds, key);
+         } catch (RuntimeException error) {
+            Tellus.LOGGER.warn("Overture water parse failed for tile {}", key, error);
+            this.tileLoadFailures.add(key);
+            OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.FAILURE);
+            throw new RuntimeException("Overture water parse failed for tile " + key, error);
+         }
+
+         this.cacheTile(cachePath, payload);
+         this.cacheParsedTile(parsedCachePath, parsed);
+         this.tileLoadFailures.remove(key);
+         OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.NETWORK);
+         return parsed;
+      }
+   }
+
+   private void ensureInitialized() {
+      if (this.initialized) {
+         return;
+      }
+
+      synchronized (this.initLock) {
+         if (this.initialized) {
+            return;
+         }
+
+         int resolvedMinZoom = 0;
+         int resolvedMaxZoom = 0;
+         boolean sourceAvailable;
+
+         try {
+            PmTilesRangeReader.PmTilesHeader header = this.pmTilesReader.header();
+            if (header.tileType() != PMTILES_TILETYPE_MVT) {
+               Tellus.LOGGER.warn("Unexpected Overture water PMTiles tile type {}, expected MVT", header.tileType());
+            }
+
+            resolvedMinZoom = header.minZoom();
+            resolvedMaxZoom = header.maxZoom();
+            sourceAvailable = true;
+         } catch (IOException error) {
+            sourceAvailable = false;
+            Tellus.LOGGER.warn("Overture water PMTiles unavailable, OSM water disabled", error);
+         }
+
+         this.available = sourceAvailable;
+         this.minZoom = resolvedMinZoom;
+         this.maxZoom = resolvedMaxZoom;
+         this.initialized = true;
+      }
+   }
+
+   private byte[] fetchTilePayloadWithRetry(TellusOsmWaterSource.TileKey key) {
+      RuntimeException lastFailure = null;
+
+      for (int attempt = 1; attempt <= FETCH_RETRY_ATTEMPTS; attempt++) {
+         try {
+            byte[] fetched = this.pmTilesReader.getTileBytes(key.zoom(), key.x(), key.y());
+            return fetched == null ? EMPTY_TILE_PAYLOAD : fetched;
+         } catch (IOException error) {
+            lastFailure = new RuntimeException("Overture water fetch failed for tile " + key, error);
+            if (attempt < FETCH_RETRY_ATTEMPTS) {
+               continue;
+            }
+            break;
+         }
+      }
+
+      this.tileLoadFailures.add(key);
+      OsmPerf.recordTileLoad(OsmPerf.TileSource.OSM_WATER, OsmPerf.TileLoadPath.FAILURE);
+      if (lastFailure != null) {
+         throw lastFailure;
+      } else {
+         return EMPTY_TILE_PAYLOAD;
+      }
+   }
+
+   private void cacheTile(Path cachePath, byte[] payload) {
+      try {
+         Files.createDirectories(cachePath.getParent());
+         Path tempPath = cachePath.resolveSibling(cachePath.getFileName() + ".tmp");
+
+         try (OutputStream output = new GZIPOutputStream(Files.newOutputStream(tempPath))) {
+            output.write(payload);
+         }
+
+         Files.move(tempPath, cachePath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to cache Overture water tile {}", cachePath, error);
+      }
+   }
+
+   private void cacheParsedTile(Path cachePath, OsmWaterTile tile) {
+      try {
+         ParsedTileCodec.writeWaterTile(cachePath, tile);
+      } catch (IOException error) {
+         Tellus.LOGGER.debug("Failed to cache parsed Overture water tile {}", cachePath, error);
+      }
+   }
+
+   private byte[] readCompressed(Path path) throws IOException {
+      try (InputStream input = new GZIPInputStream(Files.newInputStream(path))) {
+         return input.readAllBytes();
+      }
+   }
+
+   private OsmWaterTile parseVectorTile(byte[] payload, TellusOsmWaterSource.TileGeoBounds bounds, TellusOsmWaterSource.TileKey key) {
+      if (payload.length == 0) {
+         return OsmWaterTile.empty();
+      } else {
+         Tile tile;
+         try {
+            tile = Tile.parseFrom(payload);
+         } catch (Exception error) {
+            throw new RuntimeException("Failed to decode water MVT payload", error);
+         }
+
+         if (tile.getLayersCount() == 0) {
+            return OsmWaterTile.empty();
+         } else {
+            List<OsmWaterFeature> features = new ArrayList<>();
+
+            for (Layer layer : tile.getLayersList()) {
+               if (WATER_LAYER_NAME.equals(layer.getName())) {
+                  int extent = layer.hasExtent() && layer.getExtent() > 0 ? layer.getExtent() : DEFAULT_TILE_EXTENT;
+
+                  for (Feature feature : layer.getFeaturesList()) {
+                     features.addAll(this.parseFeature(feature, layer, key, extent));
+                  }
+               }
+            }
+
+            return features.isEmpty() ? OsmWaterTile.empty() : new OsmWaterTile(features, bounds.south(), bounds.west(), bounds.north(), bounds.east());
+         }
+      }
+   }
+
+   private List<OsmWaterFeature> parseFeature(Feature feature, Layer layer, TellusOsmWaterSource.TileKey key, int extent) {
+      Map<String, Object> tags = decodeTags(feature, layer);
+      String classTag = nonBlank(asString(tags.get("class")));
+      String subtype = nonBlank(asString(tags.get("subtype")));
+      if (classTag == null && subtype == null) {
+         return List.of();
+      } else {
+         boolean oceanHint = "ocean".equalsIgnoreCase(classTag) || "ocean".equalsIgnoreCase(subtype);
+         long featureId = resolveFeatureId(feature, tags);
+         return switch (feature.getType()) {
+            case POLYGON -> buildPolygonFeatures(featureId, oceanHint, decodePolygonRings(feature.getGeometryList()), key.zoom(), key.x(), key.y(), extent);
+            case LINESTRING -> buildLineFeatures(featureId, oceanHint, decodeLineStrings(feature.getGeometryList()), key.zoom(), key.x(), key.y(), extent);
+            default -> List.of();
+         };
+      }
+   }
+
+   private static List<OsmWaterFeature> buildPolygonFeatures(
+      long featureId,
+      boolean oceanHint,
+      List<List<TellusOsmWaterSource.TilePoint>> rings,
+      int zoom,
+      int tileX,
+      int tileY,
+      int extent
+   ) {
+      if (rings.isEmpty()) {
+         return List.of();
+      } else {
+         double[][] longitudes = new double[rings.size()][];
+         double[][] latitudes = new double[rings.size()][];
+
+         for (int part = 0; part < rings.size(); part++) {
+            List<TellusOsmWaterSource.TilePoint> ring = rings.get(part);
+            int points = ring.size();
+            double[] lonPart = new double[points];
+            double[] latPart = new double[points];
+            int count = 0;
+            double previousLon = Double.NaN;
+            double previousLat = Double.NaN;
+
+            for (TellusOsmWaterSource.TilePoint point : ring) {
+               double lon = tilePointToLon(zoom, tileX, (double)point.x / extent);
+               double lat = tilePointToLat(zoom, tileY, (double)point.y / extent);
+               if (Double.isFinite(lat)
+                  && Double.isFinite(lon)
+                  && !(lat < MIN_LAT)
+                  && !(lat > MAX_LAT)
+                  && !(lon < MIN_LON)
+                  && !(lon > MAX_LON)
+                  && (count <= 0 || !(Math.abs(lon - previousLon) < POINT_EPSILON) || !(Math.abs(lat - previousLat) < POINT_EPSILON))) {
+                  lonPart[count] = lon;
+                  latPart[count] = lat;
+                  previousLon = lon;
+                  previousLat = lat;
+                  count++;
+               }
+            }
+
+            if (count < 4) {
+               return List.of();
+            }
+
+            if (lonPart[0] != lonPart[count - 1] || latPart[0] != latPart[count - 1]) {
+               if (count + 1 > lonPart.length) {
+                  lonPart = Arrays.copyOf(lonPart, count + 1);
+                  latPart = Arrays.copyOf(latPart, count + 1);
+               }
+
+               lonPart[count] = lonPart[0];
+               latPart[count] = latPart[0];
+               count++;
+            }
+
+            longitudes[part] = count == lonPart.length ? lonPart : Arrays.copyOf(lonPart, count);
+            latitudes[part] = count == latPart.length ? latPart : Arrays.copyOf(latPart, count);
+         }
+
+         return List.of(new OsmWaterFeature(featureId, false, oceanHint, longitudes, latitudes));
+      }
+   }
+
+   private static List<OsmWaterFeature> buildLineFeatures(
+      long featureId,
+      boolean oceanHint,
+      List<List<TellusOsmWaterSource.TilePoint>> lines,
+      int zoom,
+      int tileX,
+      int tileY,
+      int extent
+   ) {
+      if (lines.isEmpty()) {
+         return List.of();
+      } else {
+         List<double[]> longitudeParts = new ArrayList<>();
+         List<double[]> latitudeParts = new ArrayList<>();
+
+         for (List<TellusOsmWaterSource.TilePoint> line : lines) {
+            double[] longitudes = new double[line.size()];
+            double[] latitudes = new double[line.size()];
+            int count = 0;
+            double previousLon = Double.NaN;
+            double previousLat = Double.NaN;
+
+            for (TellusOsmWaterSource.TilePoint point : line) {
+               double lon = tilePointToLon(zoom, tileX, (double)point.x / extent);
+               double lat = tilePointToLat(zoom, tileY, (double)point.y / extent);
+               if (Double.isFinite(lat)
+                  && Double.isFinite(lon)
+                  && !(lat < MIN_LAT)
+                  && !(lat > MAX_LAT)
+                  && !(lon < MIN_LON)
+                  && !(lon > MAX_LON)
+                  && (count <= 0 || !(Math.abs(lon - previousLon) < POINT_EPSILON) || !(Math.abs(lat - previousLat) < POINT_EPSILON))) {
+                  longitudes[count] = lon;
+                  latitudes[count] = lat;
+                  previousLon = lon;
+                  previousLat = lat;
+                  count++;
+               }
+            }
+
+            if (count >= 2) {
+               longitudeParts.add(count == longitudes.length ? longitudes : Arrays.copyOf(longitudes, count));
+               latitudeParts.add(count == latitudes.length ? latitudes : Arrays.copyOf(latitudes, count));
+            }
+         }
+
+         if (longitudeParts.isEmpty()) {
+            return List.of();
+         } else {
+            return List.of(new OsmWaterFeature(featureId, true, oceanHint, longitudeParts.toArray(new double[0][]), latitudeParts.toArray(new double[0][])));
+         }
+      }
+   }
+
+   private static List<List<TellusOsmWaterSource.TilePoint>> decodePolygonRings(List<Integer> geometry) {
+      if (geometry != null && !geometry.isEmpty()) {
+         List<List<TellusOsmWaterSource.TilePoint>> rings = new ArrayList<>();
+         List<TellusOsmWaterSource.TilePoint> current = null;
+         int cursorX = 0;
+         int cursorY = 0;
+         int cursor = 0;
+
+         while (cursor < geometry.size()) {
+            int commandAndCount = geometry.get(cursor++);
+            int command = commandAndCount & 7;
+            int count = commandAndCount >>> 3;
+            if (count > 0) {
+               switch (command) {
+                  case 1:
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return rings;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        if (current != null && !current.isEmpty()) {
+                           addRing(rings, current);
+                        }
+
+                        current = new ArrayList<>();
+                        current.add(new TellusOsmWaterSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 2:
+                     if (current == null) {
+                        current = new ArrayList<>();
+                     }
+
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return rings;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        current.add(new TellusOsmWaterSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 7:
+                     if (current != null && !current.isEmpty()) {
+                        addRing(rings, current);
+                        current = null;
+                     }
+                     break;
+                  default:
+                     return rings;
+               }
+            }
+         }
+
+         if (current != null && !current.isEmpty()) {
+            addRing(rings, current);
+         }
+
+         return rings;
+      } else {
+         return List.of();
+      }
+   }
+
+   private static List<List<TellusOsmWaterSource.TilePoint>> decodeLineStrings(List<Integer> geometry) {
+      if (geometry != null && !geometry.isEmpty()) {
+         List<List<TellusOsmWaterSource.TilePoint>> lines = new ArrayList<>();
+         List<TellusOsmWaterSource.TilePoint> current = null;
+         int cursorX = 0;
+         int cursorY = 0;
+         int cursor = 0;
+
+         while (cursor < geometry.size()) {
+            int commandAndCount = geometry.get(cursor++);
+            int command = commandAndCount & 7;
+            int count = commandAndCount >>> 3;
+            if (count > 0) {
+               switch (command) {
+                  case 1:
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return lines;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        if (current != null && !current.isEmpty()) {
+                           addLine(lines, current);
+                        }
+
+                        current = new ArrayList<>();
+                        current.add(new TellusOsmWaterSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 2:
+                     if (current == null) {
+                        current = new ArrayList<>();
+                     }
+
+                     for (int i = 0; i < count; i++) {
+                        if (cursor + 1 >= geometry.size()) {
+                           return lines;
+                        }
+
+                        cursorX += zigZagDecode(geometry.get(cursor++));
+                        cursorY += zigZagDecode(geometry.get(cursor++));
+                        current.add(new TellusOsmWaterSource.TilePoint(cursorX, cursorY));
+                     }
+                     break;
+                  case 7:
+                     if (current != null && !current.isEmpty()) {
+                        addLine(lines, current);
+                        current = null;
+                     }
+                     break;
+                  default:
+                     return lines;
+               }
+            }
+         }
+
+         if (current != null && !current.isEmpty()) {
+            addLine(lines, current);
+         }
+
+         return lines;
+      } else {
+         return List.of();
+      }
+   }
+
+   private static void addRing(List<List<TellusOsmWaterSource.TilePoint>> rings, List<TellusOsmWaterSource.TilePoint> points) {
+      List<TellusOsmWaterSource.TilePoint> cleaned = new ArrayList<>(points.size());
+
+      for (TellusOsmWaterSource.TilePoint point : points) {
+         if (cleaned.isEmpty() || !samePoint(cleaned.get(cleaned.size() - 1), point)) {
+            cleaned.add(point);
+         }
+      }
+
+      if (cleaned.size() >= 3) {
+         TellusOsmWaterSource.TilePoint first = cleaned.get(0);
+         TellusOsmWaterSource.TilePoint last = cleaned.get(cleaned.size() - 1);
+         if (!samePoint(first, last)) {
+            cleaned.add(first);
+         }
+
+         if (cleaned.size() >= 4) {
+            rings.add(List.copyOf(cleaned));
+         }
+      }
+   }
+
+   private static void addLine(List<List<TellusOsmWaterSource.TilePoint>> lines, List<TellusOsmWaterSource.TilePoint> points) {
+      if (points.size() >= 2) {
+         List<TellusOsmWaterSource.TilePoint> cleaned = new ArrayList<>(points.size());
+
+         for (TellusOsmWaterSource.TilePoint point : points) {
+            if (cleaned.isEmpty() || !samePoint(cleaned.get(cleaned.size() - 1), point)) {
+               cleaned.add(point);
+            }
+         }
+
+         if (cleaned.size() >= 2) {
+            lines.add(List.copyOf(cleaned));
+         }
+      }
+   }
+
+   private static boolean samePoint(TellusOsmWaterSource.TilePoint a, TellusOsmWaterSource.TilePoint b) {
+      return a.x == b.x && a.y == b.y;
+   }
+
+   private static int zigZagDecode(int encoded) {
+      return encoded >>> 1 ^ -(encoded & 1);
+   }
+
+   private static double tilePointToLon(int zoom, int tileX, double localX) {
+      double n = tilesPerAxis(zoom);
+      double normalizedX = (tileX + localX) / n;
+      return normalizedX * 360.0 - 180.0;
+   }
+
+   private static double tilePointToLat(int zoom, int tileY, double localY) {
+      double n = tilesPerAxis(zoom);
+      double normalizedY = (tileY + localY) / n;
+      double mercator = Math.PI * (1.0 - 2.0 * normalizedY);
+      return Math.toDegrees(Math.atan(Math.sinh(mercator)));
+   }
+
+   private static Map<String, Object> decodeTags(Feature feature, Layer layer) {
+      List<Integer> tags = feature.getTagsList();
+      if (tags.isEmpty()) {
+         return Map.of();
+      } else {
+         Map<String, Object> values = new HashMap<>(tags.size() / 2);
+
+         for (int i = 0; i + 1 < tags.size(); i += 2) {
+            int keyIndex = tags.get(i);
+            int valueIndex = tags.get(i + 1);
+            if (keyIndex >= 0 && keyIndex < layer.getKeysCount() && valueIndex >= 0 && valueIndex < layer.getValuesCount()) {
+               String key = layer.getKeys(keyIndex);
+               Object value = decodeValue(layer.getValues(valueIndex));
+               if (key != null && !key.isBlank() && value != null) {
+                  values.put(key, value);
+               }
+            }
+         }
+
+         return values;
+      }
+   }
+
+   private static Object decodeValue(Value value) {
+      if (value.hasStringValue()) {
+         return value.getStringValue();
+      } else if (value.hasDoubleValue()) {
+         return value.getDoubleValue();
+      } else if (value.hasFloatValue()) {
+         return (double)value.getFloatValue();
+      } else if (value.hasSintValue()) {
+         return value.getSintValue();
+      } else if (value.hasIntValue()) {
+         return value.getIntValue();
+      } else if (value.hasUintValue()) {
+         return value.getUintValue();
+      } else {
+         return value.hasBoolValue() ? value.getBoolValue() : null;
+      }
+   }
+
+   private static long resolveFeatureId(Feature feature, Map<String, Object> tags) {
+      if (feature.hasId() && feature.getId() != 0L) {
+         return feature.getId();
+      } else {
+         long idFromTag = parseLongId(tags.get("id"));
+         if (idFromTag != 0L) {
+            return idFromTag;
+         } else {
+            long idFromSources = parseSourceWayId(tags.get("sources"));
+            return idFromSources != 0L ? idFromSources : 0L;
+         }
+      }
+   }
+
+   private static long parseLongId(Object value) {
+      if (value == null) {
+         return 0L;
+      } else if (value instanceof Number number) {
+         return number.longValue();
+      } else {
+         String text = String.valueOf(value).trim();
+         if (text.isEmpty()) {
+            return 0L;
+         } else {
+            try {
+               return Long.parseLong(text);
+            } catch (NumberFormatException error) {
+               try {
+                  UUID uuid = UUID.fromString(text);
+                  long mixed = uuid.getMostSignificantBits() ^ uuid.getLeastSignificantBits();
+                  return mixed == 0L ? 1L : mixed;
+               } catch (IllegalArgumentException ignored) {
+                  return hash64(text);
+               }
+            }
+         }
+      }
+   }
+
+   private static long parseSourceWayId(Object value) {
+      if (value instanceof String sources && !sources.isBlank()) {
+         int cursor = 0;
+
+         while (true) {
+            int recordIndex = sources.indexOf("\"record_id\":\"w", cursor);
+            if (recordIndex < 0) {
+               return 0L;
+            }
+
+            int start = recordIndex + "\"record_id\":\"w".length();
+
+            int end;
+            for (end = start; end < sources.length(); end++) {
+               char ch = sources.charAt(end);
+               if (ch < '0' || ch > '9') {
+                  break;
+               }
+            }
+
+            if (end > start) {
+               try {
+                  return Long.parseLong(sources.substring(start, end));
+               } catch (NumberFormatException ignored) {
+               }
+            }
+
+            cursor = end > start ? end : recordIndex + 1;
+         }
+      } else {
+         return 0L;
+      }
+   }
+
+   private static long hash64(String text) {
+      long hash = -3750763034362895579L;
+      byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+
+      for (byte value : bytes) {
+         hash ^= value & 255;
+         hash *= 1099511628211L;
+      }
+
+      return hash == 0L ? 1L : hash;
+   }
+
+   private Path cachePathFor(TellusOsmWaterSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".mvt.gz");
+   }
+
+   private Path parsedCachePathFor(TellusOsmWaterSource.TileKey key) {
+      return this.cacheRoot.resolve(key.zoom() + "/" + key.x() + "/" + key.y() + ".pm.parsed.bin");
+   }
+
+   private static TellusOsmWaterSource.GeoBounds geoBoundsForBlockArea(
+      int minBlockX, int minBlockZ, int maxBlockX, int maxBlockZ, int marginBlocks, double worldScale
+   ) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         int margin = Math.max(0, marginBlocks);
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double west = clampLon((Math.min(minBlockX, maxBlockX) - margin) / blocksPerDegree);
+         double east = clampLon((Math.max(minBlockX, maxBlockX) + margin) / blocksPerDegree);
+         double north = clampLat(EarthProjection.blockZToLat(Math.min(minBlockZ, maxBlockZ) - margin, worldScale));
+         double south = clampLat(EarthProjection.blockZToLat(Math.max(minBlockZ, maxBlockZ) + margin, worldScale));
+         if (south > north) {
+            double swap = south;
+            south = north;
+            north = swap;
+         }
+
+         return new TellusOsmWaterSource.GeoBounds(south, west, north, east);
+      }
+   }
+
+   private static List<TellusOsmWaterSource.TileKey> tileKeysForBounds(TellusOsmWaterSource.GeoBounds bounds, int zoom) {
+      int tilesPerAxis = 1 << zoom;
+      int minX = Mth.clamp(lonToTileX(bounds.west(), zoom), 0, tilesPerAxis - 1);
+      int maxX = Mth.clamp(lonToTileX(bounds.east(), zoom), 0, tilesPerAxis - 1);
+      int minY = Mth.clamp(latToTileY(bounds.north(), zoom), 0, tilesPerAxis - 1);
+      int maxY = Mth.clamp(latToTileY(bounds.south(), zoom), 0, tilesPerAxis - 1);
+      if (maxX >= minX && maxY >= minY) {
+         List<TellusOsmWaterSource.TileKey> keys = new ArrayList<>((maxX - minX + 1) * (maxY - minY + 1));
+
+         for (int y = minY; y <= maxY; y++) {
+            for (int x = minX; x <= maxX; x++) {
+               keys.add(new TellusOsmWaterSource.TileKey(zoom, x, y));
+            }
+         }
+
+         return keys;
+      } else {
+         return List.of();
+      }
+   }
+
+   private static TellusOsmWaterSource.TileKey tileKeyForBlock(double blockX, double blockZ, double worldScale, int zoom) {
+      if (worldScale <= 0.0) {
+         return null;
+      } else {
+         double blocksPerDegree = METERS_PER_DEGREE / worldScale;
+         double lon = clampLon(blockX / blocksPerDegree);
+         double lat = clampLat(EarthProjection.blockZToLat(blockZ, worldScale));
+         double n = tilesPerAxis(zoom);
+         double x = (lon + 180.0) / 360.0 * n;
+         double y = (1.0 - Math.log(Math.tan(Math.toRadians(lat)) + 1.0 / Math.cos(Math.toRadians(lat))) / Math.PI) / 2.0 * n;
+         return !(x < 0.0) && !(y < 0.0) && !(x >= n) && !(y >= n) ? new TellusOsmWaterSource.TileKey(zoom, Mth.floor(x), Mth.floor(y)) : null;
+      }
+   }
+
+   private static TellusOsmWaterSource.TileGeoBounds tileBounds(TellusOsmWaterSource.TileKey key) {
+      double n = tilesPerAxis(key.zoom());
+      double west = key.x() / n * 360.0 - 180.0;
+      double east = (key.x() + 1.0) / n * 360.0 - 180.0;
+      double north = Math.toDegrees(Math.atan(Math.sinh(Math.PI * (1.0 - 2.0 * key.y() / n))));
+      double south = Math.toDegrees(Math.atan(Math.sinh(Math.PI * (1.0 - 2.0 * (key.y() + 1.0) / n))));
+      return new TellusOsmWaterSource.TileGeoBounds(south, west, north, east);
+   }
+
+   private static int lonToTileX(double lon, int zoom) {
+      double n = tilesPerAxis(zoom);
+      double x = (clampLon(lon) + 180.0) / 360.0 * n;
+      if (x >= n) {
+         x = n - 1.0;
+      }
+
+      return Mth.floor(x);
+   }
+
+   private static int latToTileY(double lat, int zoom) {
+      double clampedLat = clampLat(lat);
+      double n = tilesPerAxis(zoom);
+      double latRad = Math.toRadians(clampedLat);
+      double y = (1.0 - Math.log(Math.tan(latRad) + 1.0 / Math.cos(latRad)) / Math.PI) / 2.0 * n;
+      if (y >= n) {
+         y = n - 1.0;
+      }
+
+      return Mth.floor(y);
+   }
+
+   private static double clampLat(double latitude) {
+      return Mth.clamp(latitude, MIN_LAT, MAX_LAT);
+   }
+
+   private static double clampLon(double longitude) {
+      return Mth.clamp(longitude, MIN_LON, MAX_LON);
+   }
+
+   private static double tilesPerAxis(int zoom) {
+      return (double)(1 << zoom);
+   }
+
+   private static String asString(Object value) {
+      return value == null ? null : String.valueOf(value);
+   }
+
+   private static String nonBlank(String value) {
+      return value != null && !value.isBlank() ? value : null;
+   }
+
+   private static int intProperty(String key, int defaultValue, int minInclusive, int maxInclusive) {
+      String value = System.getProperty(key);
+      if (value == null) {
+         return defaultValue;
+      } else {
+         try {
+            int parsed = Integer.parseInt(value);
+            return Mth.clamp(parsed, minInclusive, maxInclusive);
+         } catch (NumberFormatException error) {
+            Tellus.LOGGER.debug("Invalid integer system property {}='{}', using {}", new Object[]{key, value, defaultValue});
+            return defaultValue;
+         }
+      }
+   }
+
+   @Override
+   public TellusCacheDomain cacheDomain() {
+      return TellusCacheDomain.OSM;
+   }
+
+   @Override
+   public void clearCache() {
+      this.cache.invalidateAll();
+      this.cache.cleanUp();
+      this.pendingAsyncLoads.clear();
+      this.tileLoadFailures.clear();
+   }
+
+   private record GeoBounds(double south, double west, double north, double east) {
+   }
+
+   public record FastWaterSample(boolean hasWater, boolean ocean, boolean hadCacheMiss) {
+   }
+
+   private record TileGeoBounds(double south, double west, double north, double east) {
+   }
+
+   private record TileKey(int zoom, int x, int y) {
+   }
+
+   private record TileLookup(OsmWaterTile tile, boolean cacheMiss) {
+   }
+
+   private record TilePoint(int x, int y) {
+   }
+
+   public record WaterQueryResult(List<OsmWaterFeature> features, boolean hadCacheMiss, int zoom) {
+      public WaterQueryResult(List<OsmWaterFeature> features, boolean hadCacheMiss, int zoom) {
+         features = features == null ? List.of() : List.copyOf(features);
+         this.features = features;
+         this.hadCacheMiss = hadCacheMiss;
+         this.zoom = zoom;
+      }
+   }
+}

--- a/neoforge/src/main/java/com/yucareux/tellus/world/realtime/TellusRealtimeManager.java
+++ b/neoforge/src/main/java/com/yucareux/tellus/world/realtime/TellusRealtimeManager.java
@@ -1,0 +1,794 @@
+package com.yucareux.tellus.world.realtime;
+
+import com.yucareux.tellus.Tellus;
+import com.yucareux.tellus.network.TellusWeatherPayload;
+import com.yucareux.tellus.world.data.source.OpenMeteoClient;
+import com.yucareux.tellus.worldgen.EarthChunkGenerator;
+import com.yucareux.tellus.worldgen.EarthGeneratorSettings;
+import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkSource;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.GameRules;
+
+public final class TellusRealtimeManager {
+   private static final long WEATHER_REFRESH_MS = 600000L;
+   private static final long TIMEZONE_REFRESH_MS = 21600000L;
+   private static final long TIME_APPLY_TICK_INTERVAL = 20L;
+   private static final long SNOW_QUEUE_REFRESH_TICKS = 100L;
+   private static final int SNOW_CHUNKS_PER_TICK = 8;
+   private static final int SNOW_MAX_RADIUS = 10;
+   private static final int GRID_RADIUS = 1;
+   private static final int GRID_SIZE = 3;
+   private static final int GRID_POINTS = 9;
+   private static final boolean NTP_ENABLED = Boolean.getBoolean("tellus.realtime.ntp");
+   private static final long NTP_REFRESH_MS = 43200000L;
+   private static final int NTP_TIMEOUT_MS = 2000;
+   private static final int NTP_PORT = 123;
+   private static final long NTP_EPOCH_OFFSET_SECONDS = 2208988800L;
+   private static final String[] NTP_SERVERS = new String[]{"time.google.com", "pool.ntp.org", "time.cloudflare.com"};
+   private final OpenMeteoClient client = new OpenMeteoClient();
+   private final ThreadFactory threadFactory;
+   private volatile ExecutorService executor;
+   private final AtomicBoolean requestInFlight = new AtomicBoolean(false);
+   private final AtomicBoolean pendingInitialSnowPass = new AtomicBoolean(false);
+   private final LongArrayFIFOQueue snowQueue = new LongArrayFIFOQueue();
+   private final LongOpenHashSet snowQueued = new LongOpenHashSet();
+   private long lastWeatherUpdateMs;
+   private long lastTimeZoneUpdateMs;
+   private long lastTimeApplyTick;
+   private long lastSnowQueueTick;
+   private boolean timeZoneReady;
+   private TellusRealtimeManager.GridAnchor lastAnchor;
+   private TellusRealtimeManager.GridAnchor lastTimeZoneAnchor;
+   private int utcOffsetSeconds;
+   private volatile long ntpOffsetMillis;
+   private volatile long lastNtpSyncMs;
+   private volatile Boolean realtimeTimeOverride;
+   private volatile Boolean realtimeWeatherOverride;
+   private volatile TellusRealtimeManager.WeatherSnapshot lastWeatherSnapshot;
+   private volatile ZoneId timeZone;
+   private volatile String timeZoneId;
+   private final AtomicBoolean ntpRequestInFlight = new AtomicBoolean(false);
+   private boolean cachedDaylightCycle;
+   private boolean cachedWeatherCycle;
+   private int cachedSleepPercentage = -1;
+   private boolean timeRulesCaptured;
+   private boolean weatherRulesCaptured;
+
+   public TellusRealtimeManager() {
+      this.threadFactory = runnable -> {
+         Thread thread = new Thread(runnable, "tellus-realtime");
+         thread.setDaemon(true);
+         return thread;
+      };
+      this.executor = this.createExecutor();
+   }
+
+   public void shutdown() {
+      ExecutorService exec = this.executor;
+      if (exec != null) {
+         exec.shutdownNow();
+      }
+   }
+
+   public void onServerStopping(MinecraftServer server) {
+      ServerLevel level = server.getLevel(Level.OVERWORLD);
+      if (level != null) {
+         this.clearRealtimeState(server, level, true);
+      } else {
+         this.resetRuntimeState();
+      }
+
+      this.clearOverrides();
+      ExecutorService exec = this.executor;
+      this.executor = null;
+      if (exec != null) {
+         exec.shutdownNow();
+      }
+
+      this.requestInFlight.set(false);
+      this.ntpRequestInFlight.set(false);
+   }
+
+   public boolean hasTimeOffset() {
+      return this.timeZoneReady;
+   }
+
+   public int currentUtcOffsetSeconds() {
+      ZoneId zone = this.timeZone;
+      return zone != null && this.timeZoneReady ? zone.getRules().getOffset(this.currentInstant()).getTotalSeconds() : this.utcOffsetSeconds;
+   }
+
+   public Instant currentInstant() {
+      return Instant.ofEpochMilli(this.currentTimeMillis());
+   }
+
+   public ZoneId currentTimeZone() {
+      return this.timeZone;
+   }
+
+   public String currentTimeZoneId() {
+      return this.timeZoneId;
+   }
+
+   public void setRealtimeTimeOverride(boolean enabled) {
+      this.realtimeTimeOverride = enabled;
+   }
+
+   public void setRealtimeWeatherOverride(boolean enabled) {
+      this.realtimeWeatherOverride = enabled;
+   }
+
+   public void clearOverrides() {
+      this.realtimeTimeOverride = null;
+      this.realtimeWeatherOverride = null;
+   }
+
+   public boolean isRealtimeTimeEnabled(EarthGeneratorSettings settings) {
+      Boolean override = this.realtimeTimeOverride;
+      return override != null ? override : settings.realtimeTime();
+   }
+
+   public boolean isRealtimeWeatherEnabled(EarthGeneratorSettings settings) {
+      Boolean override = this.realtimeWeatherOverride;
+      return override != null ? override : settings.realtimeWeather();
+   }
+
+   public TellusRealtimeManager.WeatherSnapshot lastWeatherSnapshot() {
+      return this.lastWeatherSnapshot;
+   }
+
+   public void onPlayerJoin(MinecraftServer server, ServerPlayer player) {
+      net.neoforged.neoforge.network.PacketDistributor.sendToPlayer(player, this.currentWeatherPayload());
+   }
+
+   public void onServerTick(MinecraftServer server) {
+      ServerLevel level = server.getLevel(Level.OVERWORLD);
+      if (level == null) {
+         this.resetRuntimeState();
+         return;
+      }
+
+      long tickCount = server.getTickCount();
+      if (tickCount < this.lastTimeApplyTick) {
+         this.lastTimeApplyTick = 0L;
+      }
+
+      if (tickCount < this.lastSnowQueueTick) {
+         this.lastSnowQueueTick = 0L;
+      }
+
+      if (!(level.getChunkSource().getGenerator() instanceof EarthChunkGenerator earthGenerator)) {
+         this.clearRealtimeState(server, level, true);
+         return;
+      }
+
+      EarthGeneratorSettings settings = earthGenerator.settings();
+      boolean enableTime = this.isRealtimeTimeEnabled(settings);
+      boolean enableWeather = this.isRealtimeWeatherEnabled(settings);
+      if (!enableTime && !enableWeather) {
+         this.clearRealtimeState(server, level, true);
+         return;
+      }
+
+      if (!enableWeather) {
+         boolean weatherWasActive = this.hasWeatherStateForClients();
+         TellusRealtimeState.clearRealtimeWeather();
+         if (weatherWasActive) {
+            this.sendWeatherPayload(server, false, TellusRealtimeState.PrecipitationMode.CLEAR, false, SnowGrid.empty());
+         }
+      }
+
+      BlockPos samplePos = resolveSamplePosition(server);
+      if (samplePos != null) {
+         int spacingBlocks = computeGridSpacing(settings.worldScale());
+         TellusRealtimeManager.GridAnchor anchor = TellusRealtimeManager.GridAnchor.from(samplePos, spacingBlocks);
+         boolean movedAnchor = this.lastAnchor == null || !this.lastAnchor.equals(anchor);
+         boolean movedTimeZoneAnchor = this.lastTimeZoneAnchor == null || !this.lastTimeZoneAnchor.equals(anchor);
+         if (enableWeather && movedAnchor) {
+            TellusRealtimeState.clearRealtimeWeather();
+         }
+
+         if (enableTime) {
+            this.applyTimeRules(level, server);
+            this.maybeRefreshNtp(System.currentTimeMillis());
+            this.applyRealtimeTime(level, server, earthGenerator, samplePos);
+         } else {
+            this.restoreTimeRules(level, server);
+            this.timeZoneReady = false;
+            this.timeZone = null;
+            this.timeZoneId = null;
+         }
+
+         long now = System.currentTimeMillis();
+         if (enableWeather) {
+            this.applyWeatherRules(level, server);
+            this.applyRealtimeWeather(level);
+         } else {
+            this.restoreWeatherRules(level, server);
+         }
+
+         boolean weatherPending = enableWeather && !TellusRealtimeState.isWeatherEnabled();
+         boolean shouldUpdateWeather = enableWeather && (weatherPending || movedAnchor || now - this.lastWeatherUpdateMs >= WEATHER_REFRESH_MS);
+         boolean shouldUpdateTimeZone = enableTime && (movedTimeZoneAnchor || now - this.lastTimeZoneUpdateMs >= TIMEZONE_REFRESH_MS);
+         if (shouldUpdateWeather || shouldUpdateTimeZone) {
+            this.requestUpdate(server, earthGenerator, anchor, enableWeather, false, enableTime, now);
+         }
+
+         if (!enableWeather || TellusRealtimeState.precipitationMode() != TellusRealtimeState.PrecipitationMode.SNOW) {
+            this.clearSnowQueue();
+         } else {
+            this.tickSnowPlacement(server, level, earthGenerator);
+         }
+      } else {
+         TellusRealtimeState.updateWeatherState(false, TellusRealtimeState.PrecipitationMode.CLEAR, false, SnowGrid.empty());
+      }
+   }
+
+   private void requestUpdate(
+      MinecraftServer server,
+      EarthChunkGenerator generator,
+      TellusRealtimeManager.GridAnchor anchor,
+      boolean includeWeather,
+      boolean includeSnow,
+      boolean includeTimeZone,
+      long now
+   ) {
+      if (this.requestInFlight.compareAndSet(false, true)) {
+         List<BlockPos> samplePoints = new ArrayList<>(includeSnow ? GRID_POINTS : 1);
+         if (includeSnow) {
+            for (int dz = -GRID_RADIUS; dz <= GRID_RADIUS; dz++) {
+               for (int dx = -GRID_RADIUS; dx <= GRID_RADIUS; dx++) {
+                  int x = anchor.centerX() + dx * anchor.spacingBlocks();
+                  int z = anchor.centerZ() + dz * anchor.spacingBlocks();
+                  samplePoints.add(new BlockPos(x, 0, z));
+               }
+            }
+         } else {
+            samplePoints.add(new BlockPos(anchor.centerX(), 0, anchor.centerZ()));
+         }
+
+         ExecutorService exec = this.ensureExecutor();
+         if (exec == null) {
+            this.requestInFlight.set(false);
+         } else {
+            try {
+               exec.execute(() -> {
+                  try {
+                     OpenMeteoClient.WeatherPointData[] points = new OpenMeteoClient.WeatherPointData[samplePoints.size()];
+
+                     for (int i = 0; i < samplePoints.size(); i++) {
+                        BlockPos pos = samplePoints.get(i);
+                        double lat = Mth.clamp(generator.latitudeFromBlock(pos.getZ()), -85.05112878, 85.05112878);
+                        double lon = Mth.clamp(generator.longitudeFromBlock(pos.getX()), -180.0, 180.0);
+                        points[i] = this.client.fetch(lat, lon);
+                     }
+
+                     server.execute(() -> this.applyUpdate(server, anchor, includeWeather, includeSnow, includeTimeZone, points, now));
+                  } catch (Exception var20) {
+                     Tellus.LOGGER.warn("Failed to fetch real-time weather data: {}", var20.getMessage());
+                     Tellus.LOGGER.debug("Real-time weather fetch failure", var20);
+                  } finally {
+                     this.requestInFlight.set(false);
+                  }
+               });
+            } catch (RejectedExecutionException var14) {
+               this.requestInFlight.set(false);
+               Tellus.LOGGER.debug("Realtime weather executor rejected task (server stopping or restarting).", var14);
+            }
+         }
+      }
+   }
+
+   private ExecutorService createExecutor() {
+      return Executors.newSingleThreadExecutor(this.threadFactory);
+   }
+
+   private ExecutorService ensureExecutor() {
+      ExecutorService exec = this.executor;
+      if (exec != null && !exec.isShutdown() && !exec.isTerminated()) {
+         return exec;
+      } else {
+         synchronized (this) {
+            exec = this.executor;
+            if (exec == null || exec.isShutdown() || exec.isTerminated()) {
+               exec = this.createExecutor();
+               this.executor = exec;
+               this.requestInFlight.set(false);
+            }
+
+            return exec;
+         }
+      }
+   }
+
+   private long currentTimeMillis() {
+      long now = System.currentTimeMillis();
+      return !NTP_ENABLED ? now : now + this.ntpOffsetMillis;
+   }
+
+   private void maybeRefreshNtp(long nowMs) {
+      if (NTP_ENABLED) {
+         if (this.lastNtpSyncMs == 0L || nowMs - this.lastNtpSyncMs >= NTP_REFRESH_MS) {
+            if (this.ntpRequestInFlight.compareAndSet(false, true)) {
+               ExecutorService exec = this.ensureExecutor();
+               if (exec == null) {
+                  this.ntpRequestInFlight.set(false);
+               } else {
+                  exec.execute(() -> {
+                     try {
+                        Long offset = null;
+
+                        for (String host : NTP_SERVERS) {
+                           try {
+                              offset = queryNtpOffsetMillis(host);
+                              break;
+                           } catch (Exception var10) {
+                              Tellus.LOGGER.debug("Failed NTP sync with {}", host, var10);
+                           }
+                        }
+
+                        if (offset != null) {
+                           this.ntpOffsetMillis = offset;
+                           this.lastNtpSyncMs = System.currentTimeMillis();
+                        }
+                     } finally {
+                        this.ntpRequestInFlight.set(false);
+                     }
+                  });
+               }
+            }
+         }
+      }
+   }
+
+   private static long queryNtpOffsetMillis(String host) throws Exception {
+      byte[] buffer = new byte[48];
+      buffer[0] = 27;
+      long sendTime = System.currentTimeMillis();
+      InetAddress address = InetAddress.getByName(host);
+
+      try (DatagramSocket socket = new DatagramSocket()) {
+         socket.setSoTimeout(NTP_TIMEOUT_MS);
+         DatagramPacket packet = new DatagramPacket(buffer, buffer.length, address, NTP_PORT);
+         socket.send(packet);
+         DatagramPacket response = new DatagramPacket(buffer, buffer.length);
+         socket.receive(response);
+      }
+
+      long var13 = System.currentTimeMillis();
+      long var14 = readNtpTimestamp(buffer, 40);
+      long roundTrip = var13 - sendTime;
+      return var14 - (sendTime + roundTrip / 2L);
+   }
+
+   private static long readNtpTimestamp(byte[] buffer, int offset) {
+      long seconds = 0L;
+      long fraction = 0L;
+
+      for (int i = 0; i < 4; i++) {
+         seconds = seconds << 8 | buffer[offset + i] & 255L;
+      }
+
+      for (int i = 4; i < 8; i++) {
+         fraction = fraction << 8 | buffer[offset + i] & 255L;
+      }
+
+      long epochSeconds = seconds - NTP_EPOCH_OFFSET_SECONDS;
+      return epochSeconds * 1000L + fraction * 1000L / 4294967296L;
+   }
+
+   private void updateTimeZone(OpenMeteoClient.WeatherPointData centerPoint, TellusRealtimeManager.GridAnchor anchor, long now) {
+      ZoneId zone = parseZoneId(centerPoint.timeZoneId());
+      if (zone != null) {
+         this.timeZone = zone;
+         this.timeZoneId = zone.getId();
+         this.timeZoneReady = true;
+      } else {
+         this.timeZone = null;
+         this.timeZoneId = null;
+         this.timeZoneReady = false;
+      }
+
+      this.utcOffsetSeconds = centerPoint.utcOffsetSeconds();
+      this.lastTimeZoneAnchor = anchor;
+      this.lastTimeZoneUpdateMs = now;
+   }
+
+   private static ZoneId parseZoneId(String zoneId) {
+      if (zoneId != null && !zoneId.isBlank()) {
+         try {
+            return ZoneId.of(zoneId);
+         } catch (DateTimeException var2) {
+            return null;
+         }
+      } else {
+         return null;
+      }
+   }
+
+   private ZoneId resolveTimeZone(EarthChunkGenerator generator, BlockPos pos) {
+      ZoneId zone = this.timeZone;
+      if (zone != null && this.timeZoneReady) {
+         return zone;
+      } else if (this.lastTimeZoneUpdateMs > 0L) {
+         return ZoneOffset.ofTotalSeconds(this.utcOffsetSeconds);
+      } else {
+         int offsetSeconds = approximateUtcOffsetSeconds(generator, pos);
+         return ZoneOffset.ofTotalSeconds(offsetSeconds);
+      }
+   }
+
+   private void tickSnowPlacement(MinecraftServer server, ServerLevel level, EarthChunkGenerator generator) {
+      long tick = server.getTickCount();
+      if (tick - this.lastSnowQueueTick >= SNOW_QUEUE_REFRESH_TICKS || this.snowQueue.isEmpty()) {
+         this.queueSnowChunks(server);
+         this.lastSnowQueueTick = tick;
+      }
+
+      this.processSnowQueue(level, generator, SNOW_CHUNKS_PER_TICK);
+   }
+
+   private void queueSnowChunks(MinecraftServer server) {
+      int radius = Math.min(server.getPlayerList().getViewDistance(), SNOW_MAX_RADIUS);
+      if (radius > 0) {
+         for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            ChunkPos center = player.chunkPosition();
+            int baseX = center.x;
+            int baseZ = center.z;
+
+            for (int dz = -radius; dz <= radius; dz++) {
+               for (int dx = -radius; dx <= radius; dx++) {
+                  long key = ChunkPos.asLong(baseX + dx, baseZ + dz);
+                  if (this.snowQueued.add(key)) {
+                     this.snowQueue.enqueue(key);
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   private void processSnowQueue(ServerLevel level, EarthChunkGenerator generator, int maxChunks) {
+      ChunkSource source = level.getChunkSource();
+      int processed = 0;
+
+      while (processed < maxChunks && !this.snowQueue.isEmpty()) {
+         long key = this.snowQueue.dequeueLong();
+         this.snowQueued.remove(key);
+         int chunkX = ChunkPos.getX(key);
+         int chunkZ = ChunkPos.getZ(key);
+         LevelChunk chunk = source.getChunkNow(chunkX, chunkZ);
+         if (chunk != null) {
+            generator.applyRealtimeSnowCover(level, chunk);
+            processed++;
+         }
+      }
+   }
+
+   private void clearSnowQueue() {
+      this.snowQueue.clear();
+      this.snowQueued.clear();
+   }
+
+   private void applyUpdate(
+      MinecraftServer server,
+      TellusRealtimeManager.GridAnchor anchor,
+      boolean includeWeather,
+      boolean includeSnow,
+      boolean includeTimeZone,
+      OpenMeteoClient.WeatherPointData[] points,
+      long now
+   ) {
+      if (points.length != 0) {
+         int centerIndex = includeSnow ? GRID_POINTS / 2 : 0;
+         OpenMeteoClient.WeatherPointData centerPoint = points[Math.min(centerIndex, points.length - 1)];
+         if (includeWeather || includeSnow) {
+            this.lastAnchor = anchor;
+            this.lastWeatherSnapshot = new TellusRealtimeManager.WeatherSnapshot(
+               centerPoint.latitude(), centerPoint.longitude(), centerPoint.utcOffsetSeconds(), centerPoint.timeZoneId(), centerPoint.temperatureC(), now
+            );
+            this.lastWeatherUpdateMs = now;
+         }
+
+         if (includeTimeZone) {
+            this.updateTimeZone(centerPoint, anchor, now);
+         }
+
+         TellusRealtimeState.PrecipitationMode mode = TellusRealtimeState.PrecipitationMode.CLEAR;
+         if (includeWeather) {
+            mode = resolvePrecipitation(centerPoint);
+         }
+
+         SnowGrid grid = SnowGrid.empty();
+         if (includeSnow) {
+            float[] snowIndex = new float[GRID_POINTS];
+
+            for (int i = 0; i < snowIndex.length && i < points.length; i++) {
+               snowIndex[i] = points[i].snowIndex();
+            }
+
+            grid = new SnowGrid(anchor.centerX(), anchor.centerZ(), anchor.spacingBlocks(), snowIndex);
+         }
+
+         float temperatureC = includeWeather ? centerPoint.temperatureC() : Float.NaN;
+         TellusRealtimeState.updateWeatherState(includeWeather, mode, includeSnow, grid, temperatureC);
+         this.sendWeatherPayload(server, includeWeather, mode, includeSnow, grid);
+         if (includeSnow && this.pendingInitialSnowPass.getAndSet(false)) {
+            ServerLevel level = server.getLevel(Level.OVERWORLD);
+            if (level == null) {
+               return;
+            }
+
+            if (!(level.getChunkSource().getGenerator() instanceof EarthChunkGenerator earthGenerator)) {
+               return;
+            }
+
+            this.clearSnowQueue();
+            this.queueSnowChunks(server);
+            this.processSnowQueue(level, earthGenerator, Integer.MAX_VALUE);
+         }
+      }
+   }
+
+   private void sendWeatherPayload(
+      MinecraftServer server, boolean weatherEnabled, TellusRealtimeState.PrecipitationMode mode, boolean historicalSnow, SnowGrid grid
+   ) {
+      TellusWeatherPayload payload = createWeatherPayload(weatherEnabled, mode, historicalSnow, grid);
+
+      for (ServerPlayer rawPlayer : server.getPlayerList().getPlayers()) {
+         ServerPlayer player = Objects.requireNonNull(rawPlayer, "player");
+         net.neoforged.neoforge.network.PacketDistributor.sendToPlayer(player, payload);
+      }
+   }
+
+   private TellusWeatherPayload currentWeatherPayload() {
+      return createWeatherPayload(
+         TellusRealtimeState.isWeatherEnabled(),
+         TellusRealtimeState.precipitationMode(),
+         TellusRealtimeState.isHistoricalSnowEnabled(),
+         TellusRealtimeState.snowGrid()
+      );
+   }
+
+   private static TellusWeatherPayload createWeatherPayload(
+      boolean weatherEnabled, TellusRealtimeState.PrecipitationMode mode, boolean historicalSnow, SnowGrid grid
+   ) {
+      return new TellusWeatherPayload(
+         weatherEnabled,
+         mode,
+         historicalSnow,
+         grid.centerX(),
+         grid.centerZ(),
+         grid.spacingBlocks(),
+         grid.isEmpty() ? new float[GRID_POINTS] : gridSample(grid)
+      );
+   }
+
+   private static float[] gridSample(SnowGrid grid) {
+      float[] snowIndex = new float[GRID_POINTS];
+
+      for (int i = 0; i < GRID_POINTS; i++) {
+         snowIndex[i] = grid.isEmpty() ? 0.0F : gridSampleAtIndex(grid, i);
+      }
+
+      return snowIndex;
+   }
+
+   private static float gridSampleAtIndex(SnowGrid grid, int index) {
+      int gx = index % GRID_SIZE;
+      int gz = index / GRID_SIZE;
+      int x = grid.centerX() + (gx - GRID_RADIUS) * grid.spacingBlocks();
+      int z = grid.centerZ() + (gz - GRID_RADIUS) * grid.spacingBlocks();
+      return grid.sample(x, z);
+   }
+
+   private static TellusRealtimeState.PrecipitationMode resolvePrecipitation(OpenMeteoClient.WeatherPointData data) {
+      int code = data.weatherCode();
+      float temp = data.temperatureC();
+      float precipitation = data.precipitationMm();
+      if (code >= 95) {
+         return TellusRealtimeState.PrecipitationMode.THUNDER;
+      } else if (!isSnowCode(code) && (!(temp <= 0.0F) || !(precipitation > 0.0F))) {
+         return !(precipitation > 0.0F) && !isRainCode(code) ? TellusRealtimeState.PrecipitationMode.CLEAR : TellusRealtimeState.PrecipitationMode.RAIN;
+      } else {
+         return TellusRealtimeState.PrecipitationMode.SNOW;
+      }
+   }
+
+   private static boolean isSnowCode(int code) {
+      return code >= 71 && code <= 77 || code == 85 || code == 86;
+   }
+
+   private static boolean isRainCode(int code) {
+      return code >= 51 && code <= 67 || code >= 80 && code <= 82;
+   }
+
+   private void applyRealtimeTime(ServerLevel level, MinecraftServer server, EarthChunkGenerator generator, BlockPos samplePos) {
+      long tickCount = server.getTickCount();
+      if (tickCount - this.lastTimeApplyTick >= TIME_APPLY_TICK_INTERVAL) {
+         this.lastTimeApplyTick = tickCount;
+         Instant now = this.currentInstant();
+         ZoneId zone = this.resolveTimeZone(generator, samplePos);
+         ZonedDateTime local = ZonedDateTime.ofInstant(now, zone);
+         int daySeconds = local.toLocalTime().toSecondOfDay();
+         double hours = daySeconds / 3600.0;
+         int tickOfDay = (int)Math.floor((hours - 6.0 + 24.0) % 24.0 * 1000.0);
+         long dayBase = level.getDayTime() / 24000L * 24000L;
+         level.setDayTime(dayBase + tickOfDay);
+         this.utcOffsetSeconds = local.getOffset().getTotalSeconds();
+      }
+   }
+
+   private void applyRealtimeWeather(ServerLevel level) {
+      TellusRealtimeState.PrecipitationMode mode = TellusRealtimeState.precipitationMode();
+      boolean raining = mode == TellusRealtimeState.PrecipitationMode.RAIN
+         || mode == TellusRealtimeState.PrecipitationMode.SNOW
+         || mode == TellusRealtimeState.PrecipitationMode.THUNDER;
+      boolean thundering = mode == TellusRealtimeState.PrecipitationMode.THUNDER;
+      level.setWeatherParameters(0, 6000, raining, thundering);
+   }
+
+   private void applyTimeRules(ServerLevel level, MinecraftServer server) {
+      GameRules rules = level.getGameRules();
+      boolean daylight = rules.getBoolean(GameRules.RULE_DAYLIGHT);
+      int sleepingPercent = rules.getInt(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE);
+      if (!this.timeRulesCaptured) {
+         this.cachedDaylightCycle = daylight;
+         this.cachedSleepPercentage = sleepingPercent;
+         this.timeRulesCaptured = true;
+      }
+
+      if (daylight) {
+         rules.getRule(GameRules.RULE_DAYLIGHT).set(false, server);
+      }
+
+      if (sleepingPercent != 101) {
+         rules.getRule(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE).set(101, server);
+      }
+   }
+
+   private void applyWeatherRules(ServerLevel level, MinecraftServer server) {
+      GameRules rules = level.getGameRules();
+      boolean weatherCycle = rules.getBoolean(GameRules.RULE_WEATHER_CYCLE);
+      if (!this.weatherRulesCaptured) {
+         this.cachedWeatherCycle = weatherCycle;
+         this.weatherRulesCaptured = true;
+      }
+
+      if (weatherCycle) {
+         rules.getRule(GameRules.RULE_WEATHER_CYCLE).set(false, server);
+      }
+   }
+
+   private void restoreRules(ServerLevel level, MinecraftServer server) {
+      this.restoreTimeRules(level, server);
+      this.restoreWeatherRules(level, server);
+   }
+
+   private void restoreTimeRules(ServerLevel level, MinecraftServer server) {
+      if (this.timeRulesCaptured) {
+         GameRules rules = level.getGameRules();
+         boolean daylight = rules.getBoolean(GameRules.RULE_DAYLIGHT);
+         int sleepingPercent = rules.getInt(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE);
+         if (daylight != this.cachedDaylightCycle) {
+            rules.getRule(GameRules.RULE_DAYLIGHT).set(this.cachedDaylightCycle, server);
+         }
+
+         if (sleepingPercent != this.cachedSleepPercentage) {
+            rules.getRule(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE).set(this.cachedSleepPercentage, server);
+         }
+
+         this.timeRulesCaptured = false;
+      }
+   }
+
+   private void restoreWeatherRules(ServerLevel level, MinecraftServer server) {
+      if (this.weatherRulesCaptured) {
+         GameRules rules = level.getGameRules();
+         boolean weatherCycle = rules.getBoolean(GameRules.RULE_WEATHER_CYCLE);
+         if (weatherCycle != this.cachedWeatherCycle) {
+            rules.getRule(GameRules.RULE_WEATHER_CYCLE).set(this.cachedWeatherCycle, server);
+         }
+
+         this.weatherRulesCaptured = false;
+      }
+   }
+
+   private void clearRealtimeState(MinecraftServer server, ServerLevel level, boolean notifyPlayers) {
+      boolean weatherWasActive = this.hasWeatherStateForClients();
+      this.restoreRules(level, server);
+      this.resetRuntimeState();
+      if (notifyPlayers && weatherWasActive) {
+         this.sendWeatherPayload(server, false, TellusRealtimeState.PrecipitationMode.CLEAR, false, SnowGrid.empty());
+      }
+   }
+
+   private void resetRuntimeState() {
+      this.requestInFlight.set(false);
+      this.pendingInitialSnowPass.set(false);
+      this.lastWeatherUpdateMs = 0L;
+      this.lastTimeZoneUpdateMs = 0L;
+      this.lastTimeApplyTick = 0L;
+      this.lastSnowQueueTick = 0L;
+      this.timeZoneReady = false;
+      this.lastAnchor = null;
+      this.lastTimeZoneAnchor = null;
+      this.utcOffsetSeconds = 0;
+      this.lastWeatherSnapshot = null;
+      this.timeZone = null;
+      this.timeZoneId = null;
+      this.clearSnowQueue();
+      TellusRealtimeState.clearRealtimeWeather();
+   }
+
+   private boolean hasWeatherStateForClients() {
+      return TellusRealtimeState.isWeatherEnabled()
+         || TellusRealtimeState.isHistoricalSnowEnabled()
+         || TellusRealtimeState.precipitationMode() != TellusRealtimeState.PrecipitationMode.CLEAR;
+   }
+
+   private static int computeGridSpacing(double worldScale) {
+      double targetMeters = 32000.0;
+      double spacing = targetMeters / Math.max(1.0, worldScale);
+      int spacingBlocks = Mth.floor(spacing);
+      return Mth.clamp(spacingBlocks, 1024, 16384);
+   }
+
+   private static BlockPos resolveSamplePosition(MinecraftServer server) {
+      List<ServerPlayer> players = server.getPlayerList().getPlayers();
+      if (players.isEmpty()) {
+         return null;
+      } else {
+         for (ServerPlayer player : players) {
+            if (player.level().dimension() == Level.OVERWORLD) {
+               return player.blockPosition();
+            }
+         }
+
+         return players.get(0).blockPosition();
+      }
+   }
+
+   private static int approximateUtcOffsetSeconds(EarthChunkGenerator generator, BlockPos pos) {
+      double longitude = Mth.clamp(generator.longitudeFromBlock(pos.getX()), -180.0, 180.0);
+      double hours = longitude / 15.0;
+      return (int)Math.round(hours * 3600.0);
+   }
+
+   private record GridAnchor(int centerX, int centerZ, int spacingBlocks) {
+      private static TellusRealtimeManager.GridAnchor from(BlockPos pos, int spacingBlocks) {
+         int centerX = Math.floorDiv(pos.getX(), spacingBlocks) * spacingBlocks;
+         int centerZ = Math.floorDiv(pos.getZ(), spacingBlocks) * spacingBlocks;
+         return new TellusRealtimeManager.GridAnchor(centerX, centerZ, spacingBlocks);
+      }
+   }
+
+   public record WeatherSnapshot(double latitude, double longitude, int utcOffsetSeconds, String timeZoneId, float temperatureC, long updatedAtMs) {
+   }
+}

--- a/neoforge/src/main/resources/META-INF/MANIFEST.MF
+++ b/neoforge/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Implementation-Title: Tellus
+Implementation-Version: ${file.jarVersion}
+

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,39 @@
+modLoader = "javafml"
+loaderVersion = "[4,)"
+license = "LGPL-3.0-only"
+
+[[dependencies.tellus]]
+    modId = "neoforge"
+    type = "required"
+    versionRange = "[21.1,)"
+    ordering = "NONE"
+    side = "BOTH"
+
+[[dependencies.tellus]]
+    modId = "minecraft"
+    type = "required"
+    versionRange = "[1.21.1,1.22)"
+    ordering = "NONE"
+    side = "BOTH"
+
+[[dependencies.tellus]]
+    modId = "distanthorizons"
+    type = "optional"
+    versionRange = "*"
+    ordering = "NONE"
+    side = "BOTH"
+
+[[mods]]
+    modId = "tellus"
+    version = "${file.jarVersion}"
+    displayName = "Tellus"
+    description = '''
+Tellus recreates real-world terrain in Minecraft by generating Earth-scale landscapes from geographic data.
+    '''
+    logoFile = "assets/tellus/icon.png"
+
+[[mixins]]
+    config = "tellus.mixins.json"
+
+[[mixins]]
+    config = "tellus.client.mixins.json"

--- a/neoforge/src/main/resources/pack.mcmeta
+++ b/neoforge/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Tellus NeoForge mod resources",
+    "pack_format": 34
+  }
+}

--- a/neoforge/src/main/resources/tellus.client.mixins.json
+++ b/neoforge/src/main/resources/tellus.client.mixins.json
@@ -1,0 +1,13 @@
+{
+	"required": true,
+	"package": "com.yucareux.tellus.mixin.client",
+	"compatibilityLevel": "JAVA_21",
+	"client": [
+		"LevelLoadingScreenMixin",
+		"MinecraftScreenMixin",
+		"PresetEditorMixin"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
+}

--- a/neoforge/src/main/resources/tellus.mixins.json
+++ b/neoforge/src/main/resources/tellus.mixins.json
@@ -1,0 +1,17 @@
+{
+	"required": true,
+	"package": "com.yucareux.tellus.mixin",
+	"compatibilityLevel": "JAVA_21",
+	"mixins": [
+		"BiomeFreezeMixin",
+		"BiomePrecipitationMixin",
+		"OceanMonumentBuildingMixin",
+		"OceanMonumentStructureMixin"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	},
+	"overwrites": {
+		"requireAnnotations": true
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,10 @@ pluginManagement {
 			name = 'Fabric'
 			url = 'https://maven.fabricmc.net/'
 		}
+		maven {
+			name = 'NeoForged'
+			url = 'https://maven.neoforged.net/releases/'
+		}
 		mavenCentral()
 		gradlePluginPortal()
 	}
@@ -18,3 +22,4 @@ rootProject.name = 'Tellus'
 include('mc1211')
 include('mc261')
 include('mc1201')
+include('neoforge')


### PR DESCRIPTION
Adds a new `neoforge/` subproject targeting NeoForge 21.1.172 / MC 1.21.1. The Fabric subprojects (mc1201, mc1211, mc261) are untouched.

Key changes:
- Build: net.neoforged.moddev replaces fabric-loom
- Entry point: @Mod("tellus") constructor with IEventBus replaces ModInitializer
- Events: NeoForge event bus (ServerStartedEvent, ServerTickEvent.Post, ChunkEvent.Unload, PlayerEvent.PlayerLoggedInEvent, etc.)
- Networking: PacketDistributor.sendToPlayer/sendToServer replace ServerPlayNetworking/ClientPlayNetworking; RegisterPayloadHandlersEvent replaces PayloadTypeRegistry
- Mod metadata: neoforge.mods.toml replaces fabric.mod.json
- FabricLoader: replaced with ModList.get().isLoaded() and FMLPaths
- Client annotations: @OnlyIn(Dist.CLIENT) replaces @Environment(EnvType.CLIENT)
- Client disconnect: ClientPlayerNetworkEvent.LoggingOut replaces ClientPlayConnectionEvents.DISCONNECT


Claude-Session: https://claude.ai/code/session_01RRWcn5zkwz4sHqYUyXShGg